### PR TITLE
Fix node ppa key by using it directly.

### DIFF
--- a/ansible/roles/girder/tasks/main.yml
+++ b/ansible/roles/girder/tasks/main.yml
@@ -2,15 +2,23 @@
   apt: pkg=python-pycurl state=present
   sudo: yes
 
-- name: Download nodejs install script
-  get_url:
-    url: https://deb.nodesource.com/setup_4.x
-    dest: "{{ root_dir }}/node_setup.sh"
-    mode: 0755
 
-- name: Run nodejs PPA install script
-  command: "{{ root_dir }}/node_setup.sh"
-  sudo: yes
+- name: NodeJS | Add PPA key
+  command: "apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 68576280"
+  become: yes
+  become_user: root
+
+- name: NodeJS | Add PPA
+  apt_repository:
+    repo: "deb https://deb.nodesource.com/node_4.x {{ ansible_distribution_release }} main"
+  become: yes
+  become_user: root
+
+- name: NodeJS | Install package
+  apt:
+    name: nodejs
+  become: yes
+  become_user: root
 
 - name: Install system package dependencies
   apt: name={{ item }} state=present update_cache=yes


### PR DESCRIPTION
I tried pip installing urllib3[secure], but that still had issues. This is the same approach taken by girder/girder@05fceeb.  It works in my local test.

Feedback or a different approach welcome.