### PR TITLE
Large image integration

### DIFF
--- a/.install-openslide.sh
+++ b/.install-openslide.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+PREFIX="$CACHE/openslide-$OPENSLIDE_VERSION"
+if [[ ! -f "$PREFIX/bin/openslide-show-properties" || -n "$UPDATE_CACHE" ]] ; then
+  rm -fr "$PREFIX"
+  mkdir -p "$PREFIX/src"
+  curl -L "https://github.com/openslide/openslide/releases/download/v${OPENSLIDE_VERSION}/openslide-${OPENSLIDE_VERSION}.tar.gz" | gunzip -c | tar -x -C "$PREFIX/src" --strip-components 1
+  pushd "$PREFIX/src"
+  ./configure "--prefix=$PREFIX"
+  make install
+  popd
+fi
+export PATH="$PREFIX/bin:$PATH"
+export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$PREFIX/lib"

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,25 @@ sudo: false
 compiler:
     - gcc
 
+addons:
+    apt:
+        packages:
+            # Pillow dependencies (see
+            # https://pillow.readthedocs.org/en/latest/installation.html)
+            - libtiff4-dev
+            - libjpeg8-dev
+            - zlib1g-dev
+            - libfreetype6-dev
+            - liblcms2-dev
+            - libwebp-dev
+            # vips
+            - libvips-tools
+            # openslide
+            - libopenjpeg-dev
+
 before_install:
+    - CACHE="$HOME/.cache" OPENSLIDE_VERSION="3.4.1" source .install-openslide.sh
+
     - main_path=$PWD
     - build_path=$PWD/build
     - mkdir -p $build_path
@@ -27,9 +45,8 @@ before_install:
     - cp $PWD/plugin_tests/data/girder_worker.cfg $girder_worker_path/girder_worker/worker.local.cfg
     - pip install -U -r $girder_worker_path/requirements.txt -r $girder_worker_path/girder_worker/plugins/girder_io/requirements.txt
 
-    - # TODO: install large_image server side deps, for the moment, we only need it for geojs
     - large_image_path=$girder_path/plugins/large_image
-    - git clone https://github.com/DigitalSlideArchive/large_image.git $large_image_path && git -C $large_image_path checkout 3a087579a77ee66fede87cf2b8f1f2faa7e91b4d
+    - git clone https://github.com/DigitalSlideArchive/large_image.git $large_image_path && git -C $large_image_path checkout d9331e7a5c6d3209a4805351e10051f6b6858641
 
     - export MONGO_VERSION=2.6.11
     - export PY_COVG="ON"
@@ -58,7 +75,7 @@ install:
     # https://github.com/pypa/pip/issues/2751
     - conda install --yes --file $main_path/requirements.txt setuptools==19.4
     - cd $girder_path
-    - pip install -U -r requirements.txt -r requirements-dev.txt -r $main_path/requirements.txt setuptools==19.4
+    - pip install -U -r requirements.txt -r requirements-dev.txt -r $main_path/requirements.txt -r $large_image_path/requirements.txt setuptools==19.4
     - npm install
 
 script:

--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
     "bootstrap-slider": "^6.1.1",
     "tinycolor2": "^1.3.0"
   },
-  "devDependencies": {},
+  "devDependencies": {
+    "sinon": "^1.17.3"
+  },
   "scripts": {}
 }

--- a/plugin.cmake
+++ b/plugin.cmake
@@ -41,6 +41,11 @@ add_web_client_test(
     HistomicsTK_widget "${PROJECT_SOURCE_DIR}/plugins/HistomicsTK/plugin_tests/client/widget.js"
     ENABLEDPLUGINS "HistomicsTK")
 
