### PR TITLE
Unpin versions.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -108,7 +108,7 @@ install:
     - cd $girder_path
     - python setup.py develop
     - conda install --yes ctk-cli==1.4.1
-    - pip install -r requirements_c_conda.txt && \
+    - pip install -r $main_path/requirements_c_conda.txt 
     - pip install -r $main_path/requirements.txt -r $main_path/requirements_c.txt
     - cd $main_path 
     - python setup.py build_ext --inplace

--- a/.travis.yml
+++ b/.travis.yml
@@ -101,14 +101,14 @@ before_install:
     - wget -O $build_path/install_miniconda.sh https://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh
     - bash $build_path/install_miniconda.sh -b -p $build_path/miniconda
     - source $build_path/miniconda/bin/activate $build_path/miniconda
-    - conda update --yes --quiet --all 'python<=2.7.12'
+    - conda update --yes --quiet --all
     - conda config --add channels https://conda.binstar.org/cdeepakroy
 
 install:
     - cd $girder_path
     - python setup.py develop
-    # https://github.com/pypa/pip/issues/2751
-    - conda install --yes libgfortran==1.0 ctk-cli==1.4.1 --file $main_path/requirements_c_conda.txt
+    - conda install --yes ctk-cli==1.4.1
+    - pip install -r requirements_c_conda.txt && \
     - pip install -r $main_path/requirements.txt -r $main_path/requirements_c.txt
     - cd $main_path 
     - python setup.py build_ext --inplace
@@ -116,8 +116,8 @@ install:
     - pip install -U -r requirements.txt -r requirements-dev.txt
     - pip install -U -r $large_image_path/requirements.txt
     - pip install -U -r $slicer_cli_web_path/requirements.txt 
-    - pip install "git+https://github.com/pearu/pylibtiff@848785a6a9a4e2c6eb6f56ca9f7e8f6b32e523d5" --force-reinstall --ignore-installed --upgrade
-    - pip install Pillow --force-reinstall --ignore-installed --upgrade
+    - pip install --upgrade --no-cache-dir --force-reinstall --ignore-installed openslide-python Pillow
+    - pip install "git+https://github.com/pearu/pylibtiff@848785a6a9a4e2c6eb6f56ca9f7e8f6b32e523d5" --force-reinstall --ignore-installed --upgrade --no-cache-dir
     - npm-install-retry
     - cd $large_image_path
     - python setup.py install

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,34 +15,44 @@ WORKDIR $htk_path
 
 # Install HistomicsTK and its dependencies
 RUN conda config --add channels https://conda.binstar.org/cdeepakroy && \
-    conda install --yes -c conda-forge pylibmc && \
-    conda install --yes pip libgfortran==1.0 openslide-python ctk-cli==1.4.1 \
-    --file requirements_c_conda.txt && \
+    conda install --yes pip ctk-cli==1.4.1 && \
+    # Install requirements_c_conda.txt via pip; isntalling via conda causes
+    # version issues with our home-built libtif.
+    pip install -r requirements_c_conda.txt && \
     pip install -r requirements.txt -r requirements_c.txt && \
     # Install large_image
     pip install 'git+https://github.com/girder/large_image#egg=large_image' && \
