### PR TITLE
When we install, some of our requirements were lowering library versions

### DIFF
--- a/requirements_c_conda.txt
+++ b/requirements_c_conda.txt
@@ -18,5 +18,6 @@ scipy==0.16.0
 scikit-learn==0.17.1
 pandas==0.18.1
 
-# We want Pillow 3.2.0.  Make sure conda doesn't change it on us.
-Pillow==3.2.0
+# Don't have conda install Pillow; we need a version that is linked against
+# our own libraries, and conda may not do that.
+# Pillow==3.2.0

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,5 +1,5 @@
 bumpversion==0.5.3
-cryptography==1.0.1
+cryptography>=1.0.1
 matplotlib==1.5.1
 jupyter>=1.0.0
 nbsphinx>=0.2.8


### PR DESCRIPTION
This could cause problems if we expect to work with specific versions.  For instance, we can work with Pillow 3.4 or 4.0 (but not if installed via conda), so don't revert to an earlier version.