### PR TITLE
CLI defaults

### DIFF
--- a/server/BackgroundIntensity/BackgroundIntensity.py
+++ b/server/BackgroundIntensity/BackgroundIntensity.py
@@ -5,12 +5,16 @@ from histomicstk.preprocessing.color_normalization import background_intensity
 
 
 def main(args):
-    # Allow default parameters to work.  Assume None is only
-    # meaningful as a default value
     other_args = set(['returnParameterFile', 'scheduler_address'])
     kwargs = {k: v for k, v in vars(args).items()
-              if k not in other_args and v is not None}
-    Client(args.scheduler_address)
+              if k not in other_args}
+    # Allow (some) default parameters to work.  Assume certain values
+    # are not valid.
+    for k in 'sample_percent', 'sample_approximate_total':
+        if kwargs[k] == -1:
+            del kwargs[k]
+
+    Client(args.scheduler_address or None)
     I_0 = background_intensity(**kwargs)
     with open(args.returnParameterFile, 'w') as f:
         f.write('BackgroundIntensity = ' + ','.join(map(str, I_0)) + '\n')

--- a/server/BackgroundIntensity/BackgroundIntensity.xml
+++ b/server/BackgroundIntensity/BackgroundIntensity.xml
@@ -27,35 +27,39 @@
 	<minimum>0</minimum>
 	<maximum>1</maximum>
       </constraints>
+      <default>-1</default>
     </float>
     <float>
       <name>magnification</name>
       <label>Magnification</label>
       <longflag>magnification</longflag>
-      <description>Desired magnification for sampling.  Leave unspecified for 1.25x magnification.</description>
+      <description>Desired magnification for sampling.</description>
+      <default>1.25</default>
     </float>
     <float>
       <name>tissue_seg_mag</name>
       <label>Segmentation Magnification</label>
       <longflag>segmentationMag</longflag>
-      <description>Low resolution magnification at which foreground and background will be segmented.  Default 1.25x.</description>
+      <description>Low resolution magnification at which foreground and background will be segmented.</description>
+      <default>1.25</default>
     </float>
     <float>
       <name>min_coverage</name>
       <label>Minimum Coverage</label>
       <longflag>minCoverage</longflag>
-      <description>Minimum background coverage required for a tile to
-      be sampled from.</description>
+      <description>Minimum background coverage required for a tile to be sampled from.</description>
       <constraints>
 	<minimum>0</minimum>
 	<maximum>1</maximum>
       </constraints>
+      <default>0.1</default>
     </float>
     <integer>
       <name>sample_approximate_total</name>
       <label>Approximate sample total</label>
       <longflag>sampleApproximateTotal</longflag>
       <description>Use instead of sample_percent to specify roughly how many pixels to sample.  The fewer tiles are excluded, the more accurate this will be.</description>
+      <default>-1</default>
     </integer>
     <double-vector>
       <name>BackgroundIntensity</name>
@@ -72,12 +76,14 @@
       <label>Scheduler Address</label>
       <description>Address of the dask scheduler in the format '127.0.0.1:8786'.  Not passing this parameter sets up a cluster on the local machine</description>
       <longflag>scheduler_address</longflag>
+      <default></default>
     </string>
     <integer>
       <name>tile_grouping</name>
       <label>Tile grouping</label>
       <longflag>tileGrouping</longflag>
       <description>Number of tiles to process as part of a single task</description>
+      <default>256</default>
     </integer>
   </parameters>
 </executable>

--- a/server/NucleiDetection/NucleiDetection.py
+++ b/server/NucleiDetection/NucleiDetection.py
@@ -202,7 +202,7 @@ def main(args):
 
     scheduler_address = args.scheduler_address
 
