### PR TITLE
Add python coverage tests to those run by travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -90,9 +90,9 @@ install:
 script:
     - mkdir -p $build_path/girder_testing_build
     - cd $build_path/girder_testing_build
-    - cmake -DPYTHON_COVERAGE:BOOL=${PY_COVG} -DPYTHON_VERSION:STRING=${TRAVIS_PYTHON_VERSION} -DPYTHON_COVERAGE_CONFIG="$main_path/plugin_tests/pycoverage.cfg" -DCOVERAGE_MINIMUM_PASS=19 -DRUN_CORE_TESTS:BOOL="OFF" -DTEST_PLUGINS:STRING="HistomicsTK" $girder_path
+    - cmake -DPYTHON_COVERAGE:BOOL=${PY_COVG} -DPYTHON_VERSION:STRING=${TRAVIS_PYTHON_VERSION} -DPYTHON_COVERAGE_CONFIG="$main_path/plugin_tests/pycoverage.cfg" -DCOVERAGE_MINIMUM_PASS=19 -DJS_COVERAGE_MINIMUM_PASS=19 -DRUN_CORE_TESTS:BOOL="OFF" -DTEST_PLUGINS:STRING="HistomicsTK" $girder_path
     - make
-    - JASMINE_TIMEOUT=15000 ctest -VV -R '(py_coverage_reset|py_coverage_combine|HistomicsTK|histomicstk|py_coverage$|py_coverage_xml)'
+    - JASMINE_TIMEOUT=15000 ctest -VV -R '(coverage_reset|coverage_combine|HistomicsTK|histomicstk|coverage$|coverage_xml)'
 
 after_success:
     - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -90,6 +90,6 @@ install:
 script:
     - mkdir -p $build_path/girder_testing_build
     - cd $build_path/girder_testing_build
-    - cmake -DPYTHON_COVERAGE:BOOL=${PY_COVG} -DPYTHON_VERSION:STRING=${TRAVIS_PYTHON_VERSION} -DRUN_CORE_TESTS:BOOL="OFF" -DTEST_PLUGINS:STRING="HistomicsTK" $girder_path
+    - cmake -DPYTHON_COVERAGE:BOOL=${PY_COVG} -DPYTHON_VERSION:STRING=${TRAVIS_PYTHON_VERSION} -DPYTHON_COVERAGE_CONFIG="$main_path/plugin_tests/pycoverage.cfg" -DCOVERAGE_MINIMUM_PASS=19 -DRUN_CORE_TESTS:BOOL="OFF" -DTEST_PLUGINS:STRING="HistomicsTK" $girder_path
     - make
-    - JASMINE_TIMEOUT=15000 ctest -VV -R HistomicsTK
+    - JASMINE_TIMEOUT=15000 ctest -VV -R '(py_coverage_reset|py_coverage_combine|HistomicsTK|histomicstk|py_coverage$|py_coverage_xml)'

--- a/.travis.yml
+++ b/.travis.yml
@@ -93,3 +93,6 @@ script:
     - cmake -DPYTHON_COVERAGE:BOOL=${PY_COVG} -DPYTHON_VERSION:STRING=${TRAVIS_PYTHON_VERSION} -DPYTHON_COVERAGE_CONFIG="$main_path/plugin_tests/pycoverage.cfg" -DCOVERAGE_MINIMUM_PASS=19 -DRUN_CORE_TESTS:BOOL="OFF" -DTEST_PLUGINS:STRING="HistomicsTK" $girder_path
     - make
     - JASMINE_TIMEOUT=15000 ctest -VV -R '(py_coverage_reset|py_coverage_combine|HistomicsTK|histomicstk|py_coverage$|py_coverage_xml)'
+
+after_success:
+    - bash <(curl -s https://codecov.io/bash)

--- a/README.rst
+++ b/README.rst
@@ -10,6 +10,10 @@ Documentation for this API can be found at https://histomicstk.readthedocs.org.
     :target: https://travis-ci.org/DigitalSlideArchive/HistomicsTK
     :alt: Build Status
 
+.. |codecov-io| image:: https://codecov.io/github/DigitalSlideArchiveHistomicsTK/coverage.svg?branch=master
+    :target: https://codecov.io/github/DigitalSlideArchiveHistomicsTK?branch=master
+    :alt: codecov.io
+
 .. |docs-status| image:: https://readthedocs.org/projects/histomicstk/badge/?version=latest
     :target: http://histomicstk.readthedocs.org/en/latest/?badge=latest
     :alt: Documentation Status

--- a/plugin_tests/pycoverage.cfg
+++ b/plugin_tests/pycoverage.cfg
@@ -1,0 +1,6 @@
+[run]
+branch = False
+
+[report]
+omit = girder/*,clients/python/*
+


### PR DESCRIPTION
Enabled python code coverage measurement.  We want to add more tests, and this will help determine where they are needed.  We can add a service like codecov to make it easier to see what has been covered, if developers would find that useful.