### PR TITLE
Fix minor issues with ComputeNucleiFeatures and NucleiClassification CLIs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -109,6 +109,9 @@ install:
     - cd $girder_path
     - python setup.py develop
     - cd $large_image_path
+    - pip install --no-cache-dir numpy>=1.10.2
+    - pip install --upgrade --no-cache-dir --force-reinstall --ignore-installed openslide-python Pillow
+    - pip install "git+https://github.com/pearu/pylibtiff@848785a6a9a4e2c6eb6f56ca9f7e8f6b32e523d5" --force-reinstall --ignore-installed --upgrade --no-cache-dir
     - pip install -U -r requirements.txt
     - python setup.py install
     - cd $main_path
@@ -119,8 +122,6 @@ install:
     - cd $girder_path
     - pip install -U -r requirements.txt -r requirements-dev.txt
     - pip install -U -r $slicer_cli_web_path/requirements.txt
-    - pip install --upgrade --no-cache-dir --force-reinstall --ignore-installed openslide-python Pillow
-    - pip install "git+https://github.com/pearu/pylibtiff@848785a6a9a4e2c6eb6f56ca9f7e8f6b32e523d5" --force-reinstall --ignore-installed --upgrade --no-cache-dir
     - npm-install-retry
     - BABEL_ENV=cover NYC_CWD="$main_path" girder-install web --plugins=jobs,worker,large_image,slicer_cli_web,HistomicsTK --dev
     - conda install --yes jupyter sphinx sphinx_rtd_theme

--- a/.travis.yml
+++ b/.travis.yml
@@ -109,7 +109,7 @@ install:
     - cd $girder_path
     - python setup.py develop
     - cd $large_image_path
-    - pip install --no-cache-dir numpy>=1.10.2
+    - pip install --no-cache-dir numpy>=1.12.1
     - pip install --upgrade --no-cache-dir --force-reinstall --ignore-installed openslide-python Pillow
     - pip install "git+https://github.com/pearu/pylibtiff@848785a6a9a4e2c6eb6f56ca9f7e8f6b32e523d5" --force-reinstall --ignore-installed --upgrade --no-cache-dir
     - pip install -U -r requirements.txt

--- a/server/ComputeNucleiFeatures/ComputeNucleiFeatures.py
+++ b/server/ComputeNucleiFeatures/ComputeNucleiFeatures.py
@@ -20,7 +20,7 @@ import logging
 logging.basicConfig(level=logging.CRITICAL)
 
 sys.path.append(os.path.normpath(os.path.join(os.path.dirname(__file__), '..')))
-from cli_common import utils as cli_utils # noqa
+from cli_common import utils as cli_utils  # noqa
 
 
 def compute_tile_nuclei_features(slide_path, tile_position, args, **it_kwargs):

--- a/server/ComputeNucleiFeatures/ComputeNucleiFeatures.py
+++ b/server/ComputeNucleiFeatures/ComputeNucleiFeatures.py
@@ -93,7 +93,7 @@ def check_args(args):
     if len(args.analysis_roi) != 4:
         raise ValueError('Analysis ROI must be a vector of 4 elements.')
 
-    if os.path.splitext(args.outputFeatureFile)[1] not in ['.csv', '.h5']:
+    if os.path.splitext(args.outputNucleiFeatureFile)[1] not in ['.csv', '.h5']:
         raise ValueError('Extension of output feature file must be .csv or .h5')
 
 
@@ -107,7 +107,7 @@ def main(args):
 
     check_args(args)
 
-    feature_file_format = os.path.splitext(args.outputFeatureFile)[1]
+    feature_file_format = os.path.splitext(args.outputNucleiFeatureFile)[1]
 
     if np.all(np.array(args.analysis_roi) == -1):
         process_whole_image = True
@@ -255,11 +255,11 @@ def main(args):
 
     if feature_file_format == '.csv':
 
-        nuclei_fdata.to_csv(args.outputFeatureFile, index=False)
+        nuclei_fdata.to_csv(args.outputNucleiFeatureFile, index=False)
 
     elif feature_file_format == '.h5':
 