-    if scheduler_address is None:
+    if not scheduler_address:
 
         scheduler_address = LocalCluster(
             n_workers=multiprocessing.cpu_count()-1,

--- a/server/NucleiDetection/NucleiDetection.xml
+++ b/server/NucleiDetection/NucleiDetection.xml
@@ -161,6 +161,7 @@
       <label>Scheduler Address</label>
       <description>Address of the dask scheduler in the format '127.0.0.1:8786'.  Not passing this parameter sets up a cluster on the local machine</description>
       <longflag>scheduler_address</longflag>
+      <default></default>
     </string>
   </parameters>
 </executable>

--- a/server/SeparateStainsMacenkoPCA/SeparateStainsMacenkoPCA.py
+++ b/server/SeparateStainsMacenkoPCA/SeparateStainsMacenkoPCA.py
@@ -9,8 +9,11 @@ from histomicstk.preprocessing.color_deconvolution import rgb_separate_stains_ma
 def main(args):
     returnParameterFile, args = splitArgs(args)
     args['macenko']['I_0'] = numpy.array(args['macenko']['I_0'])
+    for k in 'magnification', 'sample_percent', 'sample_approximate_total':
+        if args['sample'][k] == -1:
+            del args['sample'][k]
 
-    Client(args['dask'].get('scheduler_address'))
+    Client(args['dask']['scheduler_address'] or None)
     sample = sample_pixels(**args['sample'])
     stain_matrix = rgb_separate_stains_macenko_pca(sample.T, **args['macenko'])
     with open(returnParameterFile, 'w') as f:
@@ -23,8 +26,7 @@ def splitArgs(args):
     name before the first underscore.  Returns a dict of dicts, where
     the first key is the part of the name before the split and the
     second is the part after.  returnParameterFile is handled
-    separately, and must be given.  Other keys with value None are
-    removed to permit default parameters to work.
+    separately, and must be given.
 
     """
     def splitKey(k):
@@ -36,8 +38,6 @@ def splitArgs(args):
     firstKeys = {splitKey(k)[0] for k in args}
     a = {k: {} for k in firstKeys}
     for k, v in args.items():
-        if v is None:
-            continue
         f, s = splitKey(k)
         a[f][s] = v
     return rpf, a

--- a/server/SeparateStainsMacenkoPCA/SeparateStainsMacenkoPCA.xml
+++ b/server/SeparateStainsMacenkoPCA/SeparateStainsMacenkoPCA.xml
@@ -33,18 +33,21 @@
 	<minimum>0</minimum>
 	<maximum>1</maximum>
       </constraints>
+      <default>-1</default>
     </float>
     <float>
       <name>sample_magnification</name>
       <label>Magnification</label>
       <longflag>magnification</longflag>
-      <description>Desired magnification for sampling.  Leave unspecified for 1.25x magnification.</description>
+      <description>Desired magnification for sampling.  The default value indicates native scan magnification.</description>
+      <default>-1</default>
     </float>
     <float>
       <name>sample_tissue_seg_mag</name>
       <label>Segmentation Magnification</label>
       <longflag>segmentationMag</longflag>
-      <description>Low resolution magnification at which foreground and background will be segmented.  Default 1.25x.</description>
+      <description>Low resolution magnification at which foreground and background will be segmented.</description>
+      <default>1.25</default>
     </float>
     <float>
       <name>sample_min_coverage</name>
@@ -56,18 +59,21 @@
 	<minimum>0</minimum>
 	<maximum>1</maximum>
       </constraints>
+      <default>0.1</default>
     </float>
     <integer>
       <name>sample_sample_approximate_total</name>
       <label>Approximate sample total</label>
       <longflag>sampleApproximateTotal</longflag>
       <description>Use instead of sample_percent to specify roughly how many pixels to sample.  The fewer tiles are excluded, the more accurate this will be.</description>
+      <default>-1</default>
     </integer>
     <double>
       <name>macenko_minimum_magnitude</name>
       <label>Minimum magnitude</label>
       <longflag>minimumMagnitude</longflag>
       <description>The magnitude below which vectors will be excluded from the computation of the angle distribution</description>
+      <default>16</default>
     </double>
     <double>
       <name>macenko_min_angle_percentile</name>
@@ -78,6 +84,7 @@
 	<minimum>0</minimum>
 	<maximum>1</maximum>
       </constraints>
+      <default>0.01</default>
     </double>
     <double>
       <name>macenko_max_angle_percentile</name>
@@ -88,6 +95,7 @@
 	<minimum>0</minimum>
 	<maximum>1</maximum>
       </constraints>
+      <default>0.99</default>
     </double>
     <double-vector>
       <name>stainColor_1</name>
@@ -116,12 +124,14 @@
       <label>Scheduler Address</label>
       <description>Address of the dask scheduler in the format '127.0.0.1:8786'.  Not passing this parameter sets up a cluster on the local machine</description>
       <longflag>scheduler_address</longflag>
+      <default></default>
     </string>
     <integer>
       <name>sample_tile_grouping</name>
       <label>Tile grouping</label>
       <longflag>tileGrouping</longflag>
       <description>Number of tiles to process as part of a single task</description>
+      <default>256</default>
     </integer>
   </parameters>
 </executable>


### PR DESCRIPTION
This PR makes all default values in the CLIs explicit. This is mostly done by specifying those values, but in some cases where the default value really is `None` a magic value is used instead, e.g. `--samplePercent` and `--scheduler_address` in `SeparateStainsMacenkoPCA`.