### PR TITLE
Simplify the docker tests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,6 +52,8 @@ addons:
       # pandoc for displaying jupyter notebook examples on ReadTheDocs
       - pandoc
       - pandoc-citeproc
+      # canvas
+      - libgif-dev
 
 before_install:
     - CACHE="$HOME/.cache" OPENJPEG_VERSION=2.1.2 OPENJPEG_FILE=v2.1.2.tar.gz OPENJPEG_DIR=openjpeg-2.1.2 LIBTIFF_VERSION=4.0.6 OPENSLIDE_VERSION=3.4.1 source .install-openslide.sh

--- a/plugin_tests/cli_common_test.py
+++ b/plugin_tests/cli_common_test.py
@@ -239,7 +239,20 @@ class CliCommonTest(base.TestCase):
         with open(nuclei_bbox_annot_gtruth_file, 'r') as fbbox_annot:
             nuclei_bbox_annot_list_gtruth = json.load(fbbox_annot)['elements']
 
-        assert nuclei_bbox_annot_list == nuclei_bbox_annot_list_gtruth
+        # Check that nuclei_bbox_annot_list is nearly equal to
+        # nuclei_bbox_annot_list_gtruth
+        self.assertEqual(len(nuclei_bbox_annot_list),
+                         len(nuclei_bbox_annot_list_gtruth))
+        for pos in range(len(nuclei_bbox_annot_list)):
+            np.testing.assert_array_almost_equal(
+                nuclei_bbox_annot_list[pos]['center'],
+                nuclei_bbox_annot_list_gtruth[pos]['center'], 0)
+            np.testing.assert_almost_equal(
+                nuclei_bbox_annot_list[pos]['width'],
+                nuclei_bbox_annot_list_gtruth[pos]['width'], 1)
+            np.testing.assert_almost_equal(
+                nuclei_bbox_annot_list[pos]['height'],
+                nuclei_bbox_annot_list_gtruth[pos]['height'], 1)
 
         # compare nuclei boundary annotations with gtruth
         nuclei_bndry_annot_gtruth_file = os.path.join(

--- a/plugin_tests/client/annotationSpec.js
+++ b/plugin_tests/client/annotationSpec.js
@@ -148,10 +148,10 @@ $(function () {
                     $('#g-dialog-container #h-element-label').val('test');
                     $('#g-dialog-container .h-submit').click();
                 });
-
-                waitsFor(function () {
-                    return $('.h-elements-container .h-element .h-element-label').text() === 'test';
-                }, 'label to change');
+                girderTest.waitForLoad();
+                runs(function () {
+                    expect($('.h-elements-container .h-element .h-element-label').text()).toBe('test');
+                });
             });
 
             it('draw another point', function () {

--- a/plugin_tests/docker_test.py
+++ b/plugin_tests/docker_test.py
@@ -17,34 +17,21 @@
 #  limitations under the License.
 ###############################################################################
 
-# This is to serve as an example for how to create a server-side test in a
-# girder plugin, it is not meant to be useful.
-
-import threading
-import six
-import types
-import json
-
-
 from tests import base
-from girder import events
-
-# boiler plate to start and stop the server
-TIMEOUT = 180
 
 
 def setUpModule():
     base.enabledPlugins.append('HistomicsTK')
     base.startServer()
-    global JobStatus
-    from girder.plugins.jobs.constants import JobStatus
 
 
 def tearDownModule():
     base.stopServer()
 
 
-class DockerImageManagementTest(base.TestCase):
+class DockerImageEndpointTest(base.TestCase):
+    # This only tests for the existance of the expected endpoints.  The code
+    # behind the docker_images is tested by the slicer_cli_web plugin
     def setUp(self):
         # adding and removing docker images and using generated rest endpoints
         # requires admin access
@@ -59,224 +46,21 @@ class DockerImageManagementTest(base.TestCase):
         }
         self.admin = self.model('user').createUser(**admin)
 
-        try:
-            from docker import Client
-            self.docker_client = Client(base_url='unix://var/run/docker.sock')
-
-        except Exception as err:
-            self.fail('could not create the docker client ' + str(err))
-
-    def testAddNonExistentImage(self):
-        # add a bad image
-        img_name = 'null/null:null'
-        self.assertNoImages()
-        self.addImage(img_name, JobStatus.ERROR)
-        self.assertNoImages()
-
-    def testDockerAdd(self):
-        # try to cache a good image to the mongo database
-        img_name = "dsarchive/histomicstk:v0.1.3"
-        self.assertNoImages()
-        self.addImage(img_name, JobStatus.SUCCESS)
-        self.imageIsLoaded(img_name, True)
-
-    def testDockerDelete(self):
-        # just delete the meta data in the mongo database
-        # dont attempt to delete the docker image
-        img_name = "dsarchive/histomicstk:v0.1.3"
-        self.assertNoImages()
-        self.addImage(img_name, JobStatus.SUCCESS)
-        self.imageIsLoaded(img_name, True)
-        self.deleteImage(img_name, True, False)
-        self.imageIsLoaded(img_name, exists=False)
-        self.assertNoImages()
-
-    def testDockerDeleteFull(self):
-        # attempt to delete docker image metadata and the image off the local
-        # machine
-        img_name = "dsarchive/histomicstk:v0.1.3"
-        self.assertNoImages()
-        self.addImage(img_name, JobStatus.SUCCESS)
-        self.imageIsLoaded(img_name, True)
-        self.deleteImage(img_name, True, True, JobStatus.SUCCESS)
-
-        try:
-            self.docker_client.inspect_image(img_name)
-            self.fail('If the image was deleted then an attempt to docker '
-                      'inspect it should raise a docker exception')
-        except Exception:
-            pass
-
-        self.imageIsLoaded(img_name, exists=False)
-        self.assertNoImages()
-
-    def testDockerPull(self):
-
-        # test an instance when the image must be pulled
-        # Forces the test image to be deleted
-        self.testDockerDeleteFull()
-        self.testDockerAdd()
-
-    def testBadImageDelete(self):
-        # attempt to delete a non existent image
-        img_name = 'null/null:null'
-        self.assertNoImages()
-        self.deleteImage(img_name, False, )
-
-    def testXmlEndpoint(self):
-        # loads an image and attempts to run an arbitrary xml endpoint
-        img_name = "dsarchive/histomicstk:v0.1.3"
-        self.testDockerAdd()
-
-        name, tag = self.splitName(img_name)
-        data = self.getEndpoint()
-        for (image, tag) in six.iteritems(data):
-            for (version_name, cli) in six.iteritems(tag):
-                for (cli_name, info) in six.iteritems(cli):
-                    route = info['xmlspec']
-                    resp = self.request(
-                        path=route,
-                        user=self.admin,
-                        isJson=False)
-                    self.assertStatus(resp, 200)
-                    xmlString = self.getBody(resp)
-                    # TODO validate with xml schema
-                    self.assertNotEqual(xmlString, '')
-
-    def testEndpointDeletion(self):
-        img_name = "dsarchive/histomicstk:v0.1.3"
-        self.testXmlEndpoint()
-        data = self.getEndpoint()
-        self.deleteImage(img_name, True)
-        name, tag = self.splitName(img_name)
-
-        for (image, tag) in six.iteritems(data):
-            for (version_name, cli) in six.iteritems(tag):
-                for (cli_name, info) in six.iteritems(cli):
-                    route = info['xmlspec']
-                    resp = self.request(
-                        path=route,
-                        user=self.admin,
-                        isJson=False)
-                    # xml route should have been deleted
-                    self.assertStatus(resp, 400)
-
-    def testAddBadImage(self):
-        # job should fail gracefully after pulling the image
-        img_name = 'library/hello-world:latest'
-        self.assertNoImages()
-        self.addImage(img_name, JobStatus.ERROR)
-        self.assertNoImages()
-
-    def splitName(self, name):
-        if ':' in name:
-            imageAndTag = name.split(':')
-        else:
-            imageAndTag = name.split('@')
-        return imageAndTag[0], imageAndTag[1]
-
-    def imageIsLoaded(self, name, exists):
-
-        userAndRepo, tag = self.splitName(name)
-
-        data = self.getEndpoint()
-        if not exists:
-            if userAndRepo in data:
-                imgVersions = data[userAndRepo]
-                self.assertNotHasKeys(imgVersions, [tag])
-
-        else:
-            self.assertHasKeys(data, [userAndRepo])
-            imgVersions = data[userAndRepo]
-            self.assertHasKeys(imgVersions, [tag])
-
-    def getEndpoint(self):
+    def testGetEndpoint(self):
         resp = self.request(path='/HistomicsTK/HistomicsTK/docker_image',
                             user=self.admin)
-        self.assertStatus(resp, 200)
-        return json.loads(self.getBody(resp))
+        self.assertStatusOk(resp)
+        # We should have no images
+        self.assertEqual(resp.json, {})
 
-    def assertNoImages(self):
-        data = self.getEndpoint()
-        self.assertEqual({}, data,
-                         " There should be no pre existing docker images ")
-
-    def deleteImage(self, name,  responseCodeOK, deleteDockerImage=False,
-                    status=4):
-        """
-        Delete docker image data and test whether a docker
-        image can be deleted off the local machine
-        """
-        if deleteDockerImage:
-            event = threading.Event()
-
-            def tempListener(self, girderEvent):
-                job = girderEvent.info['job']
-
-                if (job['type'] == 'slicer_cli_web_job' and
-                        job['status'] in (JobStatus.SUCCESS, JobStatus.ERROR)):
-                    self.assertEqual(job['status'], job['status'],
-                                     'The status of the job should match')
-                    events.unbind('jobs.job.update.after', 'HistomicsTK_del')
-                    # del self.delHandler
-                    event.set()
-
-            self.delHandler = types.MethodType(tempListener, self)
-
-            events.bind('jobs.job.update.after', 'HistomicsTK_del',
-                        self.delHandler)
-
+    def testPutEndpoint(self):
         resp = self.request(path='/HistomicsTK/HistomicsTK/docker_image',
-                            user=self.admin, method='DELETE',
-                            params={"name": json.dumps(name),
-                                    "delete_from_local_repo":
-                                        deleteDockerImage
-                                    }, isJson=False)
-        if responseCodeOK:
-            self.assertStatus(resp, 200)
-        else:
-            try:
-                self.assertStatus(resp, 200)
-                self.fail('A status ok or code 200 should not have been '
-                          'recieved for deleting the image %s' % str(name))
-            except Exception:
-                    pass
-        if deleteDockerImage:
-            if not event.wait(TIMEOUT):
-                self.fail('deleting the docker image is taking '
-                          'longer than %d seconds' % TIMEOUT)
+                            user=self.admin, method='PUT')
+        # We should get back an error code since we didn't send some parameters
+        self.assertStatus(resp, 400)
 
