### PR TITLE
Reorder the openslide task so it is before installing pip's libtiff.

### DIFF
--- a/ansible/roles/girder/tasks/main.yml
+++ b/ansible/roles/girder/tasks/main.yml
@@ -16,40 +16,15 @@
   apt: name={{ item }} state=present update_cache=yes
   sudo: yes
   with_items:
-    - libssl-dev
-    - python-pip
-    - python2.7-dev
     - build-essential
-    - python-software-properties
-    - libffi-dev
-    - nodejs
-    - cmake
-    - cmake-curses-gui
     - git
-    - postfix
-    - libfreetype6-dev
-    - zlib1g-dev
-    - libpng-dev
-    - libtiff5-dev
-    - libjpeg8-dev
-    - liblcms2-dev
-    - libwebp-dev
-    - tcl8.6-dev
-    - tk8.6-dev
-    - python-tk
-    - libvips-tools
-    - libglib2.0-dev
+    - python2.7-dev
+    - libffi-dev
     - libjpeg-dev
-    - libxml2-dev
-    - libpng12-dev
-    - autoconf
-    - automake
-    - libtool
-    - pkg-config
-    - libcairo2-dev
-    - libgdk-pixbuf2.0-dev
-    - libxml2-dev
-    - libsqlite3-dev
+    - zlib1g-dev
+    - python-pip
+    - nodejs
+    - postfix
     - apt-transport-https
     - ca-certificates
     - mongodb-org

--- a/ansible/roles/openslide/tasks/main.yml
+++ b/ansible/roles/openslide/tasks/main.yml
@@ -2,12 +2,36 @@
   apt: name={{ item }} state=present
   sudo: yes
   with_items:
+    - libssl-dev
+    - python-pip
+    - python2.7-dev
+    - python-software-properties
+
     - build-essential
     - cmake
+    - cmake-curses-gui
+    - libtiff5-dev
+    - libjpeg8-dev
+    - zlib1g-dev
+    - libfreetype6-dev
+    - liblcms2-dev
+    - libwebp-dev
+    - tcl8.6-dev
+    - tk8.6-dev
+    - python-tk
+    - libvips-tools
+    - libglib2.0-dev
+    - libjpeg-dev
+    - libxml2-dev
+    - libpng12-dev
     - autoconf
     - automake
     - libtool
-    - cmake-curses-gui
+    - pkg-config
+    - libcairo2-dev
+    - libgdk-pixbuf2.0-dev
+    - libxml2-dev
+    - libsqlite3-dev
 
 - name: Download openjpeg
   command: wget -O openjpeg-1.5.2.tar.gz https://github.com/uclouvain/openjpeg/archive/version.1.5.2.tar.gz

--- a/ansible/vagrant.yml
+++ b/ansible/vagrant.yml
@@ -3,11 +3,11 @@
   roles:
     - common
     - mongodb
+    - openslide
     - girder
     - mq
     - worker
     #- itk
-    - openslide
   vars:
     vagrant: true
     root_dir: /opt/histomicstk


### PR DESCRIPTION
If the python libtiff package is installed before we build our own openjpeg, libtiff, and openslide, then we can't read some images.  For example, https://data.kitware.com/#item/57a3519e8d777f126827a678 , won't work.