### PR TITLE
Change the order of the ansible roles.

### DIFF
--- a/ansible/vagrant.yml
+++ b/ansible/vagrant.yml
@@ -4,9 +4,9 @@
     - common
     - mongodb
     - openslide
-    - girder
     - mq
     - worker
+    - girder
     - dev
     #- itk
   vars:


### PR DESCRIPTION
Install girder worker before girder, since girder worker installs docker and we need that for the slicer_cli_web plugin.

This should fix issue #192.