+add_web_client_test(
+    HistomicsTK_visualization "${PROJECT_SOURCE_DIR}/plugins/HistomicsTK/plugin_tests/client/visualization.js"
+    ENABLEDPLUGINS "HistomicsTK" "large_image")
+
+
 add_eslint_test(
   js_static_analysis_HistomicsTK "${PROJECT_SOURCE_DIR}/plugins/HistomicsTK/web_client"
   ESLINT_CONFIG_FILE "${PROJECT_SOURCE_DIR}/plugins/HistomicsTK/.eslintrc"

--- a/plugin_tests/client/.eslintrc
+++ b/plugin_tests/client/.eslintrc
@@ -3,7 +3,8 @@
     "no-console": 0
   },
   "globals": {
-    "girderTest": true
+    "girderTest": true,
+    "sinon": true
   },
   "env": {
     "jasmine": true

--- a/plugin_tests/client/visualization.js
+++ b/plugin_tests/client/visualization.js
@@ -1,0 +1,257 @@
+if (!String.prototype.startsWith) {
+    String.prototype.startsWith = function(searchString, position){
+      position = position || 0;
+      return this.substr(position, searchString.length) === searchString;
+  };
+}
+
+_.each([
+    '/plugins/HistomicsTK/node_modules/sinon/pkg/sinon.js',
+    '/plugins/HistomicsTK/web_client/js/ext/backbone.localStorage.js',
+    '/plugins/HistomicsTK/web_client/js/ext/bootstrap-colorpicker.js',
+    '/plugins/HistomicsTK/web_client/js/ext/bootstrap-slider.js',
+    '/plugins/HistomicsTK/web_client/js/ext/tinycolor.js',
+    '/clients/web/static/built/plugins/large_image/geo.min.js'
+], function (src) {
+    $('<script/>', {src: src}).appendTo('head');
+});
+
+window.histomicstk = {};
+girderTest.addCoveredScripts([
+    '/plugins/HistomicsTK/web_client/js/0init.js',
+    '/plugins/HistomicsTK/web_client/js/app.js',
+    '/plugins/HistomicsTK/web_client/js/models/widget.js',
+    '/plugins/HistomicsTK/web_client/js/schema/parser.js',
+    '/plugins/HistomicsTK/web_client/js/views/0panel.js',
+    '/plugins/HistomicsTK/web_client/js/views/body.js',
+    '/plugins/HistomicsTK/web_client/js/views/browserPanel.js',
+    '/plugins/HistomicsTK/web_client/js/views/controlsPanel.js',
+    '/plugins/HistomicsTK/web_client/js/views/controlWidget.js',
+    '/plugins/HistomicsTK/web_client/js/views/fileSelectorWidget.js',
+    '/plugins/HistomicsTK/web_client/js/views/guiSelectorWidget.js',
+    '/plugins/HistomicsTK/web_client/js/views/header.js',
+    '/plugins/HistomicsTK/web_client/js/views/jobsPanel.js',
+    '/plugins/HistomicsTK/web_client/js/views/panelGroup.js',
+    '/plugins/HistomicsTK/web_client/js/views/visualization.js',
+    '/clients/web/static/built/plugins/HistomicsTK/templates.js'
+]);
+
+describe('visualization', function () {
+    var $el, parentView = _.extend({
+        registerChildView: function () {},
+        unregisterChildView: function () {}
+    }, new Backbone.View());
+
+    girder.eventStream = {
+        off: function () {}
+    };
+
+    beforeEach(function () {
+        $el = $('<div/>').css({
+            width: '500px',
+            height: '300px'
+        }).appendTo('body');
+    });
+    afterEach(function () {
+        $el.remove();
+    });
+    it('render the view', function () {
+        new histomicstk.views.Visualization({
+            parentView: parentView,
+            el: $el
+        }).render();
+
+        expect($el.find('.h-visualization-body').length).toBe(1);
+        expect($el.find('.h-panel-title-container').text()).toBe('Open Image');
+    });
+    it('render test tiles', function () {
+        var view = new histomicstk.views.Visualization({
+            parentView: parentView,
+            el: $el
+        }).render();
+
+        var layer, failed = false;
+        view.addItem({id: 'test'})
+            .then(function (_layer) {
+                layer = _layer;
+            })
+            .fail(function (err) {
+                expect('Rendering tile set failed with: ' + err).toBe(null);
+                failed = true;
+            });
+        waitsFor(function () {
+            return (layer && Object.keys(layer.activeTiles).length === 5) || failed;
+        });
+
+        runs(function () {
+            var destroyed = false;
+            var spy = sinon.spy(view._map, 'exit');
+            view._controlModel.on('destroy', function () {
+                destroyed = true;
+            });
+            view.destroy();
+
+            expect(destroyed).toBe(true);
+            expect(spy.called).toBe(true);
+        });
+    });
+
+    it('addTileLayer without url', function () {
+        var view = new histomicstk.views.Visualization({
+            parentView: parentView,
+            el: $el
+        }).render();
+        expect(function () {
+            view.addTileLayer({});
+        }).toThrow();
+    });
+
+    describe('mocked rest requests', function () {
+        var server, rest, img, _img;
+
+        beforeEach(function () {
+            // manually stub becuase of a phantomjs bug: https://github.com/sinonjs/sinon/issues/329
+            _img = window.Image;
+            img = sinon.spy(function () {
+                return sinon.createStubInstance(Image);
+            });
+            window.Image = img;
+            rest = sinon.stub(girder, 'restRequest');
+            server = sinon.fakeServer.create({
+                autoRespond: false
+            });
+            geo.gl.vglRenderer.supported = function () {return false;};
+        });
+
+        afterEach(function () {
+            server.restore();
+            rest.restore();
+            window.Image = _img;
+        });
+
+        it('render test image', function () {
+            rest.onCall(0).returns($.when([{
+                mimeType: 'image/jpeg',
+                '_id': 'some image'
+            }]));
+
+            var view = new histomicstk.views.Visualization({
+                parentView: parentView,
+                el: $el
+            }).render();
+
+            view.addItem(new girder.models.ItemModel())
+                .then(function (quad) {
+                    var data = quad.data()[0];
+                    expect(data.ll).toEqual({x: 0, y: 256});
+                    expect(data.ur).toEqual({x: 256, y: 0});
+                    expect(data.image).toMatch(/\/file\/some image\/download$/);
+                })
+                .fail(function (err) {
+                    expect('Rendering tile set failed with: ' + err).toBe(null);
+                });
+
+            expect(img.firstCall.returnValue.src).toMatch(/\/file\/some image\/download$/);
+            img.firstCall.returnValue.width = 256;
+            img.firstCall.returnValue.height = 256;
+            img.firstCall.returnValue.onload();
+
+            expect(img.getCall(1).returnValue.src).toMatch(/\/file\/some image\/download$/);
+        });
+
+        it('render image from control widget', function () {
+            rest.onCall(0).returns($.when({}));
+            rest.onCall(1).returns($.when([{
+                mimeType: 'image/jpeg',
+                '_id': 'some image'
+            }]));
+
+            var view = new histomicstk.views.Visualization({
+                parentView: parentView,
+                el: $el
+            }).render();
+
+            view._controlModel.set({
+                value: 'some image'
+            });
+
+            expect(img.firstCall.returnValue.src).toMatch(/\/file\/some image\/download$/);
+            img.firstCall.returnValue.width = 256;
+            img.firstCall.returnValue.height = 256;
+            img.firstCall.returnValue.onload();
+
+            expect(img.getCall(1).returnValue.src).toMatch(/\/file\/some image\/download$/);
+        });
+
+        it('invalid image from control widget', function () {
+            var spy = sinon.spy();
+            rest.onCall(0).returns($.when({}));
+            rest.onCall(1).returns($.when([{
+                mimeType: 'image/jpeg',
+                '_id': 'some image'
+            }]));
+
+            var view = new histomicstk.views.Visualization({
+                parentView: parentView,
+                el: $el
+            }).render();
+
+            sinon.stub(view, 'addItem').returns(new $.Deferred().reject().promise());
+            girder.events.on('g:alert', spy);
+            view._controlModel.set({
+                value: 'some image'
+            });
+
+            expect(view.$('[data-type="file"]').hasClass('has-error')).toBe(true);
+            expect(img.callCount).toBe(0);
+            expect(spy.callCount).toBe(1);
+            sinon.assert.calledWith(spy, sinon.match({
+                text: 'Could not render item as an image',
+                type: 'danger'
+            }));
+        });
+
+        it('item with no files', function () {
+            rest.onCall(0).returns($.when([]));
+            
+            var view = new histomicstk.views.Visualization({
+                parentView: parentView,
+                el: $el
+            }).render();
+
+            var failed = false;
+            view.addItem(new girder.models.ItemModel())
+                .then(function () {
+                    expect('Rendering an item with no files should fail').toBe(null);
+                })
+                .fail(function (err) {
+                    failed = true;
+                    expect(err).toBe('No renderable image file found');
+                });
+
+            expect(failed).toBe(true);
+        });
+
+        it('invalid image file', function () {
+            rest.onCall(0).returns($.when([{
+                mimeType: 'image/jpeg',
+                '_id': 'some image'
+            }]));
+
+            var view = new histomicstk.views.Visualization({
+                parentView: parentView,
+                el: $el
+            }).render();
+
+            view.addItem(new girder.models.ItemModel())
+                .then(function () {
+                    expect('Rendering an invalid image should fail').toBe(null);
+                })
+                .fail(function (err) {
+                    expect(err).toBe('Could not load image');
+                });
+
+            img.firstCall.returnValue.onerror();
+        });
+    });
+});

--- a/web_client/js/views/body.js
+++ b/web_client/js/views/body.js
@@ -11,7 +11,7 @@ histomicstk.views.Body = girder.View.extend({
     render: function () {
         this.$el.html(histomicstk.templates.body());
         this.visView.setElement(this.$('#h-vis-container')).render();
-        this.panelGroupView.setElement(this.$('#h-panel-group-container')).render();
+        this.panelGroupView.setElement(this.$('#h-panel-controls-container')).render();
     },
     selectGui: function () {
         new histomicstk.views.GuiSelectorWidget({

--- a/web_client/js/views/visualization.js
+++ b/web_client/js/views/visualization.js
@@ -37,6 +37,9 @@ histomicstk.views.Visualization = girder.View.extend({
                 this._controlView.invalid();
             }, this));
         });
+
+        // fallback to canvas renderer rather than dom
+        geo.gl.vglRenderer.fallback = function () {return 'canvas';};
     },
 
     /**
@@ -74,30 +77,6 @@ histomicstk.views.Visualization = girder.View.extend({
     },
 
     /**
-     * This will expand the attached map's maximum bounds to cover
-     * the given bounds. {left, right, top, bottom} in pixel coordinates.
-     */
-    _expandBounds: function (bounds) {
-        var mapBounds, newBounds = {
-            left: bounds.left || 0,
-            right: bounds.right,
-            top: bounds.top || 0,
-            bottom: bounds.bottom
-        };
-        if (this._map) {
-            mapBounds = this._map.maxBounds();
-            newBounds = {
-                left: Math.min(bounds.left || 0, mapBounds.left),
-                top: Math.min(bounds.top || 0, mapBounds.top),
-                right: Math.max(bounds.right, mapBounds.right),
-                bottom: Math.max(bounds.bottom, mapBounds.bottom)
-            };
-        }
-        this._createMap(newBounds);
-        return newBounds;
-    },
-
-    /**
      * Add a map layer from a girder item object.  The girder item should contain a
      * single image file (the first encountered will be used) or be registered
      * as a tiled image via the large_image plugin.
@@ -107,12 +86,13 @@ histomicstk.views.Visualization = girder.View.extend({
      * layer.
      *
      * @TODO: How do we pass in bounds?
+     * @TODO: Allow multiple layers (don't reset map on add).
      */
     addItem: function (item) {
         var promise;
 
         // first check if it is a tiled image
-        if (item.has('largeImage')) {
+        if (item.id === 'test' || item.has('largeImage')) {
             promise = girder.restRequest({
                 path: 'item/' + item.id + '/tiles'
             })
@@ -249,17 +229,6 @@ histomicstk.views.Visualization = girder.View.extend({
 
         this.$el.html(histomicstk.templates.visualization());
         this._controlView.setElement(this.$('.h-open-image-widget')).render();
-
-        /*
-        new girder.models.ItemModel({'_id': '56f55c0f62a8f80b77e45c68'})
-            .on('change', _.bind(function (item) {
-                this.addItem(item);
-            }, this)).fetch();
-        new girder.models.ItemModel({'_id': '56fd6d8c62a8f8692876ad89'})
-            .on('change', _.bind(function (item) {
-                this.addItem(item);
-            }, this)).fetch();
-        */
 
         return this;
     },

--- a/web_client/js/views/visualization.js
+++ b/web_client/js/views/visualization.js
@@ -1,32 +1,236 @@
 histomicstk.views.Visualization = girder.View.extend({
     initialize: function () {
+        // the map object
+        this._map = null;
+
+        // the rendered map layers
+        this._layers = [];
+    },
+
+    /**
+     * Create a map object with the given global bounds.
+     * @TODO Either fix the map.maxBounds setter or recreate all the current layers
+     * in the new map object.
+     */
+    _createMap: function (bounds) {
+        if (this._map) {
+            this._map.exit();
+        }
+        var w = bounds.right - bounds.left || 0;
+        var h = bounds.bottom - bounds.top || 0;
+        var interactor = geo.mapInteractor({
+            zoomAnimation: false
+        });
+
         this._map = geo.map({
             node: '<div style="width: 100%; height: 100%"/>',
-            width: 100,
-            height: 100
+            width: this.$el.width() || 100,
+            height: this.$el.height() || 100,
+            ingcs: '+proj=longlat +axis=esu',
+            gcs: '+proj=longlat +axis=enu',
+            maxBounds: bounds,
+            clampBoundsX: true,
+            clampBoundsY: true,
+            center: {x: w / 2, y: h / 2},
+            zoom: 0,
+            discreteZoom: false,
+            interactor: interactor
         });
-        this._map.createLayer('osm', {
-            url: function () { return 'http://lorempixel.com/256/256/cats/'; },
-            keepLower: false,
-            wrapX: true,
-            wrapY: true,
-            attribution: 'Images provided by <a href="http://lorempixel.com">lorempixel</a>'
-        });
+        this.$el.empty();
+        this.$el.append(this._map.node());
     },
-    render: function () {
-        var mapnode = this._map.node();
-        if (this.$el) {
-            this.$el.empty();
-            this.$el.append(mapnode);
-            this._map.size({
-                width: this.$el.width(),
-                height: this.$el.height()
-            });
+
+    /**
+     * This will expand the attached map's maximum bounds to cover
+     * the given bounds. {left, right, top, bottom} in pixel coordinates.
+     */
+    _expandBounds: function (bounds) {
+        var mapBounds, newBounds = {
+            left: bounds.left || 0,
+            right: bounds.right,
+            top: bounds.top || 0,
+            bottom: bounds.bottom
+        };
+        if (this._map) {
+            mapBounds = this._map.maxBounds();
+            newBounds = {
+                left: Math.min(bounds.left || 0, mapBounds.left),
+                top: Math.min(bounds.top || 0, mapBounds.top),
+                right: Math.max(bounds.right, mapBounds.right),
+                bottom: Math.max(bounds.bottom, mapBounds.bottom)
+            };
         }
+        this._createMap(newBounds);
+        return newBounds;
+    },
+
+    /**
+     * Add a map layer from a girder item object.  The girder item should contain a
+     * single image file (the first encountered will be used) or be registered
+     * as a tiled image via the large_image plugin.
+     *
+     * This method is async, errors encountered will trigger an error event and
+     * reject the returned promise.  The promise is resolved with the added map
+     * layer.
+     *
+     * @TODO: How do we pass in bounds?
+     */
+    addItem: function (item) {
+        var promise;
+
+        // first check if it is a tiled image
+        if (item.has('largeImage')) {
+            promise = girder.restRequest({
+                path: 'item/' + item.id + '/tiles'
+            })
+            .then(_.bind(function (tiles) {
+                // It is a tile item
+                return this.addTileLayer(
+                    {
+                        url: girder.apiRoot + '/item/' + item.id + '/tiles/zxy/{z}/{x}/{y}',
+                        maxLevel: tiles.levels,
+                        tileWidth: tiles.tileWidth,
+                        tileHeight: tiles.tileHeight,
+                        sizeX: tiles.sizeX,
+                        sizeY: tiles.sizeY
+                    }
+                );
+            }, this));
+        } else { // check for an image file
+            promise = girder.restRequest({
+                path: 'item/' + item.id + '/files',
+                limit: 1 // we *could* look through all the files,
+            })
+            .then(_.bind(function (files) {
+                var img = null, defer, imgElement;
+
+                _.each(files, function (file) {
+                    if ((file.mimeType || '').startsWith('image/')) {
+                        img = new girder.models.FileModel(file);
+                    }
+                });
+
+                if (!img) {
+                    // no image is present, so return a reject promise
+                    return new $.Deferred().reject('No renderable image file found').promise();
+                }
+
+                // Download the file to get the image size
+                defer = new $.Deferred();
+                imgElement = new Image();
+                imgElement.onload = function () {
+                    defer.resolve(imgElement);
+                };
+                imgElement.onerror = function () {
+                    defer.reject('Could not load image');
+                };
+                imgElement.src = girder.apiRoot + '/file/' + img.id + '/download';
+                return defer.promise();
+            }))
+            .then(_.bind(function (img) {
+                // Inspect the image and add it to the map
+                return this.addImageLayer(
+                    img.src,
+                    {
+                        right: img.width,
+                        bottom: img.height
+                    }
+                );
+            }, this));
+        }
+
+        return promise;
+    },
+
+    /**
+     * Add a single image as a quad feature on the viewer from an image url.
+     *
+     * @param {string} url The url of the image
+     * @param {object} bounds
+     *  The coordinate bounds of the image (left, right, top, bottom).
+     */
+    addImageLayer: function (url, bounds) {
+        this._expandBounds(bounds);
+        var layer = this._map.createLayer('feature', {renderer: 'vgl'});
+        var quad = layer.createFeature('quad');
+        quad.data([
+            {
+                ll: {x: bounds.left || 0, y: bounds.bottom},
+                ur: {x: bounds.right, y: bounds.top || 0},
+                image: url
+            }
+        ]);
+        this._layers.push(layer);
+        this._map.draw();
+        return quad;
+    },
+
+    /**
+     * Add a tiled image as a tileLayer on the view from an options object.
+     * The options object takes options supported by geojs's tileLayer:
+     *
+     *   https://github.com/OpenGeoscience/geojs/blob/master/src/tileLayer.js
+     *
+     * @param {object} opts Tile layer required options
+     * @param {string|function} opts.url
+     */
+    addTileLayer: function (opts) {
+        var layer;
+        if (!_.has(opts, 'url')) {
+            throw new Error('`url` parameter required.');
+        }
+
+        _.defaults(opts, {
+            useCredentials: true,
+            maxLevel: 10,
+            wrapX: false,
+            wrapY: false,
+            tileOffset: function () {
+                return {x: 0, y: 0};
+            },
+            attribution: '',
+            tileWidth: 256,
+            tileHeight: 256,
+            tileRounding: Math.ceil
+        });
+
+        // estimate the global bounds if not provided
+        if (!opts.sizeX) {
+            opts.sizeX = Math.pow(2, opts.maxLevel) * opts.tileWidth;
+        }
+        if (!opts.sizeY) {
+            opts.sizeY = Math.pow(2, opts.maxLevel) * opts.tileHeight;
+        }
+
+        this._expandBounds({
+            right: opts.sizeX - 1,
+            bottom: opts.sizeY - 1
+        });
+        layer = this._map.createLayer('osm', opts);
+        this._layers.push(layer);
+        this._map.draw();
+        return layer;
+    },
+
+    render: function () {
+
+        new girder.models.ItemModel({'_id': '56f55c0f62a8f80b77e45c68'})
+            .on('change', _.bind(function (item) {
+                this.addItem(item);
+            }, this)).fetch();
+        /*
+        new girder.models.ItemModel({'_id': '56fd6d8c62a8f8692876ad89'})
+            .on('change', _.bind(function (item) {
+                this.addItem(item);
+            }, this)).fetch();
+        */
+
         return this;
     },
+
     destroy: function () {
         this._map.exit();
+        this.$el.empty();
         girder.View.prototype.destroy.apply(this, arguments);
     }
 });

--- a/web_client/stylesheets/layout/panelGroup.styl
+++ b/web_client/stylesheets/layout/panelGroup.styl
@@ -1,5 +1,4 @@
-#h-panel-group-container
-  float left
+.h-panel-group
   width 280px
   position fixed
   z-index 999

--- a/web_client/stylesheets/layout/visualization.styl
+++ b/web_client/stylesheets/layout/visualization.styl
@@ -1,2 +1,14 @@
 #h-vis-container
     height 100%
+    width 100%
+
+    .h-panel-group
+        right 0
+        margin-right 5px
+
+    .h-visualization-body
+        position relative
+        top 0
+        left 0
+        height 100%
+        width 100%

--- a/web_client/templates/body.jade
+++ b/web_client/templates/body.jade
@@ -3,4 +3,4 @@
   #h-vis-container
 
   //- contains "panels" for controlling the visualization
-  #h-panel-group-container
+  #h-panel-controls-container.h-panel-group

--- a/web_client/templates/visualization.jade
+++ b/web_client/templates/visualization.jade
@@ -1,1 +1,7 @@
-img(src="#{url}")
+.h-panel-group
+  .h-panel.h-visualization-panel
+    .h-panel-title-container
+      | Open Image
+    .h-panel-content
+      .h-open-image-widget
+.h-visualization-body


### PR DESCRIPTION
This adds a simple control widget to select a Girder item to display.  Either a "large_image" item or an item containing an image file can be selected, and it will appear in the visualization panel rendered by GeoJS.

* It requires the latest master of the large_image plugin.
* The control widget will only let you select items under your user in Girder rather than an arbitrary collection.