### PR TITLE
Add new widget types for directories and output files

### DIFF
--- a/plugin_tests/client/parser.js
+++ b/plugin_tests/client/parser.js
@@ -86,6 +86,7 @@ describe('XML Schema parser', function () {
                 slicerType: 'integer',
                 id: 'foo',
                 title: 'arg1',
+                channel: 'input',
                 description: 'An integer'
             });
         });
@@ -104,6 +105,7 @@ describe('XML Schema parser', function () {
                 slicerType: 'string',
                 id: 'foo',
                 title: 'arg1',
+                channel: 'input',
                 description: 'A description'
             });
         });
@@ -121,6 +123,7 @@ describe('XML Schema parser', function () {
                 type: 'boolean',
                 slicerType: 'boolean',
                 id: 'foo',
+                channel: 'input',
                 title: 'arg1',
                 description: 'A description'
             });
@@ -141,6 +144,7 @@ describe('XML Schema parser', function () {
                 slicerType: 'double-vector',
                 id: 'foo',
                 title: 'arg1',
+                channel: 'input',
                 description: 'A vector',
                 value: [1.5, 2.0, 2.5]
             });
@@ -160,6 +164,7 @@ describe('XML Schema parser', function () {
                 slicerType: 'string-vector',
                 id: 'foo',
                 title: 'arg1',
+                channel: 'input',
                 description: 'A description'
             });
         });
@@ -183,6 +188,7 @@ describe('XML Schema parser', function () {
                 id: 'foo',
                 title: 'arg1',
                 description: 'A choice',
+                channel: 'input',
                 value: 1.5,
                 values: [1.5, 2.5, 3.5]
             });
@@ -203,7 +209,88 @@ describe('XML Schema parser', function () {
                 id: 'foo',
                 title: 'arg1',
                 description: 'A description',
+                channel: 'input',
                 values: []
+            });
+        });
+        it('file', function () {
+            var xml = $.parseXML(
+                '<file>' +
+                '<longflag>foo</longflag>' +
+                '<channel>input</channel>' +
+                '<label>arg1</label>' +
+                '<description>A description</description>' +
+                '</file>'
+            );
+            expect(histomicstk.schema._parseParam(
+                $(xml).find('file').get(0)
+            )).toEqual({
+                type: 'file',
+                slicerType: 'file',
+                id: 'foo',
+                title: 'arg1',
+                description: 'A description',
+                channel: 'input'
+            });
+        });
+        it('directory', function () {
+            var xml = $.parseXML(
+                '<directory>' +
+                '<longflag>foo</longflag>' +
+                '<channel>input</channel>' +
+                '<label>arg1</label>' +
+                '<description>A description</description>' +
+                '</directory>'
+            );
+            expect(histomicstk.schema._parseParam(
+                $(xml).find('directory').get(0)
+            )).toEqual({
+                type: 'directory',
+                slicerType: 'directory',
+                id: 'foo',
+                title: 'arg1',
+                description: 'A description',
+                channel: 'input'
+            });
+        });
+        it('image', function () {
+            var xml = $.parseXML(
+                '<image>' +
+                '<longflag>foo</longflag>' +
+                '<channel>input</channel>' +
+                '<label>arg1</label>' +
+                '<description>A description</description>' +
+                '</image>'
+            );
+            expect(histomicstk.schema._parseParam(
+                $(xml).find('image').get(0)
+            )).toEqual({
+                type: 'file',
+                slicerType: 'image',
+                id: 'foo',
+                title: 'arg1',
+                description: 'A description',
+                channel: 'input'
+            });
+        });
+        it('output file', function () {
+            var xml = $.parseXML(
+                '<file>' +
+                '<longflag>foo</longflag>' +
+                '<channel>output</channel>' +
+                '<label>arg1</label>' +
+                '<description>A description</description>' +
+                '</file>'
+            );
+            expect(histomicstk.schema._parseParam(
+                $(xml).find('file').get(0)
+            )).toEqual({
+                type: 'file',
+                slicerType: 'file',
+                id: 'foo',
+                title: 'arg1',
+                description: 'A description',
+                channel: 'output'
             });
         });
     });
@@ -547,6 +634,7 @@ describe('XML Schema parser', function () {
                           'id': 'integerVariable',
                           'title': 'Integer Parameter',
                           'description': 'An integer without constraints',
+                          'channel': 'input',
                           'value': 30
                         }
                       ]
