### PR TITLE
Update OpenJPEG in travis

### DIFF
--- a/.install-openslide.sh
+++ b/.install-openslide.sh
@@ -1,14 +1,50 @@
-#!/bin/bash
+#!/bin/bash -e
 
-PREFIX="$CACHE/openslide-$OPENSLIDE_VERSION"
-if [[ ! -f "$PREFIX/bin/openslide-show-properties" || -n "$UPDATE_CACHE" ]] ; then
-  rm -fr "$PREFIX"
-  mkdir -p "$PREFIX/src"
-  curl -L "https://github.com/openslide/openslide/releases/download/v${OPENSLIDE_VERSION}/openslide-${OPENSLIDE_VERSION}.tar.gz" | gunzip -c | tar -x -C "$PREFIX/src" --strip-components 1
-  pushd "$PREFIX/src"
-  ./configure "--prefix=$PREFIX"
-  make install
+# Install OpenJPEG, LIBTIFF, and OpenSlide.  These are only intalled if the 
+# appropriate environment variable is set.  Here are some sample values
+#  OPENJPEG_VERSION  2.1                  2.1.2          1.5.2
+#  OPENJPEG_FILE     version.2.1.tar.gz   v2.1.2.tar.gz  version.1.5.2.tar.gz
+#  OPENJEPG_DIR      openjpeg-version.2.1 openjpeg-2.1.2 openjpeg-version.1.5.2
+#  LIBTIFF_VERSION   4.0.3                4.0.6
+#  OPENSLIDE_VERSION 3.4.1
+# This also expects the CACHE environment variable to point to a directory that
+# can be used for build files.
+
+if [[ -n "$CACHE" && -n "$OPENJPEG_VERSION" && -n "$OPENJPEG_FILE" && -n "$OPENJPEG_DIR" ]]; then
+  pushd "$CACHE"
+  wget -O "openjpeg-$OPENJPEG_VERSION.tar.gz" "https://github.com/uclouvain/openjpeg/archive/$OPENJPEG_FILE"
+  tar -zxf "openjpeg-$OPENJPEG_VERSION.tar.gz"
+  cd "$OPENJPEG_DIR"
+  cmake .
+  make -j 3
+  sudo make install
+  sudo ldconfig
   popd
 fi
-export PATH="$PREFIX/bin:$PATH"
-export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$PREFIX/lib"
+
+if [[ -n "$CACHE" && -n "$LIBTIFF_VERSION" ]]; then
+  # Build libtiff so it will use our openjpeg
+  pushd "$CACHE"
+  wget -O "tiff-$LIBTIFF_VERSION.tar.gz" "http://download.osgeo.org/libtiff/tiff-$LIBTIFF_VERSION.tar.gz"
+  tar -zxf "tiff-$LIBTIFF_VERSION.tar.gz"
+  cd "tiff-$LIBTIFF_VERSION"
+  ./configure
+  make -j 3
+  sudo make install
+  sudo ldconfig
+  popd
+fi
+
+if [[ -n "$CACHE" && -n "$OPENSLIDE_VERSION" ]]; then
+  # Build OpenSlide ourselves so that it will use our libtiff
+  pushd "$CACHE"
+  wget -O "openslide-$OPENSLIDE_VERSION.tar.gz" "https://github.com/openslide/openslide/archive/v${OPENSLIDE_VERSION}.tar.gz"
+  tar -zxf "openslide-$OPENSLIDE_VERSION.tar.gz"
+  cd "openslide-$OPENSLIDE_VERSION"
+  autoreconf -i
+  ./configure
+  make -j 3
+  sudo make install
+  sudo ldconfig
+  popd
+fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,45 +1,65 @@
 language: python
 python:
-    - "2.7"
+  - "2.7"
 
 cache:
-    directories:
-        - $HOME/.cache
+  directories:
+    - $HOME/.cache
 
 sudo: required
 
+dist: trusty
+
 services:
   - docker
+  - rabbitmq
 
 compiler:
-    - gcc
+  - gcc
 
 addons:
-    apt:
-        packages:
-            # Pillow dependencies (see
-            # https://pillow.readthedocs.org/en/latest/installation.html)
-            - libtiff4-dev
-            - libjpeg8-dev
-            - zlib1g-dev
-            - libfreetype6-dev
-            - liblcms2-dev
-            - libwebp-dev
-            # vips
-            - libvips-tools
-            # openslide
-            - libopenjpeg-dev
-            # pandoc for displaying jupyter notebook examples on ReadTheDocs
-            - pandoc
-            - pandoc-citeproc
+  apt:
+    packages:
+      # Pillow dependencies (see
+      # https://pillow.readthedocs.org/en/latest/installation.html)
+      - libtiff5-dev
+      - libjpeg8-dev
+      - zlib1g-dev
+      - libfreetype6-dev
+      - liblcms2-dev
+      - libwebp-dev
+      - tcl8.6-dev
+      - tk8.6-dev
+      - python-tk
+      # vips
+      - libvips-tools
+      # openjpeg
+      - libglib2.0-dev
+      - libjpeg-dev
+      - libxml2-dev
+      - libpng12-dev
+      # openslide
+      - autoconf
+      - automake
+      - libtool
+      - pkg-config
+      - libcairo2-dev
+      - libgdk-pixbuf2.0-dev
+      - libxml2-dev
+      - libsqlite3-dev
+      # girder worker
+      - rabbitmq-server
+      # pandoc for displaying jupyter notebook examples on ReadTheDocs
+      - pandoc
+      - pandoc-citeproc
 
 before_install:
-    - CACHE="$HOME/.cache" OPENSLIDE_VERSION="3.4.1" source .install-openslide.sh
+    - CACHE="$HOME/.cache" OPENJPEG_VERSION=2.1.2 OPENJPEG_FILE=v2.1.2.tar.gz OPENJPEG_DIR=openjpeg-2.1.2 LIBTIFF_VERSION=4.0.6 OPENSLIDE_VERSION=3.4.1 source .install-openslide.sh
 
     - GIRDER_VERSION="v1.7.0"
-    - GIRDER_WORKER_VERSION=f834d4d3701df7f6f3f64fcd7d3f22d15b3b1db2
-    - LARGE_IMAGE_VERSION=35889a8480418d4854d9d8f19025d872872fe96c
-    - SLICER_CLI_WEB_VERSION=c475cd332571dc4429658eca8060f94e417f7b22
+    - GIRDER_WORKER_VERSION=master
+    - LARGE_IMAGE_VERSION=master
+    - SLICER_CLI_WEB_VERSION=master
     - main_path=$PWD
     - build_path=$PWD/build
     - mkdir -p $build_path
@@ -93,6 +113,8 @@ install:
     - pip install -U -r requirements.txt -r requirements-dev.txt setuptools==19.4
     - pip install -U -r $large_image_path/requirements.txt 
     - pip install -U -r $slicer_cli_web_path/requirements.txt 
+    - pip install "git+https://github.com/pearu/pylibtiff@848785a6a9a4e2c6eb6f56ca9f7e8f6b32e523d5" --force-reinstall --ignore-installed --upgrade
+    - pip install Pillow --force-reinstall --ignore-installed --upgrade
     - npm install
 
 script:

--- a/plugin_tests/client/visualization.js
+++ b/plugin_tests/client/visualization.js
@@ -125,8 +125,8 @@ describe('visualization', function () {
             var bounds = view._map.bounds();
             expect(bounds.left).toBeCloseTo(0, 1);
             expect(bounds.right).toBeCloseTo(100000, 1);
-            expect(bounds.top).toBeCloseTo(-100000, 1);
-            expect(bounds.bottom).toBeCloseTo(0, 1);
+            expect(bounds.top).toBeCloseTo(0, 1);
+            expect(bounds.bottom).toBeCloseTo(100000, 1);
         });
         it('after pan', function () {
             view._map.pan({x: -10, y: 0});


### PR DESCRIPTION
Use the latest versions of OpenJPEG, libtiff, and Openslide in the travis build.