+    # Ensure we have a locally built Pillow and openslide in conda's environment
+    pip install --upgrade --no-cache-dir --force-reinstall --ignore-installed \
+      openslide-python \
+      Pillow && \
+    # Ensure we have the latest libtif
+    pip install --force-reinstall --ignore-installed --upgrade 'git+https://github.com/pearu/pylibtiff@848785a6a9a4e2c6eb6f56ca9f7e8f6b32e523d5' && \
     # Install HistomicsTK
     python setup.py install && \
     # clean up
     conda clean -i -l -t -y && \
     rm -rf /root/.cache/pip/*
 
-# Ensure we have a locally built Pillow and libtiff in conda's environment
-RUN pip install --upgrade --no-cache-dir --force-reinstall --ignore-installed \
-    Pillow \
-    libtiff && \
-    rm -rf /root/.cache/pip/*
-
-# pregenerate font cache
-RUN python -c "from matplotlib import pylab"
-
-# pregenerate libtiff wrapper
-RUN python -c "import libtiff"
-
 # git clone install slicer_cli_web
 RUN cd /build && \
     git clone https://github.com/girder/slicer_cli_web.git
 
+# Show what was installed
+RUN conda list
+
+# pregenerate font cache
+RUN python -c "from matplotlib import pylab"
+
+# pregenerate libtiff wrapper.  This also tests libtiff for failures
+RUN python -c "import libtiff"
+
 # define entrypoint through which all CLIs can be run
 WORKDIR $htk_path/server
+
+# Test our entrypoint.  If we have incompatible versions of numpy and 
+# openslide, one of these will fail
+RUN python /build/slicer_cli_web/server/cli_list_entrypoint.py --list_cli
+RUN python /build/slicer_cli_web/server/cli_list_entrypoint.py ColorDeconvolution --help
+
 ENTRYPOINT ["/build/miniconda/bin/python", "/build/slicer_cli_web/server/cli_list_entrypoint.py"]

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -18,9 +18,12 @@ large_image to find out how to install it as a Python toolkit/package.
 
 HistomicsTK also leverages the functionality of a number of scientific python
 packages including numpy_, scipy_, scikit-image_, scikit-learn_,
-and pandas_. We recommend installing anaconda_ to ease the cross-platform
-installation of these packages all of which are listed in
+and pandas_.  If you have not built libtiff or openjpeg locally, we recommend
+installing anaconda_ to ease the cross-platform installation of these packages
+all of which are listed in
 `requirments_c_conda.txt <https://github.com/DigitalSlideArchive/HistomicsTK/blob/master/requirements_c_conda.txt>`__.
+If libtiff or openjpeg were built locally, use pip to install these packages,
+as otherwise the binaries may not match properly.
 
 Once large_image is installed as a python package, HistomicsTK can be
 installed as follows::
@@ -28,10 +31,17 @@ installed as follows::
     $ git clone https://github.com/DigitalSlideArchive/HistomicsTK.git
     $ cd HistomicsTK
     $ conda config --add channels https://conda.binstar.org/cdeepakroy
-    $ conda install --yes libgfortran==1.0 ctk-cli==1.3.1 --file requirements_c_conda.txt
+    $ conda install --yes ctk-cli==1.4.1
+    $ pip install --no-cache-dir -r requirements_c_conda.txt
     $ pip install --no-cache-dir -r requirements.txt -r requirements_c.txt
     $ python setup.py build_ext --inplace
     $ pip install .
+
+If you build libtiff or openjpeg locally, ensure that the appropriate pip files
+have also been installed locally so that they use the correct libraries::
+
+    $ pip install --upgrade --force-reinstall --ignore-installed --no-cache-dir openslide-python Pillow
+    $ pip install --upgrade --force-reinstall --ignore-installed 'git+https://github.com/pearu/pylibtiff@848785a6a9a4e2c6eb6f56ca9f7e8f6b32e523d5'
 
 We are working on releasing HistomicsTK on PyPI so it can easily be pip
 installed from there.

--- a/requirements_c_conda.txt
+++ b/requirements_c_conda.txt
@@ -5,18 +5,21 @@
 #
 #########################################################
 
-# large_image requires numpy==1.10.2
-numpy==1.10.2
+# using a later version than 1.10.2 from conda causes a python import of a
+# locally built version libtiff to segfault.  Using a pip install of a later 
+# version throws an error regarding loading libmkl_avx.so or libmkl_def.so
+# unless scipy and scikit-image are also installed from pip and not conda.
+numpy>=1.10.2
 
-# scikit-image / scipy / numpy have compatability bugs with some versions
-# Do not change these versions without extensive testing
-scikit-image==0.12.3
-scipy==0.16.0
+scikit-image>=0.12.3
+scipy>=0.16.0
 
-# If Conda is used, "libgfortran==1.0" must also be specified
+# If Conda is used, some versions of numpy require that "libgfortran==1.0" must
+# also be specified *before* the packages in this file
+# libgfortran==1.0
 
-scikit-learn==0.17.1
-pandas==0.18.1
+scikit-learn>=0.17.1
+pandas>=0.18.1
 
 # Don't have conda install Pillow; we need a version that is linked against
 # our own libraries, and conda may not do that.


### PR DESCRIPTION
Use pip for installation of numpy and scipy, as the conda build conflicts with our home-built openjpeg and libtif.  Add tests in the docker build process that will fail when the libraries don't work together.