### PR TITLE
Pin the pillow version for conda.

### DIFF
--- a/requirements_c_conda.txt
+++ b/requirements_c_conda.txt
@@ -20,3 +20,6 @@ scipy==0.16.0
 
 scikit-learn==0.17.1
 pandas==0.18.1
+
+# We want Pillow 3.2.0.  Make sure conda doesn't change it on us.
+Pillow==3.2.0


### PR DESCRIPTION
Pillow 3.3.0 doesn't work in the travis environment without more work, so pin to 3.2.0.