### PR TITLE
Guard against setting properties on tests that don't exist

### DIFF
--- a/plugin.cmake
+++ b/plugin.cmake
@@ -14,6 +14,11 @@
 #  limitations under the License.
 ###############################################################################
 
+# support the "if(TEST ...)" command
+if(POLICY CMP0064)
+  cmake_policy(SET CMP0064 NEW)
+endif()
+
 function(add_histomicstk_python_test case)
   add_python_test("${case}" PLUGIN HistomicsTK
     COVERAGE_PATHS "${PROJECT_SOURCE_DIR}/plugins/HistomicsTK/histomicstk"
@@ -116,7 +121,7 @@ add_histomicstk_python_test(cli_results PLUGIN HistomicsTK
     # multiple tests, so add it in one of the tests for now
     # "plugins/HistomicsTK/Easy1.png"
 )
-if (TEST server_HistomicsTK.cli_results)
+if(TEST "server_HistomicsTK.cli_results")
   set_property(TEST server_HistomicsTK.cli_results APPEND PROPERTY ENVIRONMENT
       "CLI_LIST_ENTRYPOINT=${PROJECT_SOURCE_DIR}/plugins/slicer_cli_web/server/cli_list_entrypoint.py"
       "CLI_CWD=${PROJECT_SOURCE_DIR}/plugins/HistomicsTK/server"
@@ -131,7 +136,7 @@ add_web_client_test(
 )
 # Ideally, client tests would support the EXTERNAL_DATA keyword, but for now
 # we just use a data file used for one of the server tests.
-if (TEST web_client_HistomicsTK_annotations)
+if(TEST "web_client_HistomicsTK_annotations")
   set_property(
     TEST web_client_HistomicsTK_annotations APPEND PROPERTY
     ENVIRONMENT "GIRDER_TEST_DATA_PREFIX=${GIRDER_EXTERNAL_DATA_ROOT}"

--- a/plugin.cmake
+++ b/plugin.cmake
@@ -116,10 +116,12 @@ add_histomicstk_python_test(cli_results PLUGIN HistomicsTK
     # multiple tests, so add it in one of the tests for now
     # "plugins/HistomicsTK/Easy1.png"
 )
-set_property(TEST server_HistomicsTK.cli_results APPEND PROPERTY ENVIRONMENT
-    "CLI_LIST_ENTRYPOINT=${PROJECT_SOURCE_DIR}/plugins/slicer_cli_web/server/cli_list_entrypoint.py"
-    "CLI_CWD=${PROJECT_SOURCE_DIR}/plugins/HistomicsTK/server"
-)
+if (TEST server_HistomicsTK.cli_results)
+  set_property(TEST server_HistomicsTK.cli_results APPEND PROPERTY ENVIRONMENT
+      "CLI_LIST_ENTRYPOINT=${PROJECT_SOURCE_DIR}/plugins/slicer_cli_web/server/cli_list_entrypoint.py"
+      "CLI_CWD=${PROJECT_SOURCE_DIR}/plugins/HistomicsTK/server"
+  )
+endif()
 
 # front-end tests
 add_web_client_test(
@@ -129,10 +131,12 @@ add_web_client_test(
 )
 # Ideally, client tests would support the EXTERNAL_DATA keyword, but for now
 # we just use a data file used for one of the server tests.
-set_property(
-  TEST web_client_HistomicsTK_annotations APPEND PROPERTY
-  ENVIRONMENT "GIRDER_TEST_DATA_PREFIX=${GIRDER_EXTERNAL_DATA_ROOT}"
-)
+if (TEST web_client_HistomicsTK_annotations)
+  set_property(
+    TEST web_client_HistomicsTK_annotations APPEND PROPERTY
+    ENVIRONMENT "GIRDER_TEST_DATA_PREFIX=${GIRDER_EXTERNAL_DATA_ROOT}"
+  )
+endif()
 
 add_eslint_test(
   js_static_analysis_HistomicsTK "${PROJECT_SOURCE_DIR}/plugins/HistomicsTK/web_client"


### PR DESCRIPTION
Fixes #316