### PR TITLE
Pin to the final 1.x release of Girder

### DIFF
--- a/ansible/group_vars/all
+++ b/ansible/group_vars/all
@@ -1,6 +1,6 @@
 ---
 ctk_cli_version: master
-girder_version: master
+girder_version: "v1.7.0"
 slicer_cli_web_version: master
 histomicstk_version: master
 large_image_version: master


### PR DESCRIPTION
Girder master just moved to version 2.0, which contains breaking changes. Until we port our plugins to accommodate these changes, we'll stay with 1.x.