### PR TITLE
When building docker files, only build the girder front-end once.

### DIFF
--- a/ansible/docker_ansible.yml
+++ b/ansible/docker_ansible.yml
@@ -19,7 +19,7 @@
     - role: girder.girder
       girder_path: "{{ root_dir }}/girder"
       girder_version: "master"
-      girder_web_extra_args: "--dev --all-plugins"
+      girder_web: no
       girder_daemonize: no
       become: yes
       become_user: "{{ girder_exec_user }}"


### PR DESCRIPTION
It is built in the girder-histomicstk role, so there is no need to have the girder.girder role build it.