### PR TITLE
Name things "fraction" instead of "percent(age)" where appropriate

### DIFF
--- a/histomicstk/preprocessing/color_normalization/reinhard_stats.py
+++ b/histomicstk/preprocessing/color_normalization/reinhard_stats.py
@@ -4,7 +4,7 @@ from histomicstk.utils import sample_pixels
 from histomicstk.preprocessing import color_conversion
 
 
-def reinhard_stats(slide_path, sample_percent, magnification=None):
+def reinhard_stats(slide_path, sample_fraction, magnification=None):
     """Samples a whole-slide-image to determine colorspace statistics (mean,
     variance) needed to perform global Reinhard color normalization.
 
@@ -20,8 +20,8 @@ def reinhard_stats(slide_path, sample_percent, magnification=None):
     ----------
     slide_path : str
         path and filename of slide.
-    sample_percent : double
-       Percentage of pixels to sample (range (0, 1]).
+    sample_fraction : double
+       Fraction of pixels to sample (range (0, 1]).
     magnification : scalar
         Desired magnification for sampling. Defaults to native scan
         magnification.
@@ -46,7 +46,7 @@ def reinhard_stats(slide_path, sample_percent, magnification=None):
     """
 
     # generate a sampling of sample_pixels_rgb pixels from whole-slide image
