### PR TITLE
Migrate to Sphinx 1.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -128,6 +128,7 @@ install:
     - pip install -U -r $slicer_cli_web_path/requirements.txt
     - npm-install-retry
     - BABEL_ENV=cover NYC_CWD="$main_path" girder-install web --plugins=jobs,worker,large_image,slicer_cli_web,HistomicsTK --dev
+    - pip uninstall --yes Sphinx  # Interferes with sphinx from conda
     - conda install --yes jupyter sphinx sphinx_rtd_theme
     - pip install nbsphinx travis-sphinx
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -32,9 +32,11 @@ if not on_rtd:  # only import and set the theme if we're building docs locally
     html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 
 # -- General configuration ---------------------------------------------
+# We use footnotes to collect references without actually referencing them
+suppress_warnings = ['ref.footnote']
 
 # If your documentation needs a minimal Sphinx version, state it here.
-#needs_sphinx = '1.0'
+needs_sphinx = '1.6'  # Allow specifying top-level packages only
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
@@ -51,17 +53,8 @@ extensions = ['sphinx.ext.autodoc',
               'IPython.sphinxext.ipython_console_highlighting',
               'nbsphinx']
 
-autodoc_mock_imports = ['matplotlib', 'matplotlib.pyplot',
-                        'nimfa',
-                        'openslide', 'pandas', 'large_image',
-                        'scipy',
-                        'scipy.ndimage.morphology','scipy.ndimage.filters',
-                        'scipy.ndimage.measurements',
-                        'scipy.optimize', 'scipy.signal', 'scipy.stats',
-                        'skimage', 'skimage.feature', 'skimage.measure',
-                        'skimage.segmentation', 'skimage.morphology',
-                        'skimage.draw', 'skimage.transform',
-                        'sklearn.cluster', 'sklearn.neighbors.kde',
+autodoc_mock_imports = ['matplotlib', 'nimfa', 'openslide', 'pandas',
+                        'large_image', 'scipy', 'skimage', 'sklearn',
                         'segmentation.label.trace_boundaries_cython']
 
 # Add any paths that contain templates here, relative to this directory.

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -6,7 +6,7 @@ jupyter>=1.0.0
 nbsphinx>=0.2.8
 pprintpp==0.2.3
 PyYAML==3.11
-Sphinx==1.4.2
+Sphinx==1.6.2
 sphinx-rtd-theme==0.1.9
 watchdog==0.8.3
 wheel==0.23.0


### PR DESCRIPTION
The work I'm doing on architectural / graph features requires a few more `scipy` modules, and this approach seems cleaner if we don't need to support older Sphinx versions.

__Commit notes:__
This removes the need to specify all subpackages that need to be
mocked.  We therefore require Sphinx>=1.6.

Due to our use of footnotes, we need to suppress the new unused
footnote warning.