-            del self.delHandler
-
-    def addImage(self, name, status):
-        """Test the put endpoint, name can be a string or a list of strings"""
-
-        event = threading.Event()
-
-        def tempListener(self, girderEvent):
-            job = girderEvent.info['job']
-
-            if (job['type'] == 'slicer_cli_web_job' and
-                    job['status'] in (JobStatus.SUCCESS, JobStatus.ERROR)):
-                self.assertEqual(job['status'], status,
-                                 'The status of the job should match')
-
-                events.unbind('jobs.job.update.after', 'HistomicsTK_add')
-
-                event.set()
-
-        self.addHandler = types.MethodType(tempListener, self)
-
-        events.bind('jobs.job.update.after',
-                    'HistomicsTK_add', self.addHandler)
-
+    def testDeleteEndpoint(self):
         resp = self.request(path='/HistomicsTK/HistomicsTK/docker_image',
-                            user=self.admin, method='PUT',
-                            params={"name": json.dumps(name)}, isJson=False)
-
-        self.assertStatus(resp, 200)
-
-        if not event.wait(TIMEOUT):
-            self.fail('adding the docker image is taking '
-                      'longer than %d seconds' % TIMEOUT)
-        del self.addHandler
+                            user=self.admin, method='DELETE')
+        # We should get back an error code since we didn't send some parameters
+        self.assertStatus(resp, 400)

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -10,4 +10,3 @@ Sphinx==1.4.2
 sphinx-rtd-theme==0.1.9
 watchdog==0.8.3
 wheel==0.23.0
-docker-py>=1.9.0,<2


### PR DESCRIPTION
The docker endpoints are used from the slicer_cli_web plugin, and are tested there.  These tests were duplicates, and didn't actually cover any local code.  The tests have been simplified to just check that the expected endpoints are present.

This also removes docker-py from the development requirements, as it was only used in the tests.