### PR TITLE
Defer clicking the open image dialog in the annotation test

### DIFF
--- a/plugin_tests/client/annotationSpec.js
+++ b/plugin_tests/client/annotationSpec.js
@@ -70,8 +70,17 @@ $(function () {
         runs(function () {
             var $item = $('.g-item-list-link:contains("' + name + '")');
             imageId = $item.next().attr('href').match(/\/item\/([a-f0-9]+)\/download/)[1];
+            expect($item.length).toBe(1);
             $item.click();
-            $('.g-submit-button').click();
+        });
+
+        girderTest.waitForDialog();
+        // Sometimes clicking submit fires the `g:saved` event, but doesn't actually
+        // close the dialog.  Delaying the click seems to help.
+        runs(function () {
+            window.setTimeout(function () {
+                $('.g-submit-button').click();
+            }, 100);
         });
 
         girderTest.waitForLoad();

--- a/web_client/dialogs/openImage.js
+++ b/web_client/dialogs/openImage.js
@@ -29,6 +29,7 @@ function createDialog() {
         // reset image bounds when opening a new image
         router.setQuery('bounds', null, {trigger: false});
         router.setQuery('image', model.id, {trigger: true});
+        $('.modal').girderModal('close');
     });
     return widget;
 }


### PR DESCRIPTION
I've been running this in a loop locally for about an hour without any failures.  Hopefully it will reduce the errors on travis.