-        nuclei_fdata.to_hdf(args.outputFeatureFile, 'Features',
+        nuclei_fdata.to_hdf(args.outputNucleiFeatureFile, 'Features',
                             format='table', mode='w')
 
     else:

--- a/server/ComputeNucleiFeatures/ComputeNucleiFeatures.py
+++ b/server/ComputeNucleiFeatures/ComputeNucleiFeatures.py
@@ -237,18 +237,16 @@ def main(args):
     #
     print('\n>> Writing annotation file ...\n')
 
-    if args.outputNucleiAnnotationFile:
+    annot_fname = os.path.splitext(
+        os.path.basename(args.outputNucleiAnnotationFile))[0]
 
-        annot_fname = os.path.splitext(
-            os.path.basename(args.outputNucleiAnnotationFile))[0]
+    annotation = {
+        "name": annot_fname + '-nuclei-' + args.nuclei_annotation_format,
+        "elements": nuclei_annot_list
+    }
 
-        annotation = {
-            "name": annot_fname + '-nuclei-' + args.nuclei_annotation_format,
-            "elements": nuclei_annot_list
-        }
-
-        with open(args.outputNucleiAnnotationFile, 'w') as annotation_file:
-            json.dump(annotation, annotation_file, indent=2, sort_keys=False)
+    with open(args.outputNucleiAnnotationFile, 'w') as annotation_file:
+        json.dump(annotation, annotation_file, indent=2, sort_keys=False)
 
     #
     # Create CSV Feature file
@@ -257,7 +255,7 @@ def main(args):
 
     if feature_file_format == '.csv':
 
-        nuclei_fdata.to_csv(args.outputFeatureFile)
+        nuclei_fdata.to_csv(args.outputFeatureFile, index=False)
 
     elif feature_file_format == '.h5':
 

--- a/server/ComputeNucleiFeatures/ComputeNucleiFeatures.xml
+++ b/server/ComputeNucleiFeatures/ComputeNucleiFeatures.xml
@@ -36,7 +36,8 @@
       <name>outputNucleiAnnotationFile</name>
       <label>Output Nuclei Annotation File</label>
       <description>Output nuclei annotation file</description>
-      <longflag>outputNucleiAnnotationFile</longflag>
+      <channel>output</channel>
+      <index>2</index>
     </file>
     <boolean>
       <name>morphometry_features</name>

--- a/server/ComputeNucleiFeatures/ComputeNucleiFeatures.xml
+++ b/server/ComputeNucleiFeatures/ComputeNucleiFeatures.xml
@@ -25,17 +25,17 @@
       <longflag>analysis_roi</longflag>
       <default>-1,-1,-1,-1</default>
     </region>
-    <file fileExtensions=".csv, .h5">
-      <name>outputFeatureFile</name>
-      <label>Output Feature file</label>
+    <file fileExtensions=".csv|.h5">
+      <name>outputNucleiFeatureFile</name>
+      <label>Output Nuclei Feature file</label>
       <channel>output</channel>
       <index>1</index>
-      <description>Output feature file containing the extracted features of all nuclei</description>
+      <description>Output nuclei feature file (*.csv or *.h5)</description>
     </file>
     <file fileExtensions=".anot" reference="inputImageFile">
       <name>outputNucleiAnnotationFile</name>
       <label>Output Nuclei Annotation File</label>
-      <description>Output nuclei annotation file</description>
+      <description>Output nuclei annotation file (*.anot)</description>
       <channel>output</channel>
       <index>2</index>
     </file>

--- a/server/NucleiClassification/NucleiClassification.py
+++ b/server/NucleiClassification/NucleiClassification.py
@@ -14,7 +14,7 @@ import logging
 logging.basicConfig(level=logging.CRITICAL)
 
 sys.path.append(os.path.normpath(os.path.join(os.path.dirname(__file__), '..')))
-from cli_common import utils as cli_utils # noqa
+from cli_common import utils as cli_utils  # noqa
 
 
 def gen_distinct_rgb_colors(n, seed=None):

--- a/server/NucleiClassification/NucleiClassification.py
+++ b/server/NucleiClassification/NucleiClassification.py
@@ -56,15 +56,15 @@ def gen_distinct_rgb_colors(n, seed=None):
 
 def read_feature_file(args):
 
-    fname, feature_file_format = os.path.splitext(args.inputFeatureFile)
+    fname, feature_file_format = os.path.splitext(args.inputNucleiFeatureFile)
 
     if feature_file_format == '.csv':
 
-        ddf = dd.read_csv(args.inputFeatureFile)
+        ddf = dd.read_csv(args.inputNucleiFeatureFile)
 
     elif feature_file_format == '.h5':
 
-        ddf = dd.read_hdf(args.inputFeatureFile, 'Features')
+        ddf = dd.read_hdf(args.inputNucleiFeatureFile, 'Features')
 
     else:
         raise ValueError('Extension of output feature file must be .csv or .h5')

--- a/server/NucleiClassification/NucleiClassification.xml
+++ b/server/NucleiClassification/NucleiClassification.xml
@@ -24,24 +24,24 @@
       <index>1</index>
       <description>Pickled file of the scikit-learn model for classifying nuclei</description>
     </file>
-    <file fileExtensions=".csv, .h5">
-      <name>inputFeatureFile</name>
+    <file fileExtensions=".csv|.h5">
+      <name>inputNucleiFeatureFile</name>
       <channel>input</channel>
       <index>2</index>
-      <description>File containing the features of all nuclei to be classified</description>
+      <description>Input nuclei feature file (*.csv, *.h5) containing the features of all nuclei to be classified</description>
     </file>
     <file fileExtensions=".anot">
       <name>inputNucleiAnnotationFile</name>
       <channel>input</channel>
       <index>3</index>
-      <description>Annotation file containing nuclei annotations in the same order as their features in the feature file</description>
+      <description>Input nuclei annotation file (*.anot) containing nuclei annotations in the same order as their features in the feature file</description>
     </file>
     <file fileExtensions=".anot" reference="inputImageFile">
       <name>outputNucleiAnnotationFile</name>
       <label>Output Nuclei Annotation File</label>
       <channel>output</channel>
       <index>4</index>
-      <description>Output nuclei annotation file (with the same nuclei in input nuclei annotation file if provided) with nuclei sorted into groups based on class and accompanied by heatmaps of the classification probabilities</description>
+      <description>Output nuclei annotation file (*.anot) with the same nuclei in input nuclei annotation file if provided) with nuclei sorted into groups based on class and accompanied by heatmaps of the classification probabilities</description>
     </file>
   </parameters>
 </executable>

