### PR TITLE
Fix boundary tracing outputs

### DIFF
--- a/histomicstk/segmentation/label/TraceBounds.py
+++ b/histomicstk/segmentation/label/TraceBounds.py
@@ -71,6 +71,10 @@ def TraceBounds(Mask, Connectivity=4, XStart=None, YStart=None,
     else:
         raise ValueError("Input 'Connectivity' must be 4 or 8.")
 
+    # convert outputs from list to numpy array
+    X = np.array(X, dtype=np.uint32)
+    Y = np.array(Y, dtype=np.uint32)
+
     return X, Y
 
 
@@ -159,10 +163,6 @@ def Moore(Mask, XStart, YStart, MaxLength):
                     X = X[0:-1]
                     Y = Y[0:-1]
                     break
-
-    # convert outputs from list to numpy array
-    X = np.array(X, dtype=np.uint32)
-    Y = np.array(Y, dtype=np.uint32)
 
     return X, Y
 

--- a/histomicstk/segmentation/label/TraceBounds.py
+++ b/histomicstk/segmentation/label/TraceBounds.py
@@ -160,6 +160,10 @@ def Moore(Mask, XStart, YStart, MaxLength):
                     Y = Y[0:-1]
                     break
 
+    # convert outputs from list to numpy array
+    X = np.array(X, dtype=np.uint32)
+    Y = np.array(Y, dtype=np.uint32)
+
     return X, Y
 
 

--- a/histomicstk/segmentation/label/TraceBounds.py
+++ b/histomicstk/segmentation/label/TraceBounds.py
@@ -286,7 +286,7 @@ def ISBF(Mask, XStart, YStart, MaxLength):  # noqa: C901
             X.append(X[-1] + Coords[0, i])
             Y.append(Y[-1] + Coords[1, i])
 
-        # check of last two points on contour are first two points on contour
+        # check if last two contour points are same as first two points
         if(len(X) > 3):
             if(len(X) >= MaxLength) or \
                 (X[-1] == X[1] and X[-2] == X[0] and

--- a/histomicstk/segmentation/label/TraceBounds.py
+++ b/histomicstk/segmentation/label/TraceBounds.py
@@ -59,8 +59,8 @@ def TraceBounds(Mask, Connectivity=4, XStart=None, YStart=None,
             YStart = Indices[0][0]
             XStart = Indices[1][0]
         else:
-            X = []
-            Y = []
+            X = np.array([], dtype=np.uint32)
+            Y = np.array([], dtype=np.uint32)
             return X, Y
 
     # choose algorithm based on connectivity

--- a/histomicstk/segmentation/label/TraceBounds.py
+++ b/histomicstk/segmentation/label/TraceBounds.py
@@ -111,58 +111,61 @@ def Moore(Mask, XStart, YStart, MaxLength):
     X.append(XStart)
     Y.append(YStart)
 
-    # initialize direction
-    DX = 1
-    DY = 0
+    # check degenerate case where mask contains 1 pixel
+    if Mask.sum() > 1:
 
-    # define clockwise ordered indices
-    row = [2, 1, 0, 0, 0, 1, 2, 2]
-    col = [0, 0, 0, 1, 2, 2, 2, 1]
-    dX = [-1, 0, 0, 1, 1, 0, 0, -1]
-    dY = [0, -1, -1, 0, 0, 1, 1, 0]
-    oX = [-1, -1, -1, 0, 1, 1, 1, 0]
-    oY = [1, 0, -1, -1, -1, 0, 1, 1]
+        # initialize direction
+        DX = 1
+        DY = 0
 
-    while True:
+        # define clockwise ordered indices
+        row = [2, 1, 0, 0, 0, 1, 2, 2]
+        col = [0, 0, 0, 1, 2, 2, 2, 1]
+        dX = [-1, 0, 0, 1, 1, 0, 0, -1]
+        dY = [0, -1, -1, 0, 0, 1, 1, 0]
+        oX = [-1, -1, -1, 0, 1, 1, 1, 0]
+        oY = [1, 0, -1, -1, -1, 0, 1, 1]
 
-        # rotate template surrounding current location to fit relative frame
-        if (DX == 1) & (DY == 0):
-            T = np.rot90(Mask[Y[-1]-1:Y[-1]+2, X[-1]-1:X[-1]+2], 1)
-            Angle = np.pi/2
-        elif (DX == 0) & (DY == -1):
-            T = Mask[Y[-1]-1:Y[-1]+2, X[-1]-1:X[-1]+2]
-            Angle = 0
-        elif (DX == -1) & (DY == 0):
-            T = np.rot90(Mask[Y[-1]-1:Y[-1]+2, X[-1]-1:X[-1]+2], 3)
-            Angle = 3 * np.pi / 2
-        else:  # (Direction[0] == 0) & (DY[-1] == 1):
-            T = np.rot90(Mask[Y[-1]-1:Y[-1]+2, X[-1]-1:X[-1]+2], 2)
-            Angle = np.pi
+        while True:
 
-        # get first template entry that is 1
-        Move = np.argmax(T[row, col])
+            # rotate template surrounding current location to fit relative frame
+            if (DX == 1) & (DY == 0):
+                T = np.rot90(Mask[Y[-1]-1:Y[-1]+2, X[-1]-1:X[-1]+2], 1)
+                Angle = np.pi/2
+            elif (DX == 0) & (DY == -1):
+                T = Mask[Y[-1]-1:Y[-1]+2, X[-1]-1:X[-1]+2]
+                Angle = 0
+            elif (DX == -1) & (DY == 0):
+                T = np.rot90(Mask[Y[-1]-1:Y[-1]+2, X[-1]-1:X[-1]+2], 3)
+                Angle = 3 * np.pi / 2
+            else:  # (Direction[0] == 0) & (DY[-1] == 1):
+                T = np.rot90(Mask[Y[-1]-1:Y[-1]+2, X[-1]-1:X[-1]+2], 2)
+                Angle = np.pi
 
-        # transform points by incoming directions and add to contours
-        R = np.array([[np.cos(Angle), -np.sin(Angle)],
-                      [np.sin(Angle), np.cos(Angle)]])
-        Coords = R.dot(np.vstack((np.array(oX[Move]),
-                                  np.array(oY[Move])))).round()
-        Direction = R.dot(np.vstack((dX[Move], dY[Move]))).round()
-        DX = Direction[0]
-        DY = Direction[1]
+            # get first template entry that is 1
+            Move = np.argmax(T[row, col])
 
-        # capture next location
-        X.append(X[-1] + Coords[0][0])
-        Y.append(Y[-1] + Coords[1][0])
+            # transform points by incoming directions and add to contours
+            R = np.array([[np.cos(Angle), -np.sin(Angle)],
+                          [np.sin(Angle), np.cos(Angle)]])
+            Coords = R.dot(np.vstack((np.array(oX[Move]),
+                                      np.array(oY[Move])))).round()
+            Direction = R.dot(np.vstack((dX[Move], dY[Move]))).round()
+            DX = Direction[0]
+            DY = Direction[1]
 
-        # check of last two points on contour are first two points on contour
-        if(len(X) > 3):
-            if(len(X) >= MaxLength) or \
-                (X[-1] == X[1] and X[-2] == X[0] and
-                 Y[-1] == Y[1] and Y[-2] == Y[0]):
-                    X = X[0:-1]
-                    Y = Y[0:-1]
-                    break
+            # capture next location
+            X.append(X[-1] + Coords[0][0])
+            Y.append(Y[-1] + Coords[1][0])
+
+            # check of last two points on contour are first two points on contour
+            if(len(X) > 3):
+                if(len(X) >= MaxLength) or \
+                    (X[-1] == X[1] and X[-2] == X[0] and
+                     Y[-1] == Y[1] and Y[-2] == Y[0]):
+                        X = X[0:-1]
+                        Y = Y[0:-1]
+                        break
 
     return X, Y
 

--- a/histomicstk/segmentation/label/TraceLabel.py
+++ b/histomicstk/segmentation/label/TraceLabel.py
@@ -59,10 +59,10 @@ def TraceLabel(Label, Connectivity=4):
     for i in np.arange(1, Label.max()+1):
 
         # process non-empty objects
-        if not Locations[i] is None:
+        if not Locations[i-1] is None:
 
             # capture patch containing object of interest
-            Patch = Label[Locations[i]] == i
+            Patch = Label[Locations[i-1]] == i
 
             # pad edges for tracing
             Embed = np.zeros((Patch.shape[0]+2, Patch.shape[1]+2),
@@ -73,8 +73,8 @@ def TraceLabel(Label, Connectivity=4):
             cX, cY = TraceBounds(Embed, Connectivity)
 
             # add window offset to contour coordinates
-            cX = cX + Locations[i][1].start - 1
-            cY = cY + Locations[i][0].start - 1
+            cX = cX + Locations[i-1][1].start - 1
+            cY = cY + Locations[i-1][0].start - 1
 
             # append to list of candidate contours
             X.append(np.array(cX, dtype=np.uint32))

--- a/histomicstk/segmentation/label/TraceLabel.py
+++ b/histomicstk/segmentation/label/TraceLabel.py
@@ -80,10 +80,10 @@ def TraceLabel(Label, Connectivity=4):
             X.append(np.array(cX, dtype=np.uint32))
             Y.append(np.array(cY, dtype=np.uint32))
 
-    else:
+        else:
 
-        # append None to Outputs X, Y
-        X.append(None)
-        Y.append(None)
+            # append None to Outputs X, Y
+            X.append(None)
+            Y.append(None)
 
     return X, Y

--- a/histomicstk/segmentation/nuclear/MinimumModel.py
+++ b/histomicstk/segmentation/nuclear/MinimumModel.py
@@ -323,15 +323,15 @@ def TraceContours(I, X, Y, Min, Max, MaxLength=255):
         # trace boundary, check stopping condition, append to list of contours
         cX, cY = label.TraceBounds(Embed, Connectivity=4,
                                    XStart=pX, YStart=pY, MaxLength=MaxLength)
-        if(cX[0] == cX[-1] and cY[0] == cY[-1] and len(cX) <= MaxLength):
+        if(cX[0] == cX[-1] and cY[0] == cY[-1] and cX.size <= MaxLength):
 
             # add window offset to contour coordinates
-            cX = [x + max(0, X[i]-np.ceil(MaxLength/2.0)) - 1 for x in cX]
-            cY = [y + max(0, Y[i]-np.ceil(MaxLength/2.0)) - 1 for y in cY]
+            cX = cX + max(0, X[i]-np.ceil(MaxLength/2.0)) - 1
+            cY = cY + max(0, Y[i]-np.ceil(MaxLength/2.0)) - 1
 
             # append to list of candidate contours
-            cXs.append(np.array(cX, dtype=np.uint32))
-            cYs.append(np.array(cY, dtype=np.uint32))
+            cXs.append(cX)
+            cYs.append(cX)
 
     return cXs, cYs
 
@@ -544,8 +544,8 @@ def SplitConcavities(Label, MinDepth=4, MinConcavity=np.inf):  # noqa: C901
 
         # generate boundary coordinates, trim duplicate point
         X, Y = label.TraceBounds(Mask, Connectivity=8)
-        X = np.array(X[:-1], dtype=np.uint32)
-        Y = np.array(Y[:-1], dtype=np.uint32)
+        X = X[:-1]
+        Y = Y[:-1]
 
         # calculate distance transform of object boundary pixels to convex hull
         Distance = mp.distance_transform_edt(Hull)


### PR DESCRIPTION
Converted outputs of TraceBounds from list to array, modified functions calling TraceBounds accordingly.

Also improved handling of degenerate case where object contains a single pixel. This was causing errors when tracing with the Moore neighbor algorithm.
