### PR TITLE
Add a link to download annotations

### DIFF
--- a/web_client/panels/AnnotationSelector.js
+++ b/web_client/panels/AnnotationSelector.js
@@ -13,7 +13,8 @@ import '../stylesheets/panels/annotationSelector.styl';
 var AnnotationSelector = Panel.extend({
     events: _.extend(Panel.prototype.events, {
         'click .h-toggle-annotation': 'toggleAnnotation',
-        'click .h-delete-annotation': 'deleteAnnotation'
+        'click .h-delete-annotation': 'deleteAnnotation',
+        'click .h-download-annotation': 'downloadAnnotation'
     }),
 
     /**
@@ -93,7 +94,7 @@ var AnnotationSelector = Panel.extend({
      * `displayed` attribute of the `AnnotationModel`.
      */
     toggleAnnotation(evt) {
-        var id = $(evt.currentTarget).parent('.h-annotation').data('id');
+        var id = $(evt.currentTarget).parents('.h-annotation').data('id');
         var model = this.collection.get(id);
         model.set('displayed', !model.get('displayed'));
     },
@@ -102,7 +103,7 @@ var AnnotationSelector = Panel.extend({
      * Delete an annotation from the server.
      */
     deleteAnnotation(evt) {
-        var id = $(evt.currentTarget).parent('.h-annotation').data('id');
+        var id = $(evt.currentTarget).parents('.h-annotation').data('id');
         var model = this.collection.get(id);
         if (model) {
             model.unset('displayed');

--- a/web_client/panels/AnnotationSelector.js
+++ b/web_client/panels/AnnotationSelector.js
@@ -13,8 +13,7 @@ import '../stylesheets/panels/annotationSelector.styl';
 var AnnotationSelector = Panel.extend({
     events: _.extend(Panel.prototype.events, {
         'click .h-toggle-annotation': 'toggleAnnotation',
-        'click .h-delete-annotation': 'deleteAnnotation',
-        'click .h-download-annotation': 'downloadAnnotation'
+        'click .h-delete-annotation': 'deleteAnnotation'
     }),
 
     /**

--- a/web_client/stylesheets/panels/annotationSelector.styl
+++ b/web_client/stylesheets/panels/annotationSelector.styl
@@ -5,8 +5,11 @@
         float left
         margin-right 1em
 
-    .h-delete-annotation
+    .h-annotation-right
         float right
+
+    a
+        color #333
 
 .h-annotation:hover
     background-color #eee

--- a/web_client/templates/panels/annotationSelector.pug
+++ b/web_client/templates/panels/annotationSelector.pug
@@ -5,10 +5,9 @@ block title
 
 block content
   each annotation in annotations
-    - annotation = annotation.attributes;
-    - var name = annotation.annotation.name;
-    - var displayed = annotation.displayed;
-    .h-annotation(data-id=annotation._id)
+    - var name = annotation.get('annotation').name;
+    - var displayed = annotation.get('displayed');
+    .h-annotation(data-id=annotation.id)
       if displayed
         span.icon-eye.h-toggle-annotation(
           data-toggle='tooltip', title='Hide annotation')
@@ -16,5 +15,11 @@ block content
         span.icon-eye-off.h-toggle-annotation(
           data-toggle='tooltip', title='Show annotation')
       span.h-annotation-name #{name}
-      span.icon-cancel.h-delete-annotation(
-        data-toggle='tooltip', title='Remove annotation')
+
+      span.h-annotation-right
+        a(href=annotation.downloadUrl().replace(/\/download$/, ''),
+          download=name + '.json')
+          span.icon-download.h-download-annotation(
+            data-toggle='tooltip', title='Download annotation')
+        span.icon-cancel.h-delete-annotation(
+          data-toggle='tooltip', title='Remove annotation')


### PR DESCRIPTION
This functional, however, there is a problem when attempting to download a large annotation.  It takes the server several seconds to respond while the user has no indication that anything is happening.  The only way I can think of to deal with this is:
1. Add a `click` handler to the link which does the download and adds a spinner.  This will not work if the user tries to download via "Save As" in the context menu.
2. Add an endpoint `GET annotation/:id/download` that initiates a multipart download via paged responses.
If 2. is possible, I think it would be best because it doesn't override the browser's default behavior.

Closes #323