--- a/server/NucleiDetection/NucleiDetection.py
+++ b/server/NucleiDetection/NucleiDetection.py
@@ -19,7 +19,7 @@ import logging
 logging.basicConfig(level=logging.CRITICAL)
 
 sys.path.append(os.path.normpath(os.path.join(os.path.dirname(__file__), '..')))
-from cli_common import utils as cli_utils # noqa
+from cli_common import utils as cli_utils  # noqa
 
 
 def detect_tile_nuclei(slide_path, tile_position, args, **it_kwargs):

--- a/server/NucleiDetection/NucleiDetection.xml
+++ b/server/NucleiDetection/NucleiDetection.xml
@@ -37,7 +37,7 @@
     <file fileExtensions=".anot" reference="inputImageFile">
       <name>outputNucleiAnnotationFile</name>
       <label>Output Nuclei Annotation File</label>
-      <description>Output nuclei annotation file</description>
+      <description>Output nuclei annotation file (*.anot)</description>
       <channel>output</channel>
       <index>1</index>
     </file>

--- a/server/slicer_cli_list.json
+++ b/server/slicer_cli_list.json
@@ -15,6 +15,10 @@
     "type"    : "python"
   },
 
+  "NucleiClassification": {
+    "type"    : "python"
+  },
+
   "BackgroundIntensity": {
     "type"    : "python"
   },


### PR DESCRIPTION
* Make outputNucleiAnnotationFile a indexed output parameter
* Add NucleiClassification CLI to slicer_cli_list.json
* Remove pandas index column while writing features files
* Mentions file extensions in the descriptions of output files