@@ -561,6 +649,7 @@ describe('XML Schema parser', function () {
                           'id': 'doubleVariable',
                           'title': 'Double Parameter',
                           'description': 'An double with constraints',
+                          'channel': 'input',
                           'value': 30,
                           'min': 0,
                           'max': 1000,
@@ -583,6 +672,7 @@ describe('XML Schema parser', function () {
                           'id': 'floatVector',
                           'title': 'Float Vector Parameter',
                           'description': 'A vector of floats',
+                          'channel': 'input',
                           'value': [
                             1.3,
                             2,
@@ -595,6 +685,7 @@ describe('XML Schema parser', function () {
                           'id': 'stringVector',
                           'title': 'String Vector Parameter',
                           'description': 'A vector of strings',
+                          'channel': 'input',
                           'value': [
                             '"foo"',
                             'bar',
@@ -618,6 +709,7 @@ describe('XML Schema parser', function () {
                           'id': 'stringChoice',
                           'title': 'String Enumeration Parameter',
                           'description': 'An enumeration of strings',
+                          'channel': 'input',
                           'values': [
                             'foo',
                             '"foobar"',

--- a/plugin_tests/client/parser.js
+++ b/plugin_tests/client/parser.js
@@ -285,7 +285,7 @@ describe('XML Schema parser', function () {
             expect(histomicstk.schema._parseParam(
                 $(xml).find('file').get(0)
             )).toEqual({
-                type: 'file',
+                type: 'new-file',
                 slicerType: 'file',
                 id: 'foo',
                 title: 'arg1',

--- a/plugin_tests/client/visualization.js
+++ b/plugin_tests/client/visualization.js
@@ -27,7 +27,7 @@ girderTest.addCoveredScripts([
     '/plugins/HistomicsTK/web_client/js/views/browserPanel.js',
     '/plugins/HistomicsTK/web_client/js/views/controlsPanel.js',
     '/plugins/HistomicsTK/web_client/js/views/controlWidget.js',
-    '/plugins/HistomicsTK/web_client/js/views/fileSelectorWidget.js',
+    '/plugins/HistomicsTK/web_client/js/views/itemSelectorWidget.js',
     '/plugins/HistomicsTK/web_client/js/views/guiSelectorWidget.js',
     '/plugins/HistomicsTK/web_client/js/views/header.js',
     '/plugins/HistomicsTK/web_client/js/views/jobsPanel.js',

--- a/plugin_tests/client/widget.js
+++ b/plugin_tests/client/widget.js
@@ -617,6 +617,64 @@ describe('control widget view', function () {
         girder.views.HierarchyWidget = hwidget;
     });
 
+    it('new-file', function () {
+        var arg, item = new Backbone.Model({id: 'model id'});
+        var hwidget = girder.views.HierarchyWidget;
+        var $modal = $('<div id="g-dialog-container"/>').appendTo('body');
+
+        item.name = function () {
+            return 'b';
+        };
+
+        girder.views.HierarchyWidget = Backbone.View.extend({
+            initialize: function (_arg) {
+                arg = this;
+                this.breadcrumbs = [{
+                    get: function () { return 'a'; }
+                }];
+                _.extend(this, _arg);
+            }
+        });
+        var w = new histomicstk.views.ControlWidget({
+            parentView: parentView,
+            el: $el.get(0),
+            model: new histomicstk.models.Widget({
+                type: 'new-file',
+                title: 'Title',
+                id: 'file-widget'
+            })
+        });
+
+        w.render();
+        checkWidgetCommon(w);
+
+        w.$('.h-select-file-button').click();
+        expect(arg.parentModel).toBe(histomicstk.rootPath);
+
+        // selecting without a file name entered should error
+        $modal.find('.h-select-button').click();
+        expect($modal.find('.form-group').hasClass('has-error')).toBe(true);
+        expect($modal.find('.h-modal-error').hasClass('hidden')).toBe(false);
+
+        // selecting with a file name in a collection should error
+        $modal.find('#h-new-file-name').val('my file');
+        $modal.find('.h-select-button').click();
+        expect($modal.find('.form-group').hasClass('has-error')).toBe(false);
+        expect($modal.find('.h-modal-error').hasClass('hidden')).toBe(false);
+
+        // selecting a file in a folder should succeed
+        arg.parentModel.resourceName = 'folder';
+        $modal.find('.h-select-button').click();
+        expect($modal.find('.form-group').hasClass('has-error')).toBe(false);
+        expect($modal.find('.h-modal-error').hasClass('hidden')).toBe(true);
+        expect(w.model.get('path')).toEqual(['a']);
+        expect(w.model.get('value').get('name')).toBe('my file');
+
+        // reset the environment
+        girder.views.HierarchyWidget = hwidget;
+        $modal.modal('hide');
+        $modal.remove();
+    });
     it('invalid', function () {
         var w = new histomicstk.views.ControlWidget({
             parentView: parentView,

--- a/plugin_tests/client/widget.js
+++ b/plugin_tests/client/widget.js
@@ -580,9 +580,18 @@ describe('control widget view', function () {
     it('file', function () {
         var arg, item = new Backbone.Model({id: 'model id'});
         var hwidget = girder.views.HierarchyWidget;
+
+
+        item.name = function () {
+            return 'b';
+        };
+
         girder.views.HierarchyWidget = Backbone.View.extend({
             initialize: function (_arg) {
                 arg = _arg;
+                this.breadcrumbs = [{
+                    get: function () { return 'a'; }
+                }];
             }
         });
         var w = new histomicstk.views.ControlWidget({
@@ -601,7 +610,9 @@ describe('control widget view', function () {
         w.$('.h-select-file-button').click();
         expect(arg.parentModel).toBe(histomicstk.rootPath);
         arg.onItemClick(item);
-        expect(w.model.value()).toBe('model id');
+        expect(w.model.value().name()).toBe('b');
+
+        expect(w.model.get('path')).toEqual(['a']);
 
         girder.views.HierarchyWidget = hwidget;
     });

--- a/plugin_tests/client/widget.js
+++ b/plugin_tests/client/widget.js
@@ -306,7 +306,8 @@ describe('widget collection', function () {
             {type: 'number-vector', id: 'number-vector', value: '1,2,3'},
             {type: 'string-enumeration', id: 'string-enumeration', values: ['a'], value: 'a'},
             {type: 'number-enumeration', id: 'number-enumeration', values: [1], value: '1'},
-            {type: 'file', id: 'file', value: 'a'}
+            {type: 'file', id: 'file', value: new Backbone.Model({id: 'a'})},
+            {type: 'new-file', id: 'new-file', value: new Backbone.Model({name: 'a', folderId: 'b'})}
         ]);
 
         expect(c.values()).toEqual({
@@ -319,7 +320,9 @@ describe('widget collection', function () {
             'number-vector': [1, 2, 3],
             'string-enumeration': 'a',
             'number-enumeration': 1,
-            file: 'a'
+            'file_girderItemId': 'a',
+            'new-file_girderFolderId': 'b',
+            'new-file_name': 'a'
         });
     });
 });

--- a/plugin_tests/client/widget.js
+++ b/plugin_tests/client/widget.js
@@ -18,7 +18,7 @@ girderTest.addCoveredScripts([
     '/plugins/HistomicsTK/web_client/js/views/browserPanel.js',
     '/plugins/HistomicsTK/web_client/js/views/controlsPanel.js',
     '/plugins/HistomicsTK/web_client/js/views/controlWidget.js',
-    '/plugins/HistomicsTK/web_client/js/views/fileSelectorWidget.js',
+    '/plugins/HistomicsTK/web_client/js/views/itemSelectorWidget.js',
     '/plugins/HistomicsTK/web_client/js/views/guiSelectorWidget.js',
     '/plugins/HistomicsTK/web_client/js/views/header.js',
     '/plugins/HistomicsTK/web_client/js/views/jobsPanel.js',

--- a/web_client/extra/widget_demo.json
+++ b/web_client/extra/widget_demo.json
@@ -85,6 +85,15 @@
                     "type": "file",
                     "title": "input file #1",
                     "id": "h-control-file-selector"
+                }, {
+                    "type": "directory",
+                    "title": "input directory #1",
+                    "id": "h-control-directory-selector"
+                }, {
+                    "type": "new-file",
+                    "channel": "output",
+                    "title": "output file #1",
+                    "id": "h-control-new-file-selector"
                 }
             ]
         }]

--- a/web_client/js/models/widget.js
+++ b/web_client/js/models/widget.js
@@ -306,7 +306,19 @@ histomicstk.collections.Widget = Backbone.Collection.extend({
     values: function () {
         var params = {};
         this.each(function (m) {
-            params[m.id] = m.value();
+            // apply special handling for certain parameter types
+            // https://github.com/DigitalSlideArchive/HistomicsTK/blob/9e5112ab3444ad8c699d70452a5fe4a74ebbc778/server/__init__.py#L44-L46
+            switch (m.get('type')) {
+                case 'file':
+                    params[m.id + '_girderItemId'] = m.value().id;
+                    break;
+                case 'new-file':
+                    params[m.id + '_girderFolderId'] = m.value().get('folderId');
+                    params[m.id + '_name'] = m.value().get('name');
+                    break;
+                default:
+                    params[m.id] = m.value();
+            }
         });
         return params;
     }

--- a/web_client/js/models/widget.js
+++ b/web_client/js/models/widget.js
@@ -227,6 +227,16 @@ histomicstk.models.Widget = Backbone.Model.extend({
     },
 
     /**
+     * True if the value represents a model stored in girder.
+     */
+    isGirderModel: function () {
+        return _.contains(
+            ['directory', 'file', 'new-file'],
+            this.get('type')
+        );
+    },
+
+    /**
      * True if the value represents a file stored in girder.
      */
     isFile: function () {
@@ -253,7 +263,9 @@ histomicstk.models.Widget = Backbone.Model.extend({
         'string-vector',
         'number-enumeration',
         'string-enumeration',
-        'file'
+        'file',
+        'directory',
+        'new-file'
     ]
 });
 

--- a/web_client/js/schema/parser.js
+++ b/web_client/js/schema/parser.js
@@ -100,7 +100,8 @@ histomicstk.schema = {
                 slicerType: param.tagName,
                 id: $param.find('name').text() || $param.find('longflag').text(),
                 title: $param.find('label').text(),
-                description: $param.find('description').text()
+                description: $param.find('description').text(),
+                channel: $param.find('channel').length ? $param.find('channel').text() : 'input'
             },
             values,
             this._parseDefault(type, $param.find('default')),
@@ -129,7 +130,8 @@ histomicstk.schema = {
             'double-enumeration': 'number-enumeration',
             'string-enumeration': 'string-enumeration',
             image: 'file',
-            file: 'file'
+            file: 'file',
+            directory: 'directory'
         };
         return typeMap[param.tagName];
     },

--- a/web_client/js/schema/parser.js
+++ b/web_client/js/schema/parser.js
@@ -81,6 +81,17 @@ histomicstk.schema = {
         var $param = $(param);
         var type = this._widgetType(param);
         var values = {};
+        var channel = $param.find('channel');
+
+        if (channel.length) {
+            channel = channel.text();
+        } else {
+            channel = 'input';
+        }
+
+        if (type === 'file' && channel === 'output') {
+            type = 'new-file';
+        }
 
         if (!type) {
             console.warn('Unhandled parameter type "' + param.tagName + '"'); // eslint-disable-line no-console
@@ -101,7 +112,7 @@ histomicstk.schema = {
                 id: $param.find('name').text() || $param.find('longflag').text(),
                 title: $param.find('label').text(),
                 description: $param.find('description').text(),
-                channel: $param.find('channel').length ? $param.find('channel').text() : 'input'
+                channel: channel
             },
             values,
             this._parseDefault(type, $param.find('default')),

--- a/web_client/js/views/controlWidget.js
+++ b/web_client/js/views/controlWidget.js
@@ -23,6 +23,12 @@ histomicstk.views.ControlWidget = girder.View.extend({
         return this;
     },
 
+    remove: function () {
+        this.$('.h-control-item[data-type="color"] .input-group').colorpicker('destroy');
+        this.$('.h-control-item[data-type="range"] input').slider('destroy');
+        this.$el.empty();
+    },
+
     /**
      * Set classes on the input element to indicate to the user that the current value
      * is invalid.  This is automatically triggered by the model's "invalid" event.
@@ -109,14 +115,9 @@ histomicstk.views.ControlWidget = girder.View.extend({
      * Get the value from a file selection modal and set the text in the widget's
      * input element.
      */
-    _selectFile: function (evt) {
-        var input = $(evt.target).closest('.input-group').find('input');
-        var id = input.attr('id');
-        var name = input.attr('name');
-        var modal = new histomicstk.views.FileSelectorWidget({
+    _selectFile: function () {
+        var modal = new histomicstk.views.ItemSelectorWidget({
             el: $('#g-dialog-container'),
-            id: id,
-            name: name,
             parentView: this,
             model: this.model
         });

--- a/web_client/js/views/controlWidget.js
+++ b/web_client/js/views/controlWidget.js
@@ -17,7 +17,7 @@ histomicstk.views.ControlWidget = girder.View.extend({
         if (options && options.norender) {
             return this;
         }
-        this.$el.html(this.template()(this.model.toJSON()));
+        this.$el.html(this.template()(this.model.attributes));
         this.$('.h-control-item[data-type="range"] input').slider();
         this.$('.h-control-item[data-type="color"] .input-group').colorpicker({});
         return this;
@@ -72,6 +72,12 @@ histomicstk.views.ControlWidget = girder.View.extend({
         },
         file: {
             template: 'fileWidget'
+        },
+        directory: {
+            template: 'fileWidget'
+        },
+        'new-file': {
+            template: 'fileWidget'
         }
     },
 
@@ -102,7 +108,7 @@ histomicstk.views.ControlWidget = girder.View.extend({
             val = $el.get(0).checked;
         }
         if (this.model.isVector()) {
-            old = this.model.value().slice();
+            old = this.model.get('value').slice();
             old[$el.data('vectorComponent')] = val;
             val = old;
         }
@@ -121,8 +127,7 @@ histomicstk.views.ControlWidget = girder.View.extend({
             parentView: this,
             model: this.model
         });
-        modal.on('g:saved', _.bind(function (item) {
-            this.model.set('value', item.id);
+        modal.on('g:saved', _.bind(function () {
             modal.$el.modal('hide');
         }, this)).render();
     }

--- a/web_client/js/views/itemSelectorWidget.js
+++ b/web_client/js/views/itemSelectorWidget.js
@@ -1,11 +1,4 @@
-histomicstk.views.FileSelectorWidget = girder.View.extend({
-    initialize: function (settings) {
-        this._target = {
-            id: settings.id,
-            name: settings.name
-        };
-    },
-
+histomicstk.views.ItemSelectorWidget = girder.View.extend({
     render: function () {
         var hierarchyView = new girder.views.HierarchyWidget({
             parentView: this,
@@ -17,7 +10,7 @@ histomicstk.views.FileSelectorWidget = girder.View.extend({
         });
 
         this.$el.html(
-            histomicstk.templates.fileSelectorWidget(this._target)
+            histomicstk.templates.itemSelectorWidget(this.model.attributes)
         ).girderModal(this);
 
         hierarchyView.setElement(this.$('.modal-body')).render();

--- a/web_client/js/views/itemSelectorWidget.js
+++ b/web_client/js/views/itemSelectorWidget.js
@@ -24,9 +24,14 @@ histomicstk.views.ItemSelectorWidget = girder.View.extend({
      * Get the currently displayed path in the hierarchy view.
      */
     _path: function () {
-        return this._hierarchyView.breadcrumbs.map(function (d) {
+        var path = this._hierarchyView.breadcrumbs.map(function (d) {
             return d.get('name');
         });
+
+        if (this.model.get('type') === 'directory') {
+            path = _.initial(path)
+        }
+        return path;
     },
 
     _selectItem: function (item) {

--- a/web_client/js/views/itemSelectorWidget.js
+++ b/web_client/js/views/itemSelectorWidget.js
@@ -42,17 +42,28 @@ histomicstk.views.ItemSelectorWidget = girder.View.extend({
     _selectButton: function () {
         var inputEl = this.$('#h-new-file-name');
         var inputElGroup =  inputEl.parent();
-        var fileName = inputEl.val() || '';
+        var fileName = inputEl.val();
         var type = this.model.get('type');
         var parent = this._hierarchyView.parentModel;
+        var errorEl = this.$('.h-modal-error').addClass('hidden');
 
         inputElGroup.removeClass('has-error');
 
         switch (type) {
             case 'new-file':
 
-                if (fileName === '') {
+                // a file name must be provided
+                if (!fileName) {
                     inputElGroup.addClass('has-error');
+                    errorEl.removeClass('hidden')
+                        .text('You must provide a name for the new file.');
+                    return;
+                }
+
+                // the parent must be a folder
+                if (parent.resourceName !== 'folder') {
+                    errorEl.removeClass('hidden')
+                        .text('Files cannot be added under collections.');
                     return;
                 }
 

--- a/web_client/js/views/itemSelectorWidget.js
+++ b/web_client/js/views/itemSelectorWidget.js
@@ -1,6 +1,10 @@
 histomicstk.views.ItemSelectorWidget = girder.View.extend({
+    events: {
+        'click .h-select-button': '_selectButton'
+    },
+
     render: function () {
-        var hierarchyView = new girder.views.HierarchyWidget({
+        this._hierarchyView = new girder.views.HierarchyWidget({
             parentView: this,
             parentModel: histomicstk.rootPath,
             checkboxes: false,
@@ -13,10 +17,62 @@ histomicstk.views.ItemSelectorWidget = girder.View.extend({
             histomicstk.templates.itemSelectorWidget(this.model.attributes)
         ).girderModal(this);
 
-        hierarchyView.setElement(this.$('.modal-body')).render();
+        this._hierarchyView.setElement(this.$('.h-hierarchy-widget')).render();
+    },
+
+    /**
+     * Get the currently displayed path in the hierarchy view.
+     */
+    _path: function () {
+        return this._hierarchyView.breadcrumbs.map(function (d) {
+            return d.get('name');
+        });
     },
 
     _selectItem: function (item) {
-        this.trigger('g:saved', item);
+        if (this.model.get('type') === 'file') {
+            this.model.set({
+                path: this._path(),
+                value: item
+            });
+            this.trigger('g:saved');
+        }
+    },
+
+    _selectButton: function () {
+        var inputEl = this.$('#h-new-file-name');
+        var inputElGroup =  inputEl.parent();
+        var fileName = inputEl.val() || '';
+        var type = this.model.get('type');
+        var parent = this._hierarchyView.parentModel;
+
+        inputElGroup.removeClass('has-error');
+
+        switch (type) {
+            case 'new-file':
+
+                if (fileName === '') {
+                    inputElGroup.addClass('has-error');
+                    return;
+                }
+
+                this.model.set({
+                    path: this._path(),
+                    parent: parent,
+                    value: new girder.models.ItemModel({
+                        name: fileName,
+                        folderId: parent.id
+                    })
+                });
+                break;
+
+            case 'directory':
+                this.model.set({
+                    path: this._path(),
+                    value: parent
+                });
+                break;
+        }
+        this.trigger('g:saved');
     }
 });

--- a/web_client/js/views/panelGroup.js
+++ b/web_client/js/views/panelGroup.js
@@ -31,6 +31,7 @@ histomicstk.views.PanelGroup = girder.View.extend({
         _.each(this._panelViews, function (view) {
             view.remove();
         });
+        this._panelViews = {};
         this._jobsPanelView.setElement(this.$('.h-jobs-panel')).render();
         _.each(this.panels, _.bind(function (panel) {
             this._panelViews[panel.id] = new histomicstk.views.ControlsPanel({

--- a/web_client/js/views/panelGroup.js
+++ b/web_client/js/views/panelGroup.js
@@ -50,9 +50,16 @@ histomicstk.views.PanelGroup = girder.View.extend({
      * Submit the current values to the server.
      */
     submit: function () {
-        var params;
+        var params, invalid = false;
 
-        if (!this.validate()) {
+        invalid = this.invalidModels();
+
+        if (invalid.length) {
+            girder.events.trigger('g:alert', {
+                icon: 'attention',
+                text: 'Please enter a valid value for: ' + invalid.map(function (m) {return m.get('title');}).join(', '),
+                type: 'danger'
+            });
             return;
         }
 

--- a/web_client/js/views/panelGroup.js
+++ b/web_client/js/views/panelGroup.js
@@ -40,13 +40,32 @@ histomicstk.views.PanelGroup = girder.View.extend({
      * Submit the current values to the server.
      */
     submit: function () {
+        var params;
+
         if (!this.validate()) {
             return;
         }
 
-        // todo
-        console.log('Submit ' + this._schemaName); // eslint-disable-line no-console
-        console.log(JSON.stringify(this.parameters(), null, 2)); // eslint-disable-line no-console
+        params = this.parameters();
+        _.each(params, function (value, key) {
+            if (_.isArray(value)) {
+                params[key] = JSON.stringify(value)
+            }
+        });
+
+        // For the widget demo, just print the parameters to the console
+        if (this._schemaName === 'demo') {
+            console.log('Submit'); // eslint-disable-line no-console
+            console.log(JSON.stringify(params, null, 2)); // eslint-disable-line no-console
+            return;
+        }
+
+        // post the job to the server
+        girder.restRequest({
+            path: 'HistomicsTK/' + this._schemaName + '/run',
+            type: 'POST',
+            data: params
+        });
     },
 
     /**

--- a/web_client/js/views/panelGroup.js
+++ b/web_client/js/views/panelGroup.js
@@ -9,6 +9,14 @@ histomicstk.views.PanelGroup = girder.View.extend({
         this._panelViews = {};
         this._schemaName = null;
 
+        this._jobsPanelView = new histomicstk.views.JobsPanel({
+            parentView: this,
+            spec: {
+                title: 'Jobs',
+                collapsed: true
+            }
+        });
+
         // render a specific schema
         this.listenTo(histomicstk.router, 'route:gui', this.schema);
 
@@ -23,6 +31,7 @@ histomicstk.views.PanelGroup = girder.View.extend({
         _.each(this._panelViews, function (view) {
             view.remove();
         });
+        this._jobsPanelView.setElement(this.$('.h-jobs-panel')).render();
         _.each(this.panels, _.bind(function (panel) {
             this._panelViews[panel.id] = new histomicstk.views.ControlsPanel({
                 parentView: this,

--- a/web_client/js/views/visualization.js
+++ b/web_client/js/views/visualization.js
@@ -8,8 +8,7 @@ histomicstk.views.Visualization = girder.View.extend({
 
         // control model for file widget
         this._controlModel = new histomicstk.models.Widget({
-            type: 'file',
-            root: histomicstk.rootPath
+            type: 'file'
         });
 
         // control widget view
@@ -19,7 +18,7 @@ histomicstk.views.Visualization = girder.View.extend({
         });
 
         this.listenTo(this._controlModel, 'change:value', function (model) {
-            var id = model.get('value');
+            var id = model.get('value').id;
             girder.restRequest({
                 path: 'item/' + id
             })

--- a/web_client/templates/fileSelectorWidget.jade
+++ b/web_client/templates/fileSelectorWidget.jade
@@ -1,8 +1,0 @@
-.modal-dialog
-  .modal-content
-    .modal-header
-      button.close(data-dismiss="modal", aria-hidden="true", type="button") &times;
-      h4.modal-title
-        | Select a file for "#{name}"
-    .modal-body(
-      data-target-id='#{id}')

--- a/web_client/templates/fileWidget.jade
+++ b/web_client/templates/fileWidget.jade
@@ -2,6 +2,10 @@ extends ./widget.jade
 
 block input
   .input-group
+    if path
+      - value = '/' + path.join('/') + '/' + value.name();
+    else if value.name
+      - value = value.name();
     +input(title, type, id, value)(
       placeholder='Choose a file...'
       readonly=true)

--- a/web_client/templates/itemSelectorWidget.jade
+++ b/web_client/templates/itemSelectorWidget.jade
@@ -2,13 +2,26 @@
   .modal-content
     .modal-header
       button.close(data-dismiss="modal", aria-hidden="true", type="button") &times;
+      - var t = type === 'new-file' ? 'directory' : type;
+      - var name = title ? ' for "' + title + '"' : '';
+      if value && value.name
+        - value = value.name()
       h4.modal-title
-        | Select a #{type} for "#{name}"
+        | Select a #{t}#{name}
     .modal-body(
       data-target-id='#{id}')
-    if type === 'directory'
+      .h-hierarchy-widget
+      if type === 'new-file'
+        .form-group
+          input.form-control(
+            type='text'
+            id='h-new-file-name'
+            value=value
+            placeholder='Enter an item name...')
+
+    if type === 'directory' || type === 'new-file'
       .modal-footer
-          a.btn.btn-small.btn-default(data-dismiss="modal") Cancel
-          button.h-save-directory.btn.btn-small.btn-primary(type="submit")
-            i.icon-edit
+        a.btn.btn-small.btn-default(data-dismiss="modal") Cancel
+        button.h-select-button.btn.btn-small.btn-primary(type="submit")
+          i.icon-edit
             | Select

--- a/web_client/templates/itemSelectorWidget.jade
+++ b/web_client/templates/itemSelectorWidget.jade
@@ -26,4 +26,4 @@
         a.btn.btn-small.btn-default(data-dismiss="modal") Cancel
         button.h-select-button.btn.btn-small.btn-primary(type="submit")
           i.icon-edit
-            | Select
+          | Save

--- a/web_client/templates/itemSelectorWidget.jade
+++ b/web_client/templates/itemSelectorWidget.jade
@@ -10,6 +10,7 @@
         | Select a #{t}#{name}
     .modal-body(
       data-target-id='#{id}')
+      .alert.alert-danger.h-modal-error.hidden
       .h-hierarchy-widget
       if type === 'new-file'
         .form-group

--- a/web_client/templates/itemSelectorWidget.jade
+++ b/web_client/templates/itemSelectorWidget.jade
@@ -1,0 +1,14 @@
+.modal-dialog
+  .modal-content
+    .modal-header
+      button.close(data-dismiss="modal", aria-hidden="true", type="button") &times;
+      h4.modal-title
+        | Select a #{type} for "#{name}"
+    .modal-body(
+      data-target-id='#{id}')
+    if type === 'directory'
+      .modal-footer
+          a.btn.btn-small.btn-default(data-dismiss="modal") Cancel
+          button.h-save-directory.btn.btn-small.btn-primary(type="submit")
+            i.icon-edit
+            | Select

--- a/web_client/templates/itemSelectorWidget.jade
+++ b/web_client/templates/itemSelectorWidget.jade
@@ -14,6 +14,7 @@
       .h-hierarchy-widget
       if type === 'new-file'
         .form-group
+          label.control-label(for='h-new-file-name') Item name
           input.form-control(
             type='text'
             id='h-new-file-name'

--- a/web_client/templates/layout.jade
+++ b/web_client/templates/layout.jade
@@ -1,6 +1,5 @@
 #g-app-header-container
 #g-app-body-container.h-app-body-container
-#g-app-footer-container
 
 #g-app-progress-container
 

--- a/web_client/templates/panel.jade
+++ b/web_client/templates/panel.jade
@@ -7,7 +7,8 @@
       i.icon-down-open
     else
       i.icon-up-open
-    i.icon-cancel.h-remove-panel(data-target='##{id}')
+    if removeButton
+      i.icon-cancel.h-remove-panel(data-target='##{id}')
 
 - var attrs = {}
 if !collapsed

--- a/web_client/templates/panelGroup.jade
+++ b/web_client/templates/panelGroup.jade
@@ -8,5 +8,8 @@ if info
       .h-info-panel-buttons
         button.btn.btn-default.h-info-panel-reload Reload
         button.btn.btn-primary.h-info-panel-submit Submit
+
+  .h-jobs-panel.h-panel
+
 each panel in panels
   .h-panel(class='#{panel.type}', id='#{panel.id}')


### PR DESCRIPTION
For file outputs, I created a text `<input>` below the hierarchy widget for the user to type in the new item name.

![screen shot 2016-04-14 at 2 04 25 pm](https://cloud.githubusercontent.com/assets/31890/14538453/d69bfb22-0249-11e6-928e-93f5d21ecefd.png)

There is minimal validation done when submitting the modal.

![screen shot 2016-04-14 at 1 57 22 pm](https://cloud.githubusercontent.com/assets/31890/14538380/844c93b8-0249-11e6-8649-72bb8bd6b2b9.png)

The main control widget now shows a path string rather than an object id.

![screen shot 2016-04-14 at 1 58 07 pm](https://cloud.githubusercontent.com/assets/31890/14538497/106b6842-024a-11e6-8e8e-bd2a1830e61f.png)

Finally, the submit button actually `POST`'s to the analysis endpoint.  I think it is submitting correctly, but I haven't been able to get the celery working running correctly locally yet.