### PR TITLE
Make sure we are on girder client 1.3.1.

### DIFF
--- a/ansible/roles/girder/tasks/main.yml
+++ b/ansible/roles/girder/tasks/main.yml
@@ -117,7 +117,7 @@
   sudo: yes
 
 - name: Install girder-client pip package
-  pip: name=girder-client version=1.1.1
+  pip: name=girder-client version=1.3.1
   sudo: yes
 
 - name: Install HistomicsTK pypi C requirements


### PR DESCRIPTION
Girder work installs a version of girder client.  This script then installs a different version, which prevents some functions from working.