### PR TITLE
Pin IPython to <=5.3.0 to retain Python 2.X support

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,6 +1,7 @@
 bumpversion==0.5.3
 cryptography>=1.0.1
 matplotlib==1.5.1
+ipython<=5.3.0
 jupyter>=1.0.0
 nbsphinx>=0.2.8
 pprintpp==0.2.3

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,7 +1,7 @@
 bumpversion==0.5.3
 cryptography>=1.0.1
 matplotlib==1.5.1
-ipython<=5.3.0
+ipython<6.0.0
 jupyter>=1.0.0
 nbsphinx>=0.2.8
 pprintpp==0.2.3


### PR DESCRIPTION
Jupyter 1.0.0 in our dev requirements depends on IPython >=4.0.0  which is now (as of yesterday?)  IPython 6.0.0.  IPython 6.0.0 does not support python 2. @manthey PTAL