### PR TITLE
pre-install right version of requests to resolve conflict during ansible provisioning

### DIFF
--- a/ansible/roles/girder/tasks/main.yml
+++ b/ansible/roles/girder/tasks/main.yml
@@ -82,6 +82,10 @@
   pip: name=pip extra_args="-U"
   sudo: yes
 
+- name: Install requests
+  pip: name=requests version=2.10.0
+  sudo: yes
+  
 - name: Install ctk-cli using pip
   pip:
     name: "{{ root_dir }}/ctk-cli"

--- a/ansible/roles/girder/tasks/main.yml
+++ b/ansible/roles/girder/tasks/main.yml
@@ -82,7 +82,7 @@
   pip: name=pip extra_args="-U"
   sudo: yes
 
-- name: Install requests
+- name: Install requests (needed to resolve conflict with docker-py)
   pip: name=requests version=2.10.0
   sudo: yes
   


### PR DESCRIPTION
This issue resolves a version conflict error with the requests package that was occurring when i provision HistomicsTK via ansible using the commands `git clone DigitalSlideArchive/HistomicsTK && vagrant up`:

```
TASK [girder : Install our external girder plugins] ****************************
fatal: [default]: FAILED! =>
```
```json
{
  "changed": true,
  "cmd": [
    "girder-install",
    "plugin",
    "-s",
    "\/opt\/histomicstk\/slicer_cli_web",
    "\/opt\/histomicstk\/large_image",
    "\/opt\/histomicstk\/HistomicsTK",
    "\/opt\/histomicstk\/digital_slide_archive"
  ],
  "delta": "0:00:26.286552",
  "end": "2016-09-06 20:31:44.171682",
  "failed": true,
  "rc": 1,
  "start": "2016-09-06 20:31:17.885130",
  "stderr": "\/usr\/local\/lib\/python2.7\/dist-packages\/pip\/_vendor\/requests\/packages\/urllib3\/util\/ssl_.py:318: SNIMissingWarning: An HTTPS request has been made, but the SNI (Subject Name Indication) extension to TLS is not available on this platform. This may cause the server to present an incorrect TLS certificate, which can cause validation failures. You can upgrade to a newer version of Python to solve this. For more information, see https:\/\/urllib3.readthedocs.org\/en\/latest\/security.html#snimissingwarning.\n  SNIMissingWarning\n\/usr\/local\/lib\/python2.7\/dist-packages\/pip\/_vendor\/requests\/packages\/urllib3\/util\/ssl_.py:122: InsecurePlatformWarning: A true SSLContext object is not available. This prevents urllib3 from configuring SSL appropriately and may cause certain SSL connections to fail. You can upgrade to a newer version of Python to solve this. For more information, see https:\/\/urllib3.readthedocs.org\/en\/latest\/security.html#insecureplatformwarning.\n  InsecurePlatformWarning\n    DEPRECATION: Uninstalling a distutils installed project (requests) has been deprecated and will be removed in a future version. This is due to the fact that uninstalling a distutils project will only partially uninstall the project.\n\/usr\/local\/lib\/python2.7\/dist-packages\/pip\/_vendor\/requests\/packages\/urllib3\/util\/ssl_.py:122: InsecurePlatformWarning: A true SSLContext object is not available. This prevents urllib3 from configuring SSL appropriately and may cause certain SSL connections to fail. You can upgrade to a newer version of Python to solve this. For more information, see https:\/\/urllib3.readthedocs.org\/en\/latest\/security.html#insecureplatformwarning.\n  InsecurePlatformWarning\n\/usr\/local\/lib\/python2.7\/dist-packages\/pip\/_vendor\/requests\/packages\/urllib3\/util\/ssl_.py:122: InsecurePlatformWarning: A true SSLContext object is not available. This prevents urllib3 from configuring SSL appropriately and may cause certain SSL connections to fail. You can upgrade to a newer version of Python to solve this. For more information, see https:\/\/urllib3.readthedocs.org\/en\/latest\/security.html#insecureplatformwarning.\n  InsecurePlatformWarning\nException:\nTraceback (most recent call last):\n  File \"\/usr\/local\/lib\/python2.7\/dist-packages\/pip\/basecommand.py\", line 215, in main\n    status = self.run(options, args)\n  File \"\/usr\/local\/lib\/python2.7\/dist-packages\/pip\/commands\/install.py\", line 310, in run\n    wb.build(autobuilding=True)\n  File \"\/usr\/local\/lib\/python2.7\/dist-packages\/pip\/wheel.py\", line 750, in build\n    self.requirement_set.prepare_files(self.finder)\n  File \"\/usr\/local\/lib\/python2.7\/dist-packages\/pip\/req\/req_set.py\", line 370, in prepare_files\n    ignore_dependencies=self.ignore_dependencies))\n  File \"\/usr\/local\/lib\/python2.7\/dist-packages\/pip\/req\/req_set.py\", line 458, in _prepare_file\n    req_to_install, finder)\n  File \"\/usr\/local\/lib\/python2.7\/dist-packages\/pip\/req\/req_set.py\", line 397, in _check_skip_installed\n    req_to_install.check_if_exists()\n  File \"\/usr\/local\/lib\/python2.7\/dist-packages\/pip\/req\/req_install.py\", line 1004, in check_if_exists\n    self.req.name\n  File \"\/usr\/local\/lib\/python2.7\/dist-packages\/pip\/_vendor\/pkg_resources\/__init__.py\", line 535, in get_distribution\n    dist = get_provider(dist)\n  File \"\/usr\/local\/lib\/python2.7\/dist-packages\/pip\/_vendor\/pkg_resources\/__init__.py\", line 415, in get_provider\n    return working_set.find(moduleOrReq) or require(str(moduleOrReq))[0]\n  File \"\/usr\/local\/lib\/python2.7\/dist-packages\/pip\/_vendor\/pkg_resources\/__init__.py\", line 943, in require\n    needed = self.resolve(parse_requirements(requirements))\n  File \"\/usr\/local\/lib\/python2.7\/dist-packages\/pip\/_vendor\/pkg_resources\/__init__.py\", line 834, in resolve\n    raise VersionConflict(dist, req).with_context(dependent_req)\nContextualVersionConflict: (requests 2.2.1 (\/usr\/lib\/python2.7\/dist-packages), Requirement.parse('requests>=2.5.2'), set(['docker-py']))\nTraceback (most recent call last):\n  File \"\/usr\/local\/bin\/girder-install\", line 9, in <module>\n    load_entry_point('girder==1.5.2', 'console_scripts', 'girder-install')()\n  File \"\/opt\/histomicstk\/girder\/girder\/utility\/install.py\", line 230, in main\n    parsed.func(parsed)\n  File \"\/opt\/histomicstk\/girder\/girder\/utility\/install.py\", line 133, in install_plugin\n    raise Exception('Failed to install pip requirements at %s.' % reqs)\nException: Failed to install pip requirements at \/opt\/histomicstk\/HistomicsTK\/requirements.txt.",
  "stdout": "\u001b[35mInstalling slicer_cli_web...\u001b[0m\n\u001b[35mInstalling pip requirements for slicer_cli_web from \/opt\/histomicstk\/slicer_cli_web\/requirements.txt.\u001b[0m\nCollecting docker-py==1.9.0 (from -r \/opt\/histomicstk\/slicer_cli_web\/requirements.txt (line 1))\n  Downloading docker_py-1.9.0-py2.py3-none-any.whl (42kB)\nRequirement already satisfied (use --upgrade to upgrade): six==1.10.0 in \/usr\/local\/lib\/python2.7\/dist-packages (from -r \/opt\/histomicstk\/slicer_cli_web\/requirements.txt (line 2))\nCollecting jsonschema==2.5.1 (from -r \/opt\/histomicstk\/slicer_cli_web\/requirements.txt (line 3))\n  Downloading jsonschema-2.5.1-py2.py3-none-any.whl\nCollecting ipaddress>=1.0.16; python_version < \"3.3\" (from docker-py==1.9.0->-r \/opt\/histomicstk\/slicer_cli_web\/requirements.txt (line 1))\n  Downloading ipaddress-1.0.16-py27-none-any.whl\nCollecting requests>=2.5.2 (from docker-py==1.9.0->-r \/opt\/histomicstk\/slicer_cli_web\/requirements.txt (line 1))\n  Downloading requests-2.11.1-py2.py3-none-any.whl (514kB)\nCollecting backports.ssl-match-hostname>=3.5; python_version < \"3.5\" (from docker-py==1.9.0->-r \/opt\/histomicstk\/slicer_cli_web\/requirements.txt (line 1))\n  Downloading backports.ssl_match_hostname-3.5.0.1.tar.gz\nCollecting websocket-client>=0.32.0 (from docker-py==1.9.0->-r \/opt\/histomicstk\/slicer_cli_web\/requirements.txt (line 1))\n  Downloading websocket_client-0.37.0.tar.gz (194kB)\nCollecting functools32; python_version == \"2.7\" (from jsonschema==2.5.1->-r \/opt\/histomicstk\/slicer_cli_web\/requirements.txt (line 3))\n  Downloading functools32-3.2.3-2.zip\nBuilding wheels for collected packages: backports.ssl-match-hostname, websocket-client, functools32\n  Running setup.py bdist_wheel for backports.ssl-match-hostname: started\n  Running setup.py bdist_wheel for backports.ssl-match-hostname: finished with status 'done'\n  Stored in directory: \/root\/.cache\/pip\/wheels\/5d\/72\/36\/b2a31507b613967b728edc33378a5ff2ada0f62855b93c5ae1\n  Running setup.py bdist_wheel for websocket-client: started\n  Running setup.py bdist_wheel for websocket-client: finished with status 'done'\n  Stored in directory: \/root\/.cache\/pip\/wheels\/e4\/20\/12\/48d6732b88733a0a8f98ee1a5b2f59b64b27011d5c34c4f98c\n  Running setup.py bdist_wheel for functools32: started\n  Running setup.py bdist_wheel for functools32: finished with status 'done'\n  Stored in directory: \/root\/.cache\/pip\/wheels\/3c\/d0\/09\/cd78d0ff4d6cfecfbd730782a7815a4571cd2cd4d2ed6e69d9\nSuccessfully built backports.ssl-match-hostname websocket-client functools32\nInstalling collected packages: ipaddress, requests, backports.ssl-match-hostname, websocket-client, docker-py, functools32, jsonschema\n  Found existing installation: requests 2.2.1\n    Uninstalling requests-2.2.1:\n      Successfully uninstalled requests-2.2.1\nSuccessfully installed backports.ssl-match-hostname-3.5.0.1 docker-py-1.9.0 functools32-3.2.3-2 ipaddress-1.0.16 jsonschema-2.5.1 requests-2.11.1 websocket-client-0.37.0\n\u001b[35mInstalling large_image...\u001b[0m\n\u001b[35mInstalling pip requirements for large_image from \/opt\/histomicstk\/large_image\/requirements.txt.\u001b[0m\nCollecting cachetools==1.1.6 (from -r \/opt\/histomicstk\/large_image\/requirements.txt (line 1))\n  Downloading cachetools-1.1.6-py2.py3-none-any.whl\nCollecting enum34==1.1.6 (from -r \/opt\/histomicstk\/large_image\/requirements.txt (line 2))\n  Downloading enum34-1.1.6-py2-none-any.whl\nRequirement already satisfied (use --upgrade to upgrade): jsonschema==2.5.1 in \/usr\/local\/lib\/python2.7\/dist-packages (from -r \/opt\/histomicstk\/large_image\/requirements.txt (line 3))\nCollecting psutil==4.2.0 (from -r \/opt\/histomicstk\/large_image\/requirements.txt (line 4))\n  Downloading psutil-4.2.0.tar.gz (311kB)\nCollecting pylibmc==1.5.1 (from -r \/opt\/histomicstk\/large_image\/requirements.txt (line 5))\n  Downloading pylibmc-1.5.1.tar.gz (59kB)\nRequirement already satisfied (use --upgrade to upgrade): six==1.10.0 in \/usr\/local\/lib\/python2.7\/dist-packages (from -r \/opt\/histomicstk\/large_image\/requirements.txt (line 6))\nCollecting Pillow==3.2.0 (from -r \/opt\/histomicstk\/large_image\/requirements.txt (line 10))\n  Downloading Pillow-3.2.0.zip (10.5MB)\nRequirement already satisfied (use --upgrade to upgrade): numpy==1.10.2 in \/usr\/local\/lib\/python2.7\/dist-packages (from -r \/opt\/histomicstk\/large_image\/requirements.txt (line 13))\nCollecting libtiff==0.4.0 (from -r \/opt\/histomicstk\/large_image\/requirements.txt (line 15))\n  Downloading libtiff-0.4.0.tar.gz (119kB)\nCollecting openslide-python>=1.1.0 (from -r \/opt\/histomicstk\/large_image\/requirements.txt (line 17))\n  Downloading openslide-python-1.1.1.tar.gz (312kB)\nRequirement already satisfied (use --upgrade to upgrade): functools32; python_version == \"2.7\" in \/usr\/local\/lib\/python2.7\/dist-packages (from jsonschema==2.5.1->-r \/opt\/histomicstk\/large_image\/requirements.txt (line 3))\nBuilding wheels for collected packages: psutil, pylibmc, Pillow, libtiff, openslide-python\n  Running setup.py bdist_wheel for psutil: started\n  Running setup.py bdist_wheel for psutil: finished with status 'done'\n  Stored in directory: \/root\/.cache\/pip\/wheels\/45\/6b\/34\/070ff658d18f190a862d6b25b3011836a65c21bb3d4415b520\n  Running setup.py bdist_wheel for pylibmc: started\n  Running setup.py bdist_wheel for pylibmc: finished with status 'done'\n  Stored in directory: \/root\/.cache\/pip\/wheels\/82\/f3\/35\/53e4b60d1173968fade0902e7ad970440c38d866c20cb92459\n  Running setup.py bdist_wheel for Pillow: started\n  Running setup.py bdist_wheel for Pillow: finished with status 'done'\n  Stored in directory: \/root\/.cache\/pip\/wheels\/88\/2d\/ce\/3ff4ae4e2b8600d1bde1cbde5dfcc6d8770222c38348fe9139\n  Running setup.py bdist_wheel for libtiff: started\n  Running setup.py bdist_wheel for libtiff: finished with status 'done'\n  Stored in directory: \/root\/.cache\/pip\/wheels\/84\/ed\/d5\/8acf7965cbd3020a0a1fec373ebc989567fa9c9d5791a8adbf\n  Running setup.py bdist_wheel for openslide-python: started\n  Running setup.py bdist_wheel for openslide-python: finished with status 'done'\n  Stored in directory: \/root\/.cache\/pip\/wheels\/f5\/b6\/20\/3a29c49b0bf39ecf32e191387ee24510fb66c800b8c93e2143\nSuccessfully built psutil pylibmc Pillow libtiff openslide-python\nInstalling collected packages: cachetools, enum34, psutil, pylibmc, Pillow, libtiff, openslide-python\n  Found existing installation: psutil 4.3.1\n    Uninstalling psutil-4.3.1:\n      Successfully uninstalled psutil-4.3.1\nSuccessfully installed Pillow-3.2.0 cachetools-1.1.6 enum34-1.1.6 libtiff-0.4.0 openslide-python-1.1.1 psutil-4.2.0 pylibmc-1.5.1\n\u001b[35mInstalling HistomicsTK...\u001b[0m\n\u001b[35mInstalling pip requirements for HistomicsTK from \/opt\/histomicstk\/HistomicsTK\/requirements.txt.\u001b[0m\nCollecting lxml>=3.4.4 (from -r \/opt\/histomicstk\/HistomicsTK\/requirements.txt (line 6))\n  Downloading lxml-3.6.4-cp27-cp27mu-manylinux1_x86_64.whl (4.2MB)",
  "stdout_lines": [
    "\u001b[35mInstalling slicer_cli_web...\u001b[0m",
    "\u001b[35mInstalling pip requirements for slicer_cli_web from \/opt\/histomicstk\/slicer_cli_web\/requirements.txt.\u001b[0m",
    "Collecting docker-py==1.9.0 (from -r \/opt\/histomicstk\/slicer_cli_web\/requirements.txt (line 1))",
    "  Downloading docker_py-1.9.0-py2.py3-none-any.whl (42kB)",
    "Requirement already satisfied (use --upgrade to upgrade): six==1.10.0 in \/usr\/local\/lib\/python2.7\/dist-packages (from -r \/opt\/histomicstk\/slicer_cli_web\/requirements.txt (line 2))",
    "Collecting jsonschema==2.5.1 (from -r \/opt\/histomicstk\/slicer_cli_web\/requirements.txt (line 3))",
    "  Downloading jsonschema-2.5.1-py2.py3-none-any.whl",
    "Collecting ipaddress>=1.0.16; python_version < \"3.3\" (from docker-py==1.9.0->-r \/opt\/histomicstk\/slicer_cli_web\/requirements.txt (line 1))",
    "  Downloading ipaddress-1.0.16-py27-none-any.whl",
    "Collecting requests>=2.5.2 (from docker-py==1.9.0->-r \/opt\/histomicstk\/slicer_cli_web\/requirements.txt (line 1))",
    "  Downloading requests-2.11.1-py2.py3-none-any.whl (514kB)",
    "Collecting backports.ssl-match-hostname>=3.5; python_version < \"3.5\" (from docker-py==1.9.0->-r \/opt\/histomicstk\/slicer_cli_web\/requirements.txt (line 1))",
    "  Downloading backports.ssl_match_hostname-3.5.0.1.tar.gz",
    "Collecting websocket-client>=0.32.0 (from docker-py==1.9.0->-r \/opt\/histomicstk\/slicer_cli_web\/requirements.txt (line 1))",
    "  Downloading websocket_client-0.37.0.tar.gz (194kB)",
    "Collecting functools32; python_version == \"2.7\" (from jsonschema==2.5.1->-r \/opt\/histomicstk\/slicer_cli_web\/requirements.txt (line 3))",
    "  Downloading functools32-3.2.3-2.zip",
    "Building wheels for collected packages: backports.ssl-match-hostname, websocket-client, functools32",
    "  Running setup.py bdist_wheel for backports.ssl-match-hostname: started",
    "  Running setup.py bdist_wheel for backports.ssl-match-hostname: finished with status 'done'",
    "  Stored in directory: \/root\/.cache\/pip\/wheels\/5d\/72\/36\/b2a31507b613967b728edc33378a5ff2ada0f62855b93c5ae1",
    "  Running setup.py bdist_wheel for websocket-client: started",
    "  Running setup.py bdist_wheel for websocket-client: finished with status 'done'",
    "  Stored in directory: \/root\/.cache\/pip\/wheels\/e4\/20\/12\/48d6732b88733a0a8f98ee1a5b2f59b64b27011d5c34c4f98c",
    "  Running setup.py bdist_wheel for functools32: started",
    "  Running setup.py bdist_wheel for functools32: finished with status 'done'",
    "  Stored in directory: \/root\/.cache\/pip\/wheels\/3c\/d0\/09\/cd78d0ff4d6cfecfbd730782a7815a4571cd2cd4d2ed6e69d9",
    "Successfully built backports.ssl-match-hostname websocket-client functools32",
    "Installing collected packages: ipaddress, requests, backports.ssl-match-hostname, websocket-client, docker-py, functools32, jsonschema",
    "  Found existing installation: requests 2.2.1",
    "    Uninstalling requests-2.2.1:",
    "      Successfully uninstalled requests-2.2.1",
    "Successfully installed backports.ssl-match-hostname-3.5.0.1 docker-py-1.9.0 functools32-3.2.3-2 ipaddress-1.0.16 jsonschema-2.5.1 requests-2.11.1 websocket-client-0.37.0",
    "\u001b[35mInstalling large_image...\u001b[0m",
    "\u001b[35mInstalling pip requirements for large_image from \/opt\/histomicstk\/large_image\/requirements.txt.\u001b[0m",
    "Collecting cachetools==1.1.6 (from -r \/opt\/histomicstk\/large_image\/requirements.txt (line 1))",
    "  Downloading cachetools-1.1.6-py2.py3-none-any.whl",
    "Collecting enum34==1.1.6 (from -r \/opt\/histomicstk\/large_image\/requirements.txt (line 2))",
    "  Downloading enum34-1.1.6-py2-none-any.whl",
    "Requirement already satisfied (use --upgrade to upgrade): jsonschema==2.5.1 in \/usr\/local\/lib\/python2.7\/dist-packages (from -r \/opt\/histomicstk\/large_image\/requirements.txt (line 3))",
    "Collecting psutil==4.2.0 (from -r \/opt\/histomicstk\/large_image\/requirements.txt (line 4))",
    "  Downloading psutil-4.2.0.tar.gz (311kB)",
    "Collecting pylibmc==1.5.1 (from -r \/opt\/histomicstk\/large_image\/requirements.txt (line 5))",
    "  Downloading pylibmc-1.5.1.tar.gz (59kB)",
    "Requirement already satisfied (use --upgrade to upgrade): six==1.10.0 in \/usr\/local\/lib\/python2.7\/dist-packages (from -r \/opt\/histomicstk\/large_image\/requirements.txt (line 6))",
    "Collecting Pillow==3.2.0 (from -r \/opt\/histomicstk\/large_image\/requirements.txt (line 10))",
    "  Downloading Pillow-3.2.0.zip (10.5MB)",
    "Requirement already satisfied (use --upgrade to upgrade): numpy==1.10.2 in \/usr\/local\/lib\/python2.7\/dist-packages (from -r \/opt\/histomicstk\/large_image\/requirements.txt (line 13))",
    "Collecting libtiff==0.4.0 (from -r \/opt\/histomicstk\/large_image\/requirements.txt (line 15))",
    "  Downloading libtiff-0.4.0.tar.gz (119kB)",
    "Collecting openslide-python>=1.1.0 (from -r \/opt\/histomicstk\/large_image\/requirements.txt (line 17))",
    "  Downloading openslide-python-1.1.1.tar.gz (312kB)",
    "Requirement already satisfied (use --upgrade to upgrade): functools32; python_version == \"2.7\" in \/usr\/local\/lib\/python2.7\/dist-packages (from jsonschema==2.5.1->-r \/opt\/histomicstk\/large_image\/requirements.txt (line 3))",
    "Building wheels for collected packages: psutil, pylibmc, Pillow, libtiff, openslide-python",
    "  Running setup.py bdist_wheel for psutil: started",
    "  Running setup.py bdist_wheel for psutil: finished with status 'done'",
    "  Stored in directory: \/root\/.cache\/pip\/wheels\/45\/6b\/34\/070ff658d18f190a862d6b25b3011836a65c21bb3d4415b520",
    "  Running setup.py bdist_wheel for pylibmc: started",
    "  Running setup.py bdist_wheel for pylibmc: finished with status 'done'",
    "  Stored in directory: \/root\/.cache\/pip\/wheels\/82\/f3\/35\/53e4b60d1173968fade0902e7ad970440c38d866c20cb92459",
    "  Running setup.py bdist_wheel for Pillow: started",
    "  Running setup.py bdist_wheel for Pillow: finished with status 'done'",
    "  Stored in directory: \/root\/.cache\/pip\/wheels\/88\/2d\/ce\/3ff4ae4e2b8600d1bde1cbde5dfcc6d8770222c38348fe9139",
    "  Running setup.py bdist_wheel for libtiff: started",
    "  Running setup.py bdist_wheel for libtiff: finished with status 'done'",
    "  Stored in directory: \/root\/.cache\/pip\/wheels\/84\/ed\/d5\/8acf7965cbd3020a0a1fec373ebc989567fa9c9d5791a8adbf",
    "  Running setup.py bdist_wheel for openslide-python: started",
    "  Running setup.py bdist_wheel for openslide-python: finished with status 'done'",
    "  Stored in directory: \/root\/.cache\/pip\/wheels\/f5\/b6\/20\/3a29c49b0bf39ecf32e191387ee24510fb66c800b8c93e2143",
    "Successfully built psutil pylibmc Pillow libtiff openslide-python",
    "Installing collected packages: cachetools, enum34, psutil, pylibmc, Pillow, libtiff, openslide-python",
    "  Found existing installation: psutil 4.3.1",
    "    Uninstalling psutil-4.3.1:",
    "      Successfully uninstalled psutil-4.3.1",
    "Successfully installed Pillow-3.2.0 cachetools-1.1.6 enum34-1.1.6 libtiff-0.4.0 openslide-python-1.1.1 psutil-4.2.0 pylibmc-1.5.1",
    "\u001b[35mInstalling HistomicsTK...\u001b[0m",
    "\u001b[35mInstalling pip requirements for HistomicsTK from \/opt\/histomicstk\/HistomicsTK\/requirements.txt.\u001b[0m",
    "Collecting lxml>=3.4.4 (from -r \/opt\/histomicstk\/HistomicsTK\/requirements.txt (line 6))",
    "  Downloading lxml-3.6.4-cp27-cp27mu-manylinux1_x86_64.whl (4.2MB)"
  ],
  "warnings": [
    
  ]
}
```

