### PR TITLE
Fix scrolling in control panels

### DIFF
--- a/web_client/stylesheets/panel/panel.styl
+++ b/web_client/stylesheets/panel/panel.styl
@@ -1,8 +1,6 @@
 .h-panel-group
-  pointer-events none
 
   .h-panel
-    pointer-events initial
     background-color #ffffff
     opacity .95
     margin-top 5px


### PR DESCRIPTION
This reverts the change in 3794a403, which was intended to fix behavior observed in the demo video... When scrolling on the side panel, the image zooms when reaching a gap in the panels.  

That change had the consequence of disabling scrolling on the side panel entirely.  When attempting to fix this, I found I was unable to reproduce the behavior seen in the video.  If anyone can reproduce it with this change, let me know.