### PR TITLE
Update CondenseLabel.py

### DIFF
--- a/histomicstk/CondenseLabel.py
+++ b/histomicstk/CondenseLabel.py
@@ -29,7 +29,7 @@ def CondenseLabel(Label):
     Unique = np.delete(Unique, (Unique == 0).nonzero())
 
     # initialize output
-    Condensed = np.zeros(Label.shape)
+    Condensed = np.zeros(Label.shape, dtype=np.uint32)
 
     # get pixel list for each object
     Props = ms.regionprops(Label.astype(np.int))

--- a/histomicstk/LabelPerimeter.py
+++ b/histomicstk/LabelPerimeter.py
@@ -54,4 +54,4 @@ def LabelPerimeter(L, Connectivity=4):
         Mask = np.logical_or(Mask, Temp)
 
     # generate label-valued output
-    return Mask.astype(np.float) * L
+    return Mask.astype(np.uint32) * L

--- a/histomicstk/ShuffleLabel.py
+++ b/histomicstk/ShuffleLabel.py
@@ -32,7 +32,7 @@ def ShuffleLabel(Label):
     np.random.shuffle(Unique)
 
     # initialize output
-    Shuffled = np.zeros(Label.shape)
+    Shuffled = np.zeros(Label.shape, dtype=np.uint32)
 
     # get pixel list for each object
     Props = ms.regionprops(Label.astype(np.int))


### PR DESCRIPTION
Fixed output type of condensed label image to uint32. Integer type is required for compatibility with scipy label image processing algorithms.