### PR TITLE
Remove the regexp from the ctest invocation in .travis.yml.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -129,7 +129,7 @@ script:
     - cd $build_path/girder_testing_build
     - cmake -DPYTHON_COVERAGE:BOOL=${PY_COVG} -DPYTHON_VERSION:STRING=${TRAVIS_PYTHON_VERSION} -DPYTHON_COVERAGE_CONFIG="$main_path/plugin_tests/pycoverage.cfg" -DCOVERAGE_MINIMUM_PASS=19 -DJS_COVERAGE_MINIMUM_PASS=19 -DRUN_CORE_TESTS:BOOL="OFF" -DTEST_PLUGINS:STRING="HistomicsTK" $girder_path
     - make
-    - JASMINE_TIMEOUT=15000 ctest -VV -R '(coverage_reset|coverage_combine|HistomicsTK|histomicstk|coverage$|coverage_xml)'
+    - JASMINE_TIMEOUT=15000 ctest -VV
     - travis-sphinx --source=$main_path/docs build
 
 after_success:


### PR DESCRIPTION
It should be unnecessary, since we're disabling Girder's core tests already.