### PR TITLE
Minor fixes for demo

### DIFF
--- a/plugin_tests/cli_common_test.py
+++ b/plugin_tests/cli_common_test.py
@@ -261,6 +261,14 @@ class CliCommonTest(base.TestCase):
         )
 
         with open(nuclei_bndry_annot_gtruth_file, 'r') as fbndry_annot:
-            nuclei_bndry_annot_list_gtruth = json.load(fbndry_annot)['elements']
+            nuclei_bndry_annot_list_gtruth = json.load(
+                fbndry_annot)['elements']
 
-        assert nuclei_bndry_annot_list == nuclei_bndry_annot_list_gtruth
+        self.assertEqual(len(nuclei_bndry_annot_list),
+                         len(nuclei_bndry_annot_list_gtruth))
+
+        for pos in range(len(nuclei_bndry_annot_list)):
+
+            np.testing.assert_array_almost_equal(
+                nuclei_bndry_annot_list[pos]['points'],
+                nuclei_bndry_annot_list_gtruth[pos]['points'], 0)

--- a/server/ComputeNucleiFeatures/ComputeNucleiFeatures.xml
+++ b/server/ComputeNucleiFeatures/ComputeNucleiFeatures.xml
@@ -25,7 +25,7 @@
       <longflag>analysis_roi</longflag>
       <default>-1,-1,-1,-1</default>
     </region>
-    <file fileExtensions=".csv|.h5">
+    <file fileExtensions=".csv,.h5">
       <name>outputNucleiFeatureFile</name>
       <label>Output Nuclei Feature file</label>
       <channel>output</channel>

--- a/server/NucleiClassification/NucleiClassification.xml
+++ b/server/NucleiClassification/NucleiClassification.xml
@@ -25,7 +25,7 @@
       <index>1</index>
       <description>Pickled file (*.pkl) of the scikit-learn model for classifying nuclei</description>
     </file>
-    <file fileExtensions=".csv|.h5">
+    <file fileExtensions=".csv,.h5">
       <name>inputNucleiFeatureFile</name>
       <label>Input Nuclei Feature File</label>
       <channel>input</channel>

--- a/server/cli_common/utils.py
+++ b/server/cli_common/utils.py
@@ -123,7 +123,8 @@ def create_tile_nuclei_bbox_annotations(im_nuclei_seg_mask, tile_info):
             "width": width,
             "height": height,
             "rotation": 0,
-            "fillColor": "rgba(0,0,0,0)"
+            "fillColor": "rgba(0,0,0,0)",
+            "lineColor": "rgb(0,255,0)"
         }
 
         nuclei_annot_list.append(cur_bbox)
@@ -157,7 +158,8 @@ def create_tile_nuclei_boundary_annotations(im_nuclei_seg_mask, tile_info):
             "type": "polyline",
             "points": cur_points.tolist(),
             "closed": True,
-            "fillColor": "rgba(0,0,0,0)"
+            "fillColor": "rgba(0,0,0,0)",
+            "lineColor": "rgb(0,255,0)"
         }
 
         nuclei_annot_list.append(cur_annot)


### PR DESCRIPTION
* Explicitly set `lineColor` property of nuclei annotations to green for better visibility
* Use comma sep list for fileExtensions in xml spec