Specifically, below is the stderr part from the JSON error log i posted above to see the error:

> stderr: /usr/local/lib/python2.7/dist-packages/pip/_vendor/requests/packages/urllib3/util/ssl_.py:318: SNIMissingWarning: An HTTPS request has been made, but the SNI (Subject Name Indication) extension to TLS is not available on this platform. This may cause the server to present an incorrect TLS certificate, which can cause validation failures. You can upgrade to a newer version of Python to solve this. For more information, see https://urllib3.readthedocs.org/en/latest/security.html#snimissingwarning.
>   SNIMissingWarning
> /usr/local/lib/python2.7/dist-packages/pip/_vendor/requests/packages/urllib3/util/ssl_.py:122: InsecurePlatformWarning: A true SSLContext object is not available. This prevents urllib3 from configuring SSL appropriately and may cause certain SSL connections to fail. You can upgrade to a newer version of Python to solve this. For more information, see https://urllib3.readthedocs.org/en/latest/security.html#insecureplatformwarning.
>   InsecurePlatformWarning
>     DEPRECATION: Uninstalling a distutils installed project (requests) has been deprecated and will be removed in a future version. This is due to the fact that uninstalling a distutils project will only partially uninstall the project.
> /usr/local/lib/python2.7/dist-packages/pip/_vendor/requests/packages/urllib3/util/ssl_.py:122: InsecurePlatformWarning: A true SSLContext object is not available. This prevents urllib3 from configuring SSL appropriately and may cause certain SSL connections to fail. You can upgrade to a newer version of Python to solve this. For more information, see https://urllib3.readthedocs.org/en/latest/security.html#insecureplatformwarning.
>   InsecurePlatformWarning
> /usr/local/lib/python2.7/dist-packages/pip/_vendor/requests/packages/urllib3/util/ssl_.py:122: InsecurePlatformWarning: A true SSLContext object is not available. This prevents urllib3 from configuring SSL appropriately and may cause certain SSL connections to fail. You can upgrade to a newer version of Python to solve this. For more information, see https://urllib3.readthedocs.org/en/latest/security.html#insecureplatformwarning.
>   InsecurePlatformWarning
> Exception:
> Traceback (most recent call last):
>   File "/usr/local/lib/python2.7/dist-packages/pip/basecommand.py", line 215, in main
>     status = self.run(options, args)
>   File "/usr/local/lib/python2.7/dist-packages/pip/commands/install.py", line 310, in run
>     wb.build(autobuilding=True)
>   File "/usr/local/lib/python2.7/dist-packages/pip/wheel.py", line 750, in build
>     self.requirement_set.prepare_files(self.finder)
>   File "/usr/local/lib/python2.7/dist-packages/pip/req/req_set.py", line 370, in prepare_files
>     ignore_dependencies=self.ignore_dependencies))
>   File "/usr/local/lib/python2.7/dist-packages/pip/req/req_set.py", line 458, in _prepare_file
>     req_to_install, finder)
>   File "/usr/local/lib/python2.7/dist-packages/pip/req/req_set.py", line 397, in _check_skip_installed
>     req_to_install.check_if_exists()
>   File "/usr/local/lib/python2.7/dist-packages/pip/req/req_install.py", line 1004, in check_if_exists
>     self.req.name
>   File "/usr/local/lib/python2.7/dist-packages/pip/_vendor/pkg_resources/__init__.py", line 535, in get_distribution
>     dist = get_provider(dist)
>   File "/usr/local/lib/python2.7/dist-packages/pip/_vendor/pkg_resources/__init__.py", line 415, in get_provider
>     return working_set.find(moduleOrReq) or require(str(moduleOrReq))[0]
>   File "/usr/local/lib/python2.7/dist-packages/pip/_vendor/pkg_resources/__init__.py", line 943, in require
>     needed = self.resolve(parse_requirements(requirements))
>   File "/usr/local/lib/python2.7/dist-packages/pip/_vendor/pkg_resources/__init__.py", line 834, in resolve
>     raise VersionConflict(dist, req).with_context(dependent_req)
> ContextualVersionConflict: (requests 2.2.1 (/usr/lib/python2.7/dist-packages), Requirement.parse('requests>=2.5.2'), set(['docker-py']))
> Traceback (most recent call last):
>   File "/usr/local/bin/girder-install", line 9, in <module>
>     load_entry_point('girder==1.5.2', 'console_scripts', 'girder-install')()
>   File "/opt/histomicstk/girder/girder/utility/install.py", line 230, in main
>     parsed.func(parsed)
>   File "/opt/histomicstk/girder/girder/utility/install.py", line 133, in install_plugin
>     raise Exception('Failed to install pip requirements at %s.' % reqs)
> Exception: Failed to install pip requirements at /opt/histomicstk/HistomicsTK/requirements.txt.