### PR TITLE
Use Dask in sample_pixels (and a fix)

### DIFF
--- a/histomicstk/utils/sample_pixels.py
+++ b/histomicstk/utils/sample_pixels.py
@@ -1,3 +1,4 @@
+import dask
 import large_image
 import numpy as np
 import scipy
@@ -41,6 +42,10 @@ def sample_pixels(slide_path, sample_percent=None, magnification=None,
     Pixels : array_like
         A Nx3 matrix of RGB pixel values sampled from the whole-slide.
 
+    Notes
+    -----
+    If Dask is configured, it is used to distribute the computation.
+
     See Also
     --------
     histomicstk.preprocessing.color_normalization.reinhard
@@ -75,15 +80,36 @@ def sample_pixels(slide_path, sample_percent=None, magnification=None,
     # generate sample pixels
     sample_pixels = []
 
-    scale_hres = {'magnification': magnification}
+    iter_args = dict(scale=dict(magnification=magnification),
+                     format=large_image.tilesource.TILE_FORMAT_NUMPY)
 
-    # Accumulator for probabilistic rounding
-    frac_accum = 0.
+    im_fgnd_mask_lres = dask.delayed(im_fgnd_mask_lres)
 
-    for tile in ts.tileIterator(
-            scale=scale_hres,
-            format=large_image.tilesource.TILE_FORMAT_NUMPY):
+    grouping = 256
+    total_tiles = ts.getSingleTile(**iter_args)['iterator_range']['position']
+    for position in range(0, total_tiles, grouping):
+        sample_pixels.append(dask.delayed(_sample_pixels_tile)(
+            slide_path, iter_args,
+            (position, min(grouping, total_tiles - position)), sample_percent,
+            tissue_seg_mag, min_coverage, im_fgnd_mask_lres))
 
+    # concatenate pixel values in list
+    if sample_pixels:
+        sample_pixels = (dask.delayed(np.concatenate)(sample_pixels, 0)
+                         .compute())
+    else:
+        print "Sampling could not identify any foreground regions."
+
+    return sample_pixels
+
+
+def _sample_pixels_tile(slide_path, iter_args, positions, sample_percent,
+                        tissue_seg_mag, min_coverage, im_fgnd_mask_lres):
+    start_position, position_count = positions
+    sample_pixels = [np.empty((0, 3))]
+    ts = large_image.getTileSource(slide_path)
+    for position in range(start_position, start_position + position_count):
+        tile = ts.getSingleTile(tile_position=position, **iter_args)
         # get current region in base_pixels
         rgn_hres = {'left': tile['gx'], 'top': tile['gy'],
                     'right': tile['gx'] + tile['gwidth'],
@@ -92,7 +118,8 @@ def sample_pixels(slide_path, sample_percent=None, magnification=None,
 
         # get foreground mask for current tile at low resolution
         rgn_lres = ts.convertRegionScale(rgn_hres,
-                                         targetScale=scale_lres,
+                                         targetScale={'magnification':
+                                                      tissue_seg_mag},
                                          targetUnits='mag_pixels')
 
         top = np.int(rgn_lres['top'])
@@ -122,29 +149,17 @@ def sample_pixels(slide_path, sample_percent=None, magnification=None,
         nz_ind = np.nonzero(tile_fgnd_mask.flatten())[0]
 
         # Handle fractions in the desired sample size by rounding up
-        # or down, weighted by the fractional amount.  To reduce
-        # variance, the fraction is adjusted by a running counter that
-        # factors in previous random decisions.
+        # or down, weighted by the fractional amount.
         float_samples = sample_percent * nz_ind.size
         num_samples = int(np.floor(float_samples))
-        frac_accum += float_samples - num_samples
-        r = np.random.binomial(1, np.clip(frac_accum, 0, 1))
-        num_samples += r
-        frac_accum -= r
+        num_samples += np.random.binomial(1, float_samples - num_samples)
 
         sample_ind = np.random.choice(nz_ind, num_samples)
 
         # convert rgb tile image to Nx3 array
-        tile_pix_rgb = np.reshape(im_tile,
-                                  (im_tile.shape[0] * im_tile.shape[1], 3))
+        tile_pix_rgb = np.reshape(im_tile, (-1, 3))
 
         # add rgb triplet of sample pixels
         sample_pixels.append(tile_pix_rgb[sample_ind, :])
 
-    # concatenate pixel values in list
-    try:
-        sample_pixels = np.concatenate(sample_pixels, 0)
-    except ValueError:
-        print "Sampling could not identify any foreground regions."
-
-    return sample_pixels
+    return np.concatenate(sample_pixels, 0)

--- a/server/BackgroundIntensity/BackgroundIntensity.py
+++ b/server/BackgroundIntensity/BackgroundIntensity.py
@@ -1,4 +1,5 @@
 from ctk_cli import CLIArgumentParser
+from dask.distributed import Client
 
 from histomicstk.preprocessing.color_normalization import background_intensity
 
@@ -6,8 +7,10 @@ from histomicstk.preprocessing.color_normalization import background_intensity
 def main(args):
     # Allow default parameters to work.  Assume None is only
     # meaningful as a default value
+    other_args = set(['returnParameterFile', 'scheduler_address'])
     kwargs = {k: v for k, v in vars(args).items()
-              if k != 'returnParameterFile' and v is not None}
+              if k not in other_args and v is not None}
+    Client(args.scheduler_address)
     I_0 = background_intensity(**kwargs)
     with open(args.returnParameterFile, 'w') as f:
         f.write('BackgroundIntensity = ' + ','.join(map(str, I_0)) + '\n')

--- a/server/BackgroundIntensity/BackgroundIntensity.xml
+++ b/server/BackgroundIntensity/BackgroundIntensity.xml
@@ -64,4 +64,14 @@
       <description>Output intensity in SDA space</description>
     </double-vector>
   </parameters>
+  <parameters advanced="true">
+    <label>Dask</label>
+    <description>Dask parameters</description>
+    <string>
+      <name>scheduler_address</name>
+      <label>Scheduler Address</label>
+      <description>Address of the dask scheduler in the format '127.0.0.1:8786'.  Not passing this parameter sets up a cluster on the local machine</description>
+      <longflag>scheduler_address</longflag>
+    </string>
+  </parameters>
 </executable>

--- a/server/BackgroundIntensity/BackgroundIntensity.xml
+++ b/server/BackgroundIntensity/BackgroundIntensity.xml
@@ -32,13 +32,13 @@
       <name>magnification</name>
       <label>Magnification</label>
       <longflag>magnification</longflag>
-      <description>Desired magnification for sampling.  Leave unspecified for native scan magnification.</description>
+      <description>Desired magnification for sampling.  Leave unspecified for 1.25x magnification.</description>
     </float>
     <float>
       <name>tissue_seg_mag</name>
       <label>Segmentation Magnification</label>
       <longflag>segmentationMag</longflag>
-      <description>Low resolution magnification at which foreground and background will be segmented.</description>
+      <description>Low resolution magnification at which foreground and background will be segmented.  Default 1.25x.</description>
     </float>
     <float>
       <name>min_coverage</name>

--- a/server/BackgroundIntensity/BackgroundIntensity.xml
+++ b/server/BackgroundIntensity/BackgroundIntensity.xml
@@ -73,5 +73,11 @@
       <description>Address of the dask scheduler in the format '127.0.0.1:8786'.  Not passing this parameter sets up a cluster on the local machine</description>
       <longflag>scheduler_address</longflag>
     </string>
+    <integer>
+      <name>tile_grouping</name>
+      <label>Tile grouping</label>
+      <longflag>tileGrouping</longflag>
+      <description>Number of tiles to process as part of a single task</description>
+    </integer>
   </parameters>
 </executable>

--- a/server/NucleiDetection/NucleiDetection.py
+++ b/server/NucleiDetection/NucleiDetection.py
@@ -198,7 +198,7 @@ def main(args):
     #
     print('\n>> Creating Dask client ...\n')
 
-    scheduler_address = json.loads(args.scheduler_address)
+    scheduler_address = args.scheduler_address
 
     if scheduler_address is None:
 

--- a/server/NucleiDetection/NucleiDetection.xml
+++ b/server/NucleiDetection/NucleiDetection.xml
@@ -159,9 +159,8 @@
     <string>
       <name>scheduler_address</name>
       <label>Scheduler Address</label>
-      <description>Address of the dask scheduler in the format '127.0.0.1:8786', Default value = 'null' sets up a cluster on the local machine</description>
+      <description>Address of the dask scheduler in the format '127.0.0.1:8786'.  Not passing this parameter sets up a cluster on the local machine</description>
       <longflag>scheduler_address</longflag>
-      <default>null</default>
     </string>
   </parameters>
 </executable>

--- a/server/SeparateStainsMacenkoPCA/SeparateStainsMacenkoPCA.py
+++ b/server/SeparateStainsMacenkoPCA/SeparateStainsMacenkoPCA.py
@@ -1,4 +1,5 @@
 from ctk_cli import CLIArgumentParser
+from dask.distributed import Client
 import numpy
 
 from histomicstk.utils import sample_pixels
@@ -9,6 +10,7 @@ def main(args):
     returnParameterFile, args = splitArgs(args)
     args['macenko']['I_0'] = numpy.array(args['macenko']['I_0'])
 
+    Client(args['dask'].get('scheduler_address'))
     sample = sample_pixels(**args['sample'])
     stain_matrix = rgb_separate_stains_macenko_pca(sample.T, **args['macenko'])
     with open(returnParameterFile, 'w') as f:

--- a/server/SeparateStainsMacenkoPCA/SeparateStainsMacenkoPCA.xml
+++ b/server/SeparateStainsMacenkoPCA/SeparateStainsMacenkoPCA.xml
@@ -117,5 +117,11 @@
       <description>Address of the dask scheduler in the format '127.0.0.1:8786'.  Not passing this parameter sets up a cluster on the local machine</description>
       <longflag>scheduler_address</longflag>
     </string>
+    <integer>
+      <name>sample_tile_grouping</name>
+      <label>Tile grouping</label>
+      <longflag>tileGrouping</longflag>
+      <description>Number of tiles to process as part of a single task</description>
+    </integer>
   </parameters>
 </executable>

--- a/server/SeparateStainsMacenkoPCA/SeparateStainsMacenkoPCA.xml
+++ b/server/SeparateStainsMacenkoPCA/SeparateStainsMacenkoPCA.xml
@@ -38,13 +38,13 @@
       <name>sample_magnification</name>
       <label>Magnification</label>
       <longflag>magnification</longflag>
-      <description>Desired magnification for sampling.  Leave unspecified for native scan magnification.</description>
+      <description>Desired magnification for sampling.  Leave unspecified for 1.25x magnification.</description>
     </float>
     <float>
       <name>sample_tissue_seg_mag</name>
       <label>Segmentation Magnification</label>
       <longflag>segmentationMag</longflag>
-      <description>Low resolution magnification at which foreground and background will be segmented.</description>
+      <description>Low resolution magnification at which foreground and background will be segmented.  Default 1.25x.</description>
     </float>
     <float>
       <name>sample_min_coverage</name>

--- a/server/SeparateStainsMacenkoPCA/SeparateStainsMacenkoPCA.xml
+++ b/server/SeparateStainsMacenkoPCA/SeparateStainsMacenkoPCA.xml
@@ -108,4 +108,14 @@
       <description>SDA color of stain 3</description>
     </double-vector>
   </parameters>
+  <parameters advanced="true">
+    <label>Dask</label>
+    <description>Dask parameters</description>
+    <string>
+      <name>dask_scheduler_address</name>
+      <label>Scheduler Address</label>
+      <description>Address of the dask scheduler in the format '127.0.0.1:8786'.  Not passing this parameter sets up a cluster on the local machine</description>
+      <longflag>scheduler_address</longflag>
+    </string>
+  </parameters>
 </executable>


### PR DESCRIPTION
The main effect of this PR is to increase the use of Dask to the `sample_pixels` function in `histomicstk.utils` and all the CLIs that directly or indirectly make use of it, namely:
- `BackgroundIntensity`
- `SeparateStainsMacenkoPCA`

These CLIs now, like `NucleiDetection`, take an optional `--scheduler_address` parameter for an existing Dask distributed cluster. If not passed, a `LocalCluster` is created and used automatically.

Other changes are:
- `NucleiDetection` uses the default `None` when no other default is specified rather than `"null"`, simplifying argument handling
- The documentation for the magnification parameters of `BackgroundIntensity` and `SeparateStainsMacenkoPCA` has been updated to reflect the changes made to the defaults of `background_intensity` late in the life of #280. (This is the titular fix)