### PR TITLE
Fix doc references

### DIFF
--- a/histomicstk/features/ComputeFSDFeatures.py
+++ b/histomicstk/features/ComputeFSDFeatures.py
@@ -34,7 +34,7 @@ def ComputeFSDFeatures(im_label, K=128, Fs=6, Delta=8, rprops=None):
 
     References
     ----------
-    .. D. Zhang et al. "A comparative study on shape retrieval using
+    .. [#] D. Zhang et al. "A comparative study on shape retrieval using
        Fourier descriptors with different shape signatures," In Proc.
        ICIMADE01, 2001.
 

--- a/histomicstk/features/ComputeGradientFeatures.py
+++ b/histomicstk/features/ComputeGradientFeatures.py
@@ -61,7 +61,7 @@ def ComputeGradientFeatures(im_label, im_intensity,
 
     References
     ----------
-    .. Daniel Zwillinger and Stephen Kokoska. "CRC standard probability
+    .. [#] Daniel Zwillinger and Stephen Kokoska. "CRC standard probability
        and statistics tables and formulae," Crc Press, 1999.
 
     """

--- a/histomicstk/features/ComputeHaralickFeatures.py
+++ b/histomicstk/features/ComputeHaralickFeatures.py
@@ -204,10 +204,10 @@ def ComputeHaralickFeatures(im_label, im_intensity, offsets=None,
 
     References
     ----------
-    .. Haralick, et al. "Textural features for image classification,"
+    .. [#] Haralick, et al. "Textural features for image classification,"
        IEEE Transactions on Systems, Man, and Cybernatics, vol. 6,
        pp: 610-621, 1973.
-    .. Luis Pedro Coelho. "Mahotas: Open source software for scriptable
+    .. [#] Luis Pedro Coelho. "Mahotas: Open source software for scriptable
        computer vision," Journal of Open Research Software, vol 1, 2013.
     """
 

--- a/histomicstk/features/ComputeIntensityFeatures.py
+++ b/histomicstk/features/ComputeIntensityFeatures.py
@@ -78,7 +78,7 @@ def ComputeIntensityFeatures(im_label, im_intensity,
 
     References
     ----------
-    .. Daniel Zwillinger and Stephen Kokoska. "CRC standard probability
+    .. [#] Daniel Zwillinger and Stephen Kokoska. "CRC standard probability
        and statistics tables and formulae," Crc Press, 1999.
 
     """

--- a/histomicstk/features/graycomatrixext.py
+++ b/histomicstk/features/graycomatrixext.py
@@ -94,11 +94,11 @@ def graycomatrixext(im_input, im_roi_mask=None,
 
     References
     ----------
-    .. Haralick, R.M., K. Shanmugan, and I. Dinstein, "Textural Features
+    .. [#] Haralick, R.M., K. Shanmugan, and I. Dinstein, "Textural Features
        for Image Classification", IEEE Transactions on Systems, Man, and
        Cybernetics, Vol. SMC-3, 1973, pp. 610-621.
 
-    .. Haralick, R.M., and L.G. Shapiro. Computer and Robot Vision:
+    .. [#] Haralick, R.M., and L.G. Shapiro. Computer and Robot Vision:
        Vol. 1, Addison-Wesley, 1992, p. 459.
 
     """

--- a/histomicstk/filters/shape/clog.py
+++ b/histomicstk/filters/shape/clog.py
@@ -33,7 +33,7 @@ def clog(im_input, mask, sigma_min=30 * 1.414, sigma_max=50 * 1.414):
 
     References
     ----------
-    .. [1] Y. Al-Kofahi et al "Improved Automatic Detection and Segmentation
+    .. [#] Y. Al-Kofahi et al "Improved Automatic Detection and Segmentation
            of Cell Nuclei in Histopathology Images" in IEEE Transactions on
            Biomedical Engineering,vol.57,no.4,pp.847-52, 2010.
     """

--- a/histomicstk/filters/shape/glog.py
+++ b/histomicstk/filters/shape/glog.py
@@ -38,7 +38,7 @@ def glog(im_input, alpha=1,
 
     References
     ----------
-    .. H. Kong, H.C. Akakin, S.E. Sarma, "A Generalized Laplacian of
+    .. [#] H. Kong, H.C. Akakin, S.E. Sarma, "A Generalized Laplacian of
        Gaussian Filter for Blob Detection and Its Applications," in IEEE
        Transactions on Cybernetics, vol.43,no.6,pp.1719-33, 2013.
 

--- a/histomicstk/filters/shape/vesselness.py
+++ b/histomicstk/filters/shape/vesselness.py
@@ -30,7 +30,7 @@ def vesselness(im_input, sigma):
 
     References
     ----------
-    .. Frangi, Alejandro F., et al. "Multiscale vessel enhancement
+    .. [#] Frangi, Alejandro F., et al. "Multiscale vessel enhancement
        filtering." Medical Image Computing and Computer-Assisted
        Interventation. MICCAI98. Springer Berlin Heidelberg,1998. 130-137.
 

--- a/histomicstk/preprocessing/color_conversion/lab_mean_std.py
+++ b/histomicstk/preprocessing/color_conversion/lab_mean_std.py
@@ -49,12 +49,12 @@ def lab_mean_std(im_input):
 
     References
     ----------
-    .. E. Reinhard, M. Adhikhmin, B. Gooch, P. Shirley, "Color transfer
+    .. [#] E. Reinhard, M. Adhikhmin, B. Gooch, P. Shirley, "Color transfer
        between images," in IEEE Computer Graphics and Applications, vol.21,
        no.5,pp.34-41, 2001.
-    .. D. Ruderman, T. Cronin, and C. Chiao, "Statistics of cone responses
-       to natural images: implications for visual coding," J. Opt. Soc. Am. A
-       vol.15, pp.2036-2045, 1998.
+    .. [#] D. Ruderman, T. Cronin, and C. Chiao, "Statistics of cone
+       responses to natural images: implications for visual coding,"
+       J. Opt. Soc. Am. A vol.15, pp.2036-2045, 1998.
 
     """
     im_lab = rgb_to_lab(im_input)

--- a/histomicstk/preprocessing/color_conversion/lab_to_rgb.py
+++ b/histomicstk/preprocessing/color_conversion/lab_to_rgb.py
@@ -28,9 +28,9 @@ def lab_to_rgb(im_lab):
 
     References
     ----------
-    .. D. Ruderman, T. Cronin, and C. Chiao, "Statistics of cone responses
-       to natural images: implications for visual coding," J. Opt. Soc. Am. A
-       15, 2036-2045 (1998).
+    .. [#] D. Ruderman, T. Cronin, and C. Chiao, "Statistics of cone
+       responses to natural images: implications for visual coding,"
+       J. Opt. Soc. Am. A 15, 2036-2045 (1998).
     """
 
     # get input image dimensions

--- a/histomicstk/preprocessing/color_conversion/rgb_to_lab.py
+++ b/histomicstk/preprocessing/color_conversion/rgb_to_lab.py
@@ -36,9 +36,9 @@ def rgb_to_lab(im_rgb):
 
     References
     ----------
-    .. D. Ruderman, T. Cronin, and C. Chiao, "Statistics of cone responses
-       to natural images: implications for visual coding," J. Opt. Soc. Am. A
-       vol.15, pp.2036-2045, 1998.
+    .. [#] D. Ruderman, T. Cronin, and C. Chiao, "Statistics of cone
+       responses to natural images: implications for visual coding,"
+       J. Opt. Soc. Am. A vol.15, pp.2036-2045, 1998.
     """
 
     # get input image dimensions

--- a/histomicstk/preprocessing/color_deconvolution/sparse_color_deconvolution.py
+++ b/histomicstk/preprocessing/color_deconvolution/sparse_color_deconvolution.py
@@ -49,7 +49,7 @@ def sparse_color_deconvolution(im_rgb, w_init, beta):
 
     References
     ----------
-    .. [1] J. Xu, L. Xiang, G. Wang, S. Ganesan, M. Feldman, N.N. Shih,
+    .. [#] J. Xu, L. Xiang, G. Wang, S. Ganesan, M. Feldman, N.N. Shih,
            H. Gilmore, A. Madabhushi, "Sparse Non-negative Matrix
            Factorization (SNMF) based color unmixing for breast
            histopathological image analysis," in IEEE Computer Graphics

--- a/histomicstk/preprocessing/color_normalization/reinhard.py
+++ b/histomicstk/preprocessing/color_normalization/reinhard.py
@@ -49,10 +49,10 @@ def reinhard(im_src, target_mu, target_sigma, src_mu=None, src_sigma=None):
 
     References
     ----------
-    .. [1] E. Reinhard, M. Adhikhmin, B. Gooch, P. Shirley, "Color transfer
+    .. [#] E. Reinhard, M. Adhikhmin, B. Gooch, P. Shirley, "Color transfer
        between images," in IEEE Computer Graphics and Applications, vol.21,
        no.5,pp.34-41, 2001.
-    .. [2] D. Ruderman, T. Cronin, and C. Chiao, "Statistics of cone responses
+    .. [#] D. Ruderman, T. Cronin, and C. Chiao, "Statistics of cone responses
        to natural images: implications for visual coding," J. Opt. Soc. Am. A
        vol.15, pp.2036-2045, 1998.
     """

--- a/histomicstk/segmentation/label/compact.py
+++ b/histomicstk/segmentation/label/compact.py
@@ -36,7 +36,7 @@ def compact(im_label, compaction=3):
 
     References
     ----------
-    .. [1] S. Weinert et al "Detection and Segmentation of Cell Nuclei in
+    .. [#] S. Weinert et al "Detection and Segmentation of Cell Nuclei in
            Virtual Microscopy Images: A Minimum-Model Approach" in Nature
            Scientific Reports,vol.2,no.503, doi:10.1038/srep00503, 2012.
     """

--- a/histomicstk/segmentation/label/trace_object_boundaries.py
+++ b/histomicstk/segmentation/label/trace_object_boundaries.py
@@ -45,7 +45,7 @@ def trace_object_boundaries(im_label,
 
     References
     ----------
-    .. J. Seo et al "Fast Contour-Tracing Algorithm Based on a Pixel-
+    .. [#] J. Seo et al "Fast Contour-Tracing Algorithm Based on a Pixel-
        Following Method for Image Sensors" in Sensors,vol.16,no.353,
        doi:10.3390/s16030353, 2016.
 

--- a/histomicstk/segmentation/level_set/chan_vese.py
+++ b/histomicstk/segmentation/level_set/chan_vese.py
@@ -48,7 +48,7 @@ def chan_vese(im_input, im_mask, sigma,
 
     References
     ----------
-    .. C. Li, C. Xu, C. Gui, M.D. fox, "Distance Regularized Level Set
+    .. [#] C. Li, C. Xu, C. Gui, M.D. Fox, "Distance Regularized Level Set
        Evolution and Its Application to Image Segmentation," in IEEE
        Transactions on Image Processing, vol.19,no.12,pp.3243-54, 2010.
 

--- a/histomicstk/segmentation/level_set/reg_edge.py
+++ b/histomicstk/segmentation/level_set/reg_edge.py
@@ -58,7 +58,7 @@ def reg_edge(im_input, im_phi, well='double', sigma=1.5, dt=1.0, mu=0.2,
 
     References
     ----------
-    .. C. Li, C. Xu, C. Gui, M.D. fox, "Distance Regularized Level Set
+    .. [#] C. Li, C. Xu, C. Gui, M.D. Fox, "Distance Regularized Level Set
        Evolution and Its Application to Image Segmentation," in IEEE
        Transactions on Image Processing, vol.19,no.12,pp.3243-54, 2010.
 

--- a/histomicstk/segmentation/nuclear/gaussian_voting.py
+++ b/histomicstk/segmentation/nuclear/gaussian_voting.py
@@ -53,7 +53,7 @@ def gaussian_voting(I, rmax=35, rmin=10, sSigma=5, Tau=5, bw=15, Psi=0.3):
 
     References
     ----------
-    .. X. Qi, F. Xing, D.J. Foran, L. Yang, "Robust Segmentation of
+    .. [#] X. Qi, F. Xing, D.J. Foran, L. Yang, "Robust Segmentation of
        Overlapping Cells in Histopathology Specimens Using Parallel
        Seed Detection and Repulsive Level Set," in IEEE Transactions
        on Biomedical Engineering, vol.59,no.23,pp.754-65, 2011.

--- a/histomicstk/segmentation/nuclear/gvf_tracking.py
+++ b/histomicstk/segmentation/nuclear/gvf_tracking.py
@@ -53,7 +53,7 @@ def gvf_tracking(I, Mask, K=1000, Diffusions=10, Mu=5, Lambda=5, Iterations=10,
 
     References
     ----------
-    .. G. Li et al "3D cell nuclei segmentation based on gradient flow
+    .. [#] G. Li et al "3D cell nuclei segmentation based on gradient flow
        tracking" in BMC Cell Biology,vol.40,no.8, 2007.
     """
 

--- a/histomicstk/segmentation/nuclear/max_clustering.py
+++ b/histomicstk/segmentation/nuclear/max_clustering.py
@@ -40,11 +40,11 @@ def max_clustering(im_response, im_fgnd_mask, r=10):
 
     References
     ----------
-    .. XW. Wu et al "The local maximum clustering method and its
+    .. [#] XW. Wu et al "The local maximum clustering method and its
        application in microarray gene expression data analysis,"
        EURASIP J. Appl. Signal Processing, volume 2004, no.1, pp.53-63,
        2004.
-    .. Y. Al-Kofahi et al "Improved Automatic Detection and Segmentation
+    .. [#] Y. Al-Kofahi et al "Improved Automatic Detection and Segmentation
        of Cell Nuclei in Histopathology Images" in IEEE Transactions on
        Biomedical Engineering,vol.57,no.4,pp.847-52, 2010.
     """

--- a/histomicstk/segmentation/nuclear/min_model.py
+++ b/histomicstk/segmentation/nuclear/min_model.py
@@ -140,7 +140,7 @@ def seed_contours(I, Delta=0.3):
 
     References
     ----------
-    .. [1] S. Weinert et al "Detection and Segmentation of Cell Nuclei in
+    .. [#] S. Weinert et al "Detection and Segmentation of Cell Nuclei in
     Virtual Microscopy Images: A Minimum-Model Approach" in Nature Scientific
     Reports,vol.2,no.503, doi:10.1038/srep00503, 2012.
     """
@@ -291,7 +291,7 @@ def trace_contours(I, X, Y, Min, Max, MaxLength=255):
 
     References
     ----------
-    .. [1] S. Weinert et al "Detection and Segmentation of Cell Nuclei in
+    .. [#] S. Weinert et al "Detection and Segmentation of Cell Nuclei in
     Virtual Microscopy Images: A Minimum-Model Approach" in Nature Scientific
     Reports,vol.2,no.503, doi:10.1038/srep00503, 2012.
     """
@@ -370,7 +370,7 @@ def score_contours(I, cXs, cYs):
 
     References
     ----------
-    .. [1] S. Weinert et al "Detection and Segmentation of Cell Nuclei in
+    .. [#] S. Weinert et al "Detection and Segmentation of Cell Nuclei in
     Virtual Microscopy Images: A Minimum-Model Approach" in Nature Scientific
     Reports,vol.2,no.503, doi:10.1038/srep00503, 2012.
     """
@@ -439,7 +439,7 @@ def label_contour(Shape, cXs, cYs, Scores):
 
     References
     ----------
-    .. [1] S. Weinert et al "Detection and Segmentation of Cell Nuclei in
+    .. [#] S. Weinert et al "Detection and Segmentation of Cell Nuclei in
     Virtual Microscopy Images: A Minimum-Model Approach" in Nature Scientific
     Reports,vol.2,no.503, doi:10.1038/srep00503, 2012.
     """
@@ -504,7 +504,7 @@ def split_concavities(Label, MinDepth=4, MinConcavity=np.inf):  # noqa: C901
 
     References
     ----------
-    .. [1] S. Weinert et al "Detection and Segmentation of Cell Nuclei in
+    .. [#] S. Weinert et al "Detection and Segmentation of Cell Nuclei in
     Virtual Microscopy Images: A Minimum-Model Approach" in Nature Scientific
     Reports,vol.2,no.503, doi:10.1038/srep00503, 2012.
     """
@@ -712,7 +712,7 @@ def angle_score(ax1, ay1, bx1, by1, ax2, ay2, bx2, by2, cx1, cy1, cx2, cy2):
 
     References
     ----------
-    .. [1] S. Weinert et al "Detection and Segmentation of Cell Nuclei in
+    .. [#] S. Weinert et al "Detection and Segmentation of Cell Nuclei in
     Virtual Microscopy Images: A Minimum-Model Approach" in Nature Scientific
     Reports,vol.2,no.503, doi:10.1038/srep00503, 2012.
     """
@@ -751,7 +751,7 @@ def length_score(x1, y1, x2, y2, d1, d2):
 
     References
     ----------
-    .. [1] S. Weinert et al "Detection and Segmentation of Cell Nuclei in
+    .. [#] S. Weinert et al "Detection and Segmentation of Cell Nuclei in
     Virtual Microscopy Images: A Minimum-Model Approach" in Nature Scientific
     Reports,vol.2,no.503, doi:10.1038/srep00503, 2012.
     """
@@ -780,7 +780,7 @@ def cut(Mask, x1, y1, x2, y2):
 
     References
     ----------
-    .. [1] S. Weinert et al "Detection and Segmentation of Cell Nuclei in
+    .. [#] S. Weinert et al "Detection and Segmentation of Cell Nuclei in
     Virtual Microscopy Images: A Minimum-Model Approach" in Nature Scientific
     Reports,vol.2,no.503, doi:10.1038/srep00503, 2012.
     """

--- a/histomicstk/segmentation/nuclear/min_model.py
+++ b/histomicstk/segmentation/nuclear/min_model.py
@@ -66,7 +66,7 @@ def min_model(I, Delta=0.3, MaxLength=255, Compaction=3,
 
     References
     ----------
-    .. S. Weinert et al "Detection and Segmentation of Cell Nuclei in
+    .. [#] S. Weinert et al "Detection and Segmentation of Cell Nuclei in
        Virtual Microscopy Images: A Minimum-Model Approach" in Nature
        Scientific Reports,vol.2,no.503, doi:10.1038/srep00503, 2012.
     """

--- a/histomicstk/utils/fit_poisson_mixture.py
+++ b/histomicstk/utils/fit_poisson_mixture.py
@@ -34,7 +34,7 @@ def fit_poisson_mixture(im_input, mu=None, tol=0.1):
 
     References
     ----------
-    .. Y. Al-Kofahi et al "Improved Automatic Detection and Segmentation
+    .. [#] Y. Al-Kofahi et al "Improved Automatic Detection and Segmentation
        of Cell Nuclei in Histopathology Images" in IEEE Transactions on
        Biomedical Engineering,vol.57,no.4,pp.847-52, 2010.
     """

--- a/histomicstk/utils/gradient_diffusion.py
+++ b/histomicstk/utils/gradient_diffusion.py
@@ -48,7 +48,7 @@ def gradient_diffusion(im_dx, im_dy, im_fgnd_mask,
 
     References
     ----------
-    .. [1] G. Li et al "3D cell nuclei segmentation based on gradient flow
+    .. [#] G. Li et al "3D cell nuclei segmentation based on gradient flow
            tracking" in BMC Cell Biology,vol.40,no.8, 2007.
     """
 


### PR DESCRIPTION
I noticed that many of the references are syntactically comments, which means they don't show up in the documentation. Also, because of how Sphinx scopes target names, numbering these references per-file creates warnings (cf. how the Travis CI build of #280 was failing when my changes introduced additional references named [1] and [2] in the same module). reST fortunately supports auto-numbering, which handles that.

This PR should fix these issues.