-    sample_pixels_rgb = sample_pixels(slide_path, sample_percent,
+    sample_pixels_rgb = sample_pixels(slide_path, sample_fraction,
                                       magnification)
 
     # reshape the Nx3 pixel array into a 1 x N x 3 image for lab_mean_std

--- a/histomicstk/segmentation/nuclear/gaussian_voting.py
+++ b/histomicstk/segmentation/nuclear/gaussian_voting.py
@@ -33,7 +33,7 @@ def gaussian_voting(I, rmax=35, rmin=10, sSigma=5, Tau=5, bw=15, Psi=0.3):
     bw : double
         Bandwidth parameter for mean-shift clustering. Default value = 15.
     Psi : double
-        Lower limit threshold on votes. Expressed as a percentage of
+        Lower limit threshold on votes. Expressed as a fraction of
         the maximum vote, ranges from [0, 1). Default value = 0.3.
 
     Returns

--- a/histomicstk/segmentation/nuclear/min_model.py
+++ b/histomicstk/segmentation/nuclear/min_model.py
@@ -18,10 +18,10 @@ def min_model(I, Delta=0.3, MaxLength=255, Compaction=3,
         An intensity image used for analyzing local minima/maxima and
         gradients. Dimensions M x N.
     Delta : float
-        Percent difference threshold between minima/maxima pairs to be included
-        in seed point detection. Percentage difference ([0, 1]) in total image
-        range e.g. Delta = 0.3 with a uint8 input would translate to 0.3 * 255.
-        Default value = 0.3.
+        Fractional difference threshold between minima/maxima pairs to
+        be included in seed point detection. Fractional difference
+        ([0, 1]) in total image range e.g. Delta = 0.3 with a uint8
+        input would translate to 0.3 * 255. Default value = 0.3.
     MaxLength : int
         Maximum allowable contour length. Default value = 255.
     Compaction : int
@@ -107,10 +107,10 @@ def seed_contours(I, Delta=0.3):
         An intensity image used for analyzing local minima/maxima and
         gradients. Dimensions M x N.
     Delta : float
-        Percent difference threshold between minima/maxima pairs to be included
-        in seed point detection. Percentage difference ([0, 1]) in total image
-        range e.g. Delta = 0.3 with a uint8 input would translate to 0.3 * 255.
-        Default value = 0.3.
+        Fractional difference threshold between minima/maxima pairs to
+        be included in seed point detection. Fractional difference
+        ([0, 1]) in total image range e.g. Delta = 0.3 with a uint8
+        input would translate to 0.3 * 255.  Default value = 0.3.
 
     Notes
     -----

--- a/histomicstk/utils/convert_schedule.py
+++ b/histomicstk/utils/convert_schedule.py
@@ -12,7 +12,7 @@ def convert_schedule(schedule, magnification, tol=0.002):
     magnification : scalar
         Desired magnification to convert schedule to.
     tol : double, optional
-        Acceptable mismatch percentage for desired magnification.
+        Acceptable mismatch fraction for desired magnification.
         Default value is 0.002.
 
     Returns

--- a/histomicstk/utils/simple_mask.py
+++ b/histomicstk/utils/simple_mask.py
@@ -8,7 +8,7 @@ from scipy import signal
 
 def simple_mask(im_rgb, bandwidth=2, bgnd_std=2.5, tissue_std=30,
                 min_peak_width=10, max_peak_width=25,
-                percent=0.10, min_tissue_prob=0.05):
+                fraction=0.10, min_tissue_prob=0.05):
     """Performs segmentation of the foreground (tissue)
     Uses a simple two-component Gaussian mixture model to mask tissue areas
     from background in brightfield H&E images. Kernel-density estimation is
@@ -39,8 +39,8 @@ def simple_mask(im_rgb, bandwidth=2, bgnd_std=2.5, tissue_std=30,
     max_peak_width: double, optional
         Maximum peak width for finding peaks in KDE histogram. Used to
         initialize curve fitting process. Default value = 25.
-    percent: double, optional
-        Percentage of pixels to sample for building foreground/background
+    fraction: double, optional
+        Fraction of pixels to sample for building foreground/background
         model. Default value = 0.10.
     min_tissue_prob : double, optional
         Minimum probability to qualify as tissue pixel. Default value = 0.05.
@@ -58,7 +58,7 @@ def simple_mask(im_rgb, bandwidth=2, bgnd_std=2.5, tissue_std=30,
     # convert image to grayscale, flatten and sample
     im_rgb = 255 * color.rgb2gray(im_rgb)
     im_rgb = im_rgb.astype(np.uint8)
-    num_samples = np.int(percent * im_rgb.size)
+    num_samples = np.int(fraction * im_rgb.size)
     sI = np.random.choice(im_rgb.flatten(), num_samples)[:, np.newaxis]
 
     # kernel-density smoothed histogram

--- a/histomicstk/utils/tiling_schedule.py
+++ b/histomicstk/utils/tiling_schedule.py
@@ -16,7 +16,7 @@ def tiling_schedule(slide_path, magnification, tile_size, tol=0.002):
     tile_size : int
        tilesize at desired magnification.
     tol: double
-       acceptable mismatch percentage for desired magnification
+       acceptable mismatch fraction for desired magnification
 
     Returns
     -------

--- a/server/BackgroundIntensity/BackgroundIntensity.py
+++ b/server/BackgroundIntensity/BackgroundIntensity.py
@@ -10,7 +10,7 @@ def main(args):
               if k not in other_args}
     # Allow (some) default parameters to work.  Assume certain values
     # are not valid.
-    for k in 'sample_percent', 'sample_approximate_total':
+    for k in 'sample_fraction', 'sample_approximate_total':
         if kwargs[k] == -1:
             del kwargs[k]
 

--- a/server/BackgroundIntensity/BackgroundIntensity.xml
+++ b/server/BackgroundIntensity/BackgroundIntensity.xml
@@ -19,10 +19,10 @@
       <description>Path to input slide image to be deconvolved</description>
     </file>
     <float>
-      <name>sample_percent</name>
-      <label>Sample Percent</label>
-      <longflag>samplePercent</longflag>
-      <description>Percentage of pixels to sample.  Specify either this or --sampleApproximateTotal</description>
+      <name>sample_fraction</name>
+      <label>Sample Fraction</label>
+      <longflag>sampleFraction</longflag>
+      <description>Fraction of pixels to sample.  Specify either this or --sampleApproximateTotal</description>
       <constraints>
 	<minimum>0</minimum>
 	<maximum>1</maximum>
@@ -58,7 +58,7 @@
       <name>sample_approximate_total</name>
       <label>Approximate sample total</label>
       <longflag>sampleApproximateTotal</longflag>
-      <description>Use instead of sample_percent to specify roughly how many pixels to sample.  The fewer tiles are excluded, the more accurate this will be.</description>
+      <description>Use instead of sample_fraction to specify roughly how many pixels to sample.  The fewer tiles are excluded, the more accurate this will be.</description>
       <default>-1</default>
     </integer>
     <double-vector>

--- a/server/SeparateStainsMacenkoPCA/SeparateStainsMacenkoPCA.py
+++ b/server/SeparateStainsMacenkoPCA/SeparateStainsMacenkoPCA.py
@@ -9,7 +9,7 @@ from histomicstk.preprocessing.color_deconvolution import rgb_separate_stains_ma
 def main(args):
     returnParameterFile, args = splitArgs(args)
     args['macenko']['I_0'] = numpy.array(args['macenko']['I_0'])
-    for k in 'magnification', 'sample_percent', 'sample_approximate_total':
+    for k in 'magnification', 'sample_fraction', 'sample_approximate_total':
         if args['sample'][k] == -1:
             del args['sample'][k]
 

--- a/server/SeparateStainsMacenkoPCA/SeparateStainsMacenkoPCA.xml
+++ b/server/SeparateStainsMacenkoPCA/SeparateStainsMacenkoPCA.xml
@@ -25,10 +25,10 @@
       <description>Background intensity in each channel</description>
     </double-vector>
     <float>
-      <name>sample_sample_percent</name>
-      <label>Sample Percent</label>
-      <longflag>samplePercent</longflag>
-      <description>Percentage of pixels to sample.  Specify either this or --sampleApproximateTotal</description>
+      <name>sample_sample_fraction</name>
+      <label>Sample Fraction</label>
+      <longflag>sampleFraction</longflag>
+      <description>Fraction of pixels to sample.  Specify either this or --sampleApproximateTotal</description>
       <constraints>
 	<minimum>0</minimum>
 	<maximum>1</maximum>
@@ -65,7 +65,7 @@
       <name>sample_sample_approximate_total</name>
       <label>Approximate sample total</label>
       <longflag>sampleApproximateTotal</longflag>
-      <description>Use instead of sample_percent to specify roughly how many pixels to sample.  The fewer tiles are excluded, the more accurate this will be.</description>
+      <description>Use instead of sample_fraction to specify roughly how many pixels to sample.  The fewer tiles are excluded, the more accurate this will be.</description>
       <default>-1</default>
     </integer>
     <double>


### PR DESCRIPTION
In a number of places, the words "percent" and "percentage" are used where, because the argument range is [0,1], "fraction" or "fractional" is more appropriate. This changes those.

Note: The use of "percentile" in `separate_stains_macenko_pca` and those with the same parameters is kept the same, as I'm unaware of a good replacement term ("quantile" seems to refer to the dividing quantity -- thus a percentile is identical to a 100-quantile)