### PR TITLE
Improve CLI XML

### DIFF
--- a/server/BackgroundIntensity/BackgroundIntensity.xml
+++ b/server/BackgroundIntensity/BackgroundIntensity.xml
@@ -24,7 +24,6 @@
       <longflag>samplePercent</longflag>
       <description>Percentage of pixels to sample.  Specify either this or --sampleApproximateTotal</description>
       <constraints>
-	<minimum>0</minimum>
 	<maximum>1</maximum>
       </constraints>
       <default>-1</default>

--- a/server/BackgroundIntensity/BackgroundIntensity.xml
+++ b/server/BackgroundIntensity/BackgroundIntensity.xml
@@ -11,13 +11,13 @@
   <parameters>
     <label>IO</label>
     <description>Input/output parameters.</description>
-    <file>
+    <image>
       <name>slide_path</name>
       <label>Input Slide</label>
       <channel>input</channel>
       <index>0</index>
       <description>Path to input slide image to be deconvolved</description>
-    </file>
+    </image>
     <float>
       <name>sample_percent</name>
       <label>Sample Percent</label>

--- a/server/SeparateStainsMacenkoPCA/SeparateStainsMacenkoPCA.xml
+++ b/server/SeparateStainsMacenkoPCA/SeparateStainsMacenkoPCA.xml
@@ -11,13 +11,13 @@
   <parameters>
     <label>IO</label>
     <description>Input/output parameters.</description>
-    <file>
+    <image>
       <name>sample_slide_path</name>
       <label>Input Slide</label>
       <channel>input</channel>
       <index>0</index>
       <description>Path to input slide image to be deconvolved</description>
-    </file>
+    </image>
     <double-vector>
       <name>macenko_I_0</name>
       <label>Background Intensity</label>

--- a/server/SeparateStainsMacenkoPCA/SeparateStainsMacenkoPCA.xml
+++ b/server/SeparateStainsMacenkoPCA/SeparateStainsMacenkoPCA.xml
@@ -30,7 +30,6 @@
       <longflag>samplePercent</longflag>
       <description>Percentage of pixels to sample.  Specify either this or --sampleApproximateTotal</description>
       <constraints>
-	<minimum>0</minimum>
 	<maximum>1</maximum>
       </constraints>
       <default>-1</default>


### PR DESCRIPTION
This improves the XML specifications for `BackgroundIntensity` and `SeparateStainsMacenkoPCA`, namely by:
- Specifying the input images with `<image>` rather than `<file>`
- Removing the `minimum` constraint on `--samplePath`, allowing the special default value of `-1` to be valid.