### PR TITLE
Fix the Dockerfile build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -212,3 +212,5 @@ target/
 
 web_main
 
+# Scikit-build
+_skbuild/

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,10 +14,14 @@ COPY . $htk_path/
 WORKDIR $htk_path
 
 # Install HistomicsTK and its dependencies
-RUN pip install --upgrade pip && \
+#   Upgrade setuptools, as the version in Conda won't upgrade cleanly unless it
+# is ignored.
+RUN pip install --upgrade --ignore-installed pip setuptools && \
     pip install --upgrade 'git+https://github.com/cdeepakroy/ctk-cli' && \
     # Install requirements.txt via pip; installing via conda causes
     # version issues with our home-built libtif.
+    # Try twice; conda sometimes causes pip to fail the first time, but if it
+    # fails twice then there is a real issue.
     pip install -r requirements.txt && \
     # Install large_image
     pip install 'git+https://github.com/girder/large_image#egg=large_image' && \
@@ -49,7 +53,7 @@ RUN python -c "import libtiff"
 # define entrypoint through which all CLIs can be run
 WORKDIR $htk_path/server
 
-# Test our entrypoint.  If we have incompatible versions of numpy and 
+# Test our entrypoint.  If we have incompatible versions of numpy and
 # openslide, one of these will fail
 RUN python /build/slicer_cli_web/server/cli_list_entrypoint.py --list_cli
 RUN python /build/slicer_cli_web/server/cli_list_entrypoint.py ColorDeconvolution --help

--- a/web_client/stylesheets/body.styl
+++ b/web_client/stylesheets/body.styl
@@ -1,4 +1,2 @@
-body
-    user-select none
 #h-body-container
     height 100%

--- a/web_client/stylesheets/body.styl
+++ b/web_client/stylesheets/body.styl
@@ -1,2 +1,4 @@
+body
+    user-select none
 #h-body-container
     height 100%


### PR DESCRIPTION
Setup tools doesn't upgrade cleanly unless --ignore-installed is added.