### PR TITLE
Ensure locales are installed.

### DIFF
--- a/ansible/Dockerfile-girder-worker
+++ b/ansible/Dockerfile-girder-worker
@@ -3,7 +3,7 @@ MAINTAINER David Manthey <david.manthey@kitware.com>
 
 RUN apt-get update
 RUN DEBIAN_FRONTEND=noninteractive apt-get --yes -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" dist-upgrade
-RUN apt-get install -y git python2.7-dev python-pip libssl-dev sudo net-tools vim
+RUN apt-get install -y git python2.7-dev python-pip libssl-dev sudo net-tools vim locales apt-utils
 # Install some additional packages for convenience when testing with bash
 RUN apt-get install -y iputils-ping telnet-ssl tmux
 RUN pip install -U pip

--- a/ansible/Dockerfile-histomicstk
+++ b/ansible/Dockerfile-histomicstk
@@ -4,7 +4,7 @@ MAINTAINER David Manthey <david.manthey@kitware.com>
 RUN apt-get update
 # For a dist upgrade
 RUN DEBIAN_FRONTEND=noninteractive apt-get --yes -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" dist-upgrade
-RUN apt-get install -y git python2.7-dev python-pip libssl-dev sudo net-tools vim
+RUN apt-get install -y git python2.7-dev python-pip libssl-dev sudo net-tools vim locales apt-utils
 # Install some additional packages for convenience when testing with bash
 RUN apt-get install -y iputils-ping telnet-ssl tmux
 RUN pip install -U pip


### PR DESCRIPTION
Using today's Ubuntu 16.04 docker base, you have to install the locales package explicitly.  We need this to ensure that filenames are handles in UTF-8, since Girder uses the internal file names when sending files to girder worker.

A few days ago, locales was installed as a side-effect of another package.