### PR TITLE
Once we have built and installed openslide, purge the pip cache.

### DIFF
--- a/ansible/roles/openslide/tasks/main.yml
+++ b/ansible/roles/openslide/tasks/main.yml
@@ -122,3 +122,13 @@
 - name: Run ldconfig
   command: ldconfig
   sudo: yes
+
+- name: Purge pip cache
+  command: bash -c "if PIP_CACHE=`python -c 'import pip.locations, sys;sys.stdout.write(pip.locations.USER_CACHE_DIR)'`; then rm -r $PIP_CACHE; fi"
+  sudo: yes
+  ignore_errors: yes
+
+- name: Uninstall Pillow, if installed
+  command: pip uninstall Pillow
+  sudo: yes
+  ignore_errors: yes

--- a/ansible/roles/openslide/tasks/main.yml
+++ b/ansible/roles/openslide/tasks/main.yml
@@ -123,12 +123,25 @@
   command: ldconfig
   sudo: yes
 
-- name: Purge pip cache
-  command: bash -c "if PIP_CACHE=`python -c 'import pip.locations, sys;sys.stdout.write(pip.locations.USER_CACHE_DIR)'`; then rm -r $PIP_CACHE; fi"
+- name: Get the most recent version of pip
+  pip: name=pip extra_args="-U"
   sudo: yes
-  ignore_errors: yes
 
-- name: Uninstall Pillow, if installed
-  command: pip uninstall Pillow
+- name: Purge pip cache
+  command: |
+    python -c '
+    import pip.locations, shutil
+    shutil.rmtree(pip.locations.USER_CACHE_DIR, True)
+    '
   sudo: yes
-  ignore_errors: yes
+
+- name: Reinstall python modules that depend on OpenJPEG and libtiff if they are installed.
+  command: |
+    python -c '
+    import pip
+    packages = ["Pillow", "libtiff"]
+    for package in pip.commands.show.search_packages_info(packages):
+    ''  pip.main(["install", "--force-reinstall", "--ignore-installed", 
+    ''           "%s==%s" % (package["name"], package["version"])])
+    '
+  sudo: yes


### PR DESCRIPTION
Once we have built and installed openslide, purge the pip cache and explicitly uninstall Pillow if it is installed.

Ask pip for the location of the pip cache and remove that directory.  I feel this is brittle and heavy-handed.

If Pillow is installed, it will look for the old jpeg libraries rather than the ones we have just built.  If the cache is not cleared, pip will just reinstall Pillow from the cache and still look for the wrong libraries.

This addresses issue #206.

@zachmullen I've put this in at the end of the OpenSlide role, as that is when the pip cache tends to have something invalid in it.  I feel there should be a cleaner way to do this, and welcome suggestions or a completely different approach.