### PR TITLE
Specify compiler flag mmacosx-version-min to 10.9 to use libc++ 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -84,7 +84,8 @@ setup(name='histomicstk',
            sources=["histomicstk/segmentation/label/isbf.pyx",
                     "histomicstk/segmentation/label/isbfcpp.cpp"],
            include_dirs=[numpy.get_include()],
-           extra_compile_args=["-std=c++11"],
+           extra_compile_args=["-std=c++11",
+                               "-mmacosx-version-min=10.9"],
            language="c++",
            )
       )

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,7 @@ except ImportError:
 import os
 import json
 import numpy
+import sys
 from Cython.Build import cythonize
 from pkg_resources import parse_requirements, RequirementParseError
 
@@ -53,6 +54,13 @@ test_requirements = [
     # TODO: Should we list Girder here?
 ]
 
+# cython extensions
+ext_compiler_args = ["-std=c++11"]
+
+if sys.platform == "darwin":  # osx
+    ext_compiler_args.append("-mmacosx-version-min=10.9")
+
+
 setup(name='histomicstk',
       version=pkginfo['version'],
       description=pkginfo['description'],
@@ -84,9 +92,8 @@ setup(name='histomicstk',
            sources=["histomicstk/segmentation/label/isbf.pyx",
                     "histomicstk/segmentation/label/isbfcpp.cpp"],
            include_dirs=[numpy.get_include()],
-           extra_compile_args=["-std=c++11",
-                               "-mmacosx-version-min=10.9"],
+           extra_compile_args=ext_compiler_args,
            language="c++",
            )
       )
-      )
+)


### PR DESCRIPTION
Building cython code that uses c++11 features on osx seems to result in build errors. See issue #219.

According to [this](http://stackoverflow.com/questions/36960587/cython-build-cant-find-c11-stl-files-but-only-when-called-from-setup-py) stackoverflow, the default of mmacosx-version-min to be 10.5 which was making it use libstdc++ instead of libc++. Hence it doesnt seem to recognize c++11 features. 

This PR sets mmacosx-version-min to 10.9 to fix it.