### PR TITLE
Support newer versions of docker-py/docker.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ __pycache__/
 docs/_build
 dist/
 build
+_build
 .coverage
 *.egg
 *.egg-info
@@ -20,3 +21,5 @@ ansible/roles/girder.girder
 # scikit-build
 _skbuild
 MANIFEST
+# cython output
+*.so

--- a/.travis.yml
+++ b/.travis.yml
@@ -79,7 +79,8 @@ before_install:
     - girder_worker_path=$girder_path/plugins/girder_worker
     - git clone https://github.com/girder/girder_worker.git $girder_worker_path && git -C $girder_worker_path checkout $GIRDER_WORKER_VERSION
     - cp $PWD/plugin_tests/data/girder_worker.cfg $girder_worker_path/girder_worker/worker.local.cfg
-    - pip install -U -r $girder_worker_path/requirements.txt -r $girder_worker_path/girder_worker/plugins/girder_io/requirements.txt
+    - pip install -U -r $girder_worker_path/requirements.txt 
+    - pip install -U -r $girder_worker_path/girder_worker/plugins/girder_io/requirements.txt
 
     - large_image_path=$girder_path/plugins/large_image
     - git clone https://github.com/girder/large_image.git $large_image_path && git -C $large_image_path checkout $LARGE_IMAGE_VERSION

--- a/ansible/README.rst
+++ b/ansible/README.rst
@@ -18,9 +18,9 @@ Install git, python-pip, and docker.io.  On Ubuntu, this can be done via::
 
     sudo apt-get install git docker.io python-pip
 
-Install docker-py::
+Install the pythom docker module::
 
-    sudo pip install docker-py
+    sudo pip install docker
 
 Get the HistomicsTK repository::
 

--- a/ansible/README.rst
+++ b/ansible/README.rst
@@ -16,9 +16,16 @@ Prerequisites
 
 Install git, python-pip, and docker.io.  On Ubuntu, this can be done via::
 
+    sudo apt-get update
     sudo apt-get install git docker.io python-pip
 
-Install the pythom docker module::
+The current user needs to be a member of the docker group::
+
+    sudo usermod -aG docker `id -u -n`
+
+After which, you will need to log out and log back in.
+
+Install the python docker module::
 
     sudo pip install docker
 

--- a/ansible/deploy_docker.py
+++ b/ansible/deploy_docker.py
@@ -74,7 +74,7 @@ def containers_provision(**kwargs):
     """
     Provision or reprovision the containers.
     """
-    client = docker.from_env()
+    client = docker.from_env(version='auto')
     client = client if not hasattr(client, 'api') else client.api
     ctn = get_docker_image_and_container(
         client, 'histomicstk', version=kwargs.get('pinned'))
@@ -145,7 +145,7 @@ def containers_start(port=8080, rmq='docker', mongo='docker', provision=False,
     :param provision: if True, reprovision after starting.  Otherwise, only
         provision if the histomictk container is created.
     """
-    client = docker.from_env()
+    client = docker.from_env(version='auto')
     client = client if not hasattr(client, 'api') else client.api
     env = {}
     started = False
@@ -385,7 +385,7 @@ def containers_status(**kwargs):
     """"
     Report the status of any containers we are responsible for.
     """
-    client = docker.from_env()
+    client = docker.from_env(version='auto')
     client = client if not hasattr(client, 'api') else client.api
 
     keys = ImageList.keys()
@@ -415,7 +415,7 @@ def containers_stop(remove=False, **kwargs):
 
     :param remove: True to remove the containers.  False to just stop them.
     """
-    client = docker.from_env()
+    client = docker.from_env(version='auto')
     client = client if not hasattr(client, 'api') else client.api
     keys = ImageList.keys()
     keys.reverse()
@@ -517,7 +517,7 @@ def images_build(retry=False, names=None):
         names to build.
     """
     basepath = os.path.dirname(os.path.realpath(__file__))
-    client = docker.from_env()
+    client = docker.from_env(version='auto')
     client = client if not hasattr(client, 'api') else client.api
 
     if names is None:
@@ -559,7 +559,7 @@ def images_repull(**kwargs):
     """"
     Repull all docker images.
     """
-    client = docker.from_env()
+    client = docker.from_env(version='auto')
     client = client if not hasattr(client, 'api') else client.api
     for key, image in six.iteritems(ImageList):
         if 'name' not in image and not kwargs.get('cli'):

--- a/ansible/deploy_docker.py
+++ b/ansible/deploy_docker.py
@@ -12,8 +12,8 @@ import tarfile
 import time
 from distutils.version import LooseVersion
 
-if not (LooseVersion('1.9') <= LooseVersion(docker.version) < LooseVersion('2')):
-    raise Exception('docker-py must be >= version 1.9 and < version 2')
+if not (LooseVersion('1.9') <= LooseVersion(docker.version)):
+    raise Exception('docker or docker-py must be >= version 1.9')
 
 
 BaseName = 'histomicstk'
@@ -75,6 +75,7 @@ def containers_provision(**kwargs):
     Provision or reprovision the containers.
     """
     client = docker.from_env()
+    client = client if not hasattr(client, 'api') else client.api
     ctn = get_docker_image_and_container(
         client, 'histomicstk', version=kwargs.get('pinned'))
 
@@ -145,6 +146,7 @@ def containers_start(port=8080, rmq='docker', mongo='docker', provision=False,
         provision if the histomictk container is created.
     """
     client = docker.from_env()
+    client = client if not hasattr(client, 'api') else client.api
     env = {}
     started = False
 
@@ -384,6 +386,7 @@ def containers_status(**kwargs):
     Report the status of any containers we are responsible for.
     """
     client = docker.from_env()
+    client = client if not hasattr(client, 'api') else client.api
 
     keys = ImageList.keys()
     results = []
@@ -413,6 +416,7 @@ def containers_stop(remove=False, **kwargs):
     :param remove: True to remove the containers.  False to just stop them.
     """
     client = docker.from_env()
+    client = client if not hasattr(client, 'api') else client.api
     keys = ImageList.keys()
     keys.reverse()
     for key in keys:
@@ -514,6 +518,7 @@ def images_build(retry=False, names=None):
     """
     basepath = os.path.dirname(os.path.realpath(__file__))
     client = docker.from_env()
+    client = client if not hasattr(client, 'api') else client.api
 
     if names is None:
         names = ImageList.keys()
@@ -555,6 +560,7 @@ def images_repull(**kwargs):
     Repull all docker images.
     """
     client = docker.from_env()
+    client = client if not hasattr(client, 'api') else client.api
     for key, image in six.iteritems(ImageList):
         if 'name' not in image and not kwargs.get('cli'):
             continue

--- a/ansible/deploy_docker.py
+++ b/ansible/deploy_docker.py
@@ -74,8 +74,7 @@ def containers_provision(**kwargs):
     """
     Provision or reprovision the containers.
     """
-    client = docker.from_env(version='auto')
-    client = client if not hasattr(client, 'api') else client.api
+    client = docker_client()
     ctn = get_docker_image_and_container(
         client, 'histomicstk', version=kwargs.get('pinned'))
 
@@ -145,8 +144,7 @@ def containers_start(port=8080, rmq='docker', mongo='docker', provision=False,
     :param provision: if True, reprovision after starting.  Otherwise, only
         provision if the histomictk container is created.
     """
-    client = docker.from_env(version='auto')
-    client = client if not hasattr(client, 'api') else client.api
+    client = docker_client()
     env = {}
     started = False
 
@@ -385,8 +383,7 @@ def containers_status(**kwargs):
     """"
     Report the status of any containers we are responsible for.
     """
-    client = docker.from_env(version='auto')
-    client = client if not hasattr(client, 'api') else client.api
+    client = docker_client()
 
     keys = ImageList.keys()
     results = []
@@ -415,8 +412,7 @@ def containers_stop(remove=False, **kwargs):
 
     :param remove: True to remove the containers.  False to just stop them.
     """
-    client = docker.from_env(version='auto')
-    client = client if not hasattr(client, 'api') else client.api
+    client = docker_client()
     keys = ImageList.keys()
     keys.reverse()
     for key in keys:
@@ -431,6 +427,16 @@ def containers_stop(remove=False, **kwargs):
 
     if remove:
         network_remove(client, BaseName)
+
+
+def docker_client():
+    """
+    Return the current docker client in a manner that works with both the
+    docker-py and docker modules.
+    """
+    client = docker.from_env(version='auto')
+    client = client if not hasattr(client, 'api') else client.api
+    return client
 
 
 def docker_mounts():
@@ -517,8 +523,7 @@ def images_build(retry=False, names=None):
         names to build.
     """
     basepath = os.path.dirname(os.path.realpath(__file__))
-    client = docker.from_env(version='auto')
-    client = client if not hasattr(client, 'api') else client.api
+    client = docker_client()
 
     if names is None:
         names = ImageList.keys()
@@ -559,8 +564,7 @@ def images_repull(**kwargs):
     """"
     Repull all docker images.
     """
-    client = docker.from_env(version='auto')
-    client = client if not hasattr(client, 'api') else client.api
+    client = docker_client()
     for key, image in six.iteritems(ImageList):
         if 'name' not in image and not kwargs.get('cli'):
             continue

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,15 @@
+comment: false
+coverage:
+  status:
+    # We have some variation in tests due to variations in the test runs.  We
+    # want to ignore these changes, but not let code coverage slip too much.
+    project:
+      default:
+        threshold: 1
+    # This applies to the changed code.  We allow it to be much less covered
+    # than the main code, since we use the project threshold for that.
+    patch:
+      default:
+        threshold: 25
+        only_pulls: true
+

--- a/plugin.cmake
+++ b/plugin.cmake
@@ -14,6 +14,9 @@
 #  limitations under the License.
 ###############################################################################
 
+# This gets us basic linting tests
+add_standard_plugin_tests(NO_CLIENT_TESTS NO_SERVER_TESTS)
+
 function(add_histomicstk_python_test case)
   add_python_test("${case}" PLUGIN HistomicsTK
     COVERAGE_PATHS "${PROJECT_SOURCE_DIR}/plugins/HistomicsTK/histomicstk"
@@ -22,11 +25,9 @@ function(add_histomicstk_python_test case)
 endfunction()
 
 # style tests
-add_python_style_test(
-  python_static_analysis_HistomicsTK_plugins
-  "${PROJECT_SOURCE_DIR}/plugins/HistomicsTK/server"
-)
 
+# We have to add the python tests and static analysis of them manually, since
+# the standard plugin tests don't handle external data
 add_python_style_test(
   python_static_analysis_HistomicsTK_tests
   "${PROJECT_SOURCE_DIR}/plugins/HistomicsTK/plugin_tests"
@@ -41,6 +42,8 @@ add_python_style_test(
 add_histomicstk_python_test(docker)
 
 add_histomicstk_python_test(example)
+
+add_histomicstk_python_test(annotation_handler)
 
 add_histomicstk_python_test(import_package)
 
@@ -137,12 +140,6 @@ add_web_client_test(
   PLUGIN HistomicsTK
   TEST_MODULE "plugin_tests.web_client_test"
   # EXTERNAL_DATA "plugins/HistomicsTK/sample_svs_image.TCGA-DU-6399-01A-01-TS1.e8eb65de-d63e-42db-af6f-14fefbbdf7bd.svs"
-)
-
-add_eslint_test(
-  js_static_analysis_HistomicsTK "${PROJECT_SOURCE_DIR}/plugins/HistomicsTK/web_client"
-  ESLINT_CONFIG_FILE "${PROJECT_SOURCE_DIR}/plugins/HistomicsTK/.eslintrc"
-  ESLINT_IGNORE_FILE "${PROJECT_SOURCE_DIR}/plugins/HistomicsTK/.eslintignore"
 )
 
 add_eslint_test(

--- a/plugin_tests/annotation_handler_test.py
+++ b/plugin_tests/annotation_handler_test.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+#############################################################################
+#  Copyright Kitware Inc.
+#
+#  Licensed under the Apache License, Version 2.0 ( the "License" );
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#############################################################################
+
+# This is to serve as an example for how to create a server-side test in a
+# girder plugin, it is not meant to be useful.
+
+import json
+
+from girder import events
+
+from tests import base
+
+
+# boiler plate to start and stop the server
+def setUpModule():
+    base.enabledPlugins.append('HistomicsTK')
+    base.startServer()
+
+
+def tearDownModule():
+    base.stopServer()
+
+
+class AnnotationHandlerTest(base.TestCase):
+
+    def testHandleAnntation(self):
+        admin = self.model('user').findOne({'login': 'admin'})
+        item = self.model('item').findOne({'name': 'Item 1'})
+        file1 = self.model('file').findOne({'name': 'File 1'})
+        file2 = self.model('file').findOne({'name': 'File 2'})
+        file3 = self.model('file').findOne({'name': 'File 3'})
+        file4 = self.model('file').findOne({'name': 'File 4'})
+        assetstore = self.model('assetstore').load(id=file1['assetstoreId'])
+        annot = list(self.model('annotation', 'large_image').find({'itemId': item['_id']}))
+        self.assertEqual(len(annot), 0)
+
+        # Process a list of annotations
+        events.trigger('data.process', {
+            'file': file1,
+            'assetstore': assetstore,
+            'reference': json.dumps({
+                'identifier': 'sampleAnnotationFile',
+                'itemId': str(file1['_id']),
+                'userId': str(admin['_id']),
+            })
+        })
+        annot = list(self.model('annotation', 'large_image').find({'itemId': item['_id']}))
+        self.assertEqual(len(annot), 2)
+
+        # If the reference doesn't contain userId or itemId, we won't add any
+        # annotations
+        events.trigger('data.process', {
+            'file': file1,
+            'assetstore': assetstore,
+            'reference': json.dumps({
+                'identifier': 'sampleAnnotationFile',
+                'userId': str(admin['_id']),
+            })
+        })
+        annot = list(self.model('annotation', 'large_image').find({'itemId': item['_id']}))
+        self.assertEqual(len(annot), 2)
+        events.trigger('data.process', {
+            'file': file1,
+            'assetstore': assetstore,
+            'reference': json.dumps({
+                'identifier': 'sampleAnnotationFile',
+                'itemId': str(file1['_id']),
+            })
+        })
+        annot = list(self.model('annotation', 'large_image').find({'itemId': item['_id']}))
+        self.assertEqual(len(annot), 2)
+
+        # If the user id isn't valid, we won't add an annotation
+        events.trigger('data.process', {
+            'file': file1,
+            'assetstore': assetstore,
+            'reference': json.dumps({
+                'identifier': 'sampleAnnotationFile',
+                'itemId': str(file1['_id']),
+                'userId': str(item['_id']),  # this is not a user
+            })
+        })
+        annot = list(self.model('annotation', 'large_image').find({'itemId': item['_id']}))
+        self.assertEqual(len(annot), 2)
+
+        # Process a single annotation
+        events.trigger('data.process', {
+            'file': file2,
+            'assetstore': assetstore,
+            'reference': json.dumps({
+                'identifier': 'sampleAnnotationFile',
+                'itemId': str(file2['_id']),
+                'userId': str(admin['_id']),
+            })
+        })
+        annot = list(self.model('annotation', 'large_image').find({'itemId': item['_id']}))
+        self.assertEqual(len(annot), 3)
+
+        # A file that isn't json shouldn't throw an error or add anything
+        with self.assertRaises(ValueError):
+            events.trigger('data.process', {
+                'file': file3,
+                'assetstore': assetstore,
+                'reference': json.dumps({
+                    'identifier': 'sampleAnnotationFile',
+                    'itemId': str(file3['_id']),
+                    'userId': str(admin['_id']),
+                })
+            })
+        annot = list(self.model('annotation', 'large_image').find({'itemId': item['_id']}))
+        self.assertEqual(len(annot), 3)
+
+        # A json file that isn't an annotation shouldn't add anything either
+        with self.assertRaises(AttributeError):
+            events.trigger('data.process', {
+                'file': file4,
+                'assetstore': assetstore,
+                'reference': json.dumps({
+                    'identifier': 'sampleAnnotationFile',
+                    'itemId': str(file4['_id']),
+                    'userId': str(admin['_id']),
+                })
+            })
+        annot = list(self.model('annotation', 'large_image').find({'itemId': item['_id']}))
+        self.assertEqual(len(annot), 3)

--- a/plugin_tests/annotation_handler_test.yml
+++ b/plugin_tests/annotation_handler_test.yml
@@ -1,0 +1,24 @@
+---
+users:
+  - login: 'admin'
+    email: 'admin@email.com'
+    firstName: 'Admin'
+    lastName: 'Last'
+    password: 'adminpassword'
+    admin: true
+    defaultFolders: true
+    folders:
+      - name: 'Additional folder'
+        public: true
+        items:
+          - name: 'Item 1'
+            files:
+              - name: 'File 1'
+                path: 'test_files/annotation1.json'
+              - name: 'File 2'
+                path: 'test_files/annotation2.json'
+              - name: 'File 3'
+                path: 'test_files/annotation_bad1.txt'
+              - name: 'File 4'
+                path: 'test_files/annotation_bad2.json'
+

--- a/plugin_tests/test_files/annotation1.json
+++ b/plugin_tests/test_files/annotation1.json
@@ -1,0 +1,47 @@
+[
+  {
+    "elements": [
+      {
+        "points": [
+          [
+            7954.0,
+            11424.0,
+            0.0
+          ],
+          [
+            7954.0,
+            11424.0,
+            0.0
+          ]
+        ],
+        "type": "polyline",
+        "fillColor": "rgba(0,0,0,0)",
+        "closed": true
+      }
+    ],
+    "name": "classify-170630a-nuclei-class-0"
+  },
+  {
+    "elements": [
+      {
+        "lineColor": "rgb(255,54,0)",
+        "points": [
+          [
+            8382.0,
+            11422.0,
+            0.0
+          ],
+          [
+            8954.0,
+            12803.0,
+            0.0
+          ]
+        ],
+        "type": "polyline",
+        "fillColor": "rgba(0,0,0,0)",
+        "closed": true
+      }
+    ],
+    "name": "classify-170630a-nuclei-class-1"
+  }
+]

--- a/plugin_tests/test_files/annotation2.json
+++ b/plugin_tests/test_files/annotation2.json
@@ -1,0 +1,23 @@
+{
+  "elements": [
+    {
+      "lineColor": "rgb(255,54,0)",
+      "points": [
+        [
+          8382.0,
+          11422.0,
+          0.0
+        ],
+        [
+          8954.0,
+          12803.0,
+          0.0
+        ]
+      ],
+      "type": "polyline",
+      "fillColor": "rgba(0,0,0,0)",
+      "closed": true
+    }
+  ],
+  "name": "classify-170630a-nuclei-class-1"
+}

--- a/plugin_tests/test_files/annotation_bad1.txt
+++ b/plugin_tests/test_files/annotation_bad1.txt
@@ -1,0 +1,1 @@
+This is not json

--- a/plugin_tests/test_files/annotation_bad2.json
+++ b/plugin_tests/test_files/annotation_bad2.json
@@ -1,0 +1,1 @@
+["This is not an annotation"]

--- a/server/handlers.py
+++ b/server/handlers.py
@@ -1,4 +1,5 @@
 import json
+import six
 
 from girder.constants import AccessType
 from girder.utility.model_importer import ModelImporter
@@ -8,22 +9,19 @@ from girder import logger
 def process_annotations(event):
     """Add annotations to an image on a ``data.process`` event"""
     info = event.info
-    if 'anot' in info.get('file', {}).get('exts', []):
-        reference = info.get('reference', None)
-
+    identifier = None
+    reference = info.get('reference', None)
+    if reference is not None:
         try:
             reference = json.loads(reference)
+            if (isinstance(reference, dict) and
+                    isinstance(reference.get('identifier'), six.string_types)):
+                identifier = reference['identifier']
         except (ValueError, TypeError):
-            logger.error(
-                'Warning: Could not get reference from the annotation param. '
-                'Make sure you have at least ctk-cli>=1.4.1 installed.'
-            )
-            raise
-
+            logger.warning('Failed to parse data.process reference: %r', reference)
+    if identifier is not None and identifier.endswith('AnnotationFile'):
         if 'userId' not in reference or 'itemId' not in reference:
-            logger.error(
-                'Annotation reference does not contain required information.'
-            )
+            logger.error('Annotation reference does not contain required information.')
             return
 
         userId = reference['userId']
@@ -45,29 +43,20 @@ def process_annotations(event):
         )
 
         if not (item and user and file):
-            logger.error(
-                'Could not load models from the database'
-            )
+            logger.error('Could not load models from the database')
             return
 
         try:
-            data = json.loads(
-                ''.join(File.download(file)())
-            )
+            data = json.loads(''.join(File.download(file)()))
         except Exception:
-            logger.error(
-                'Could not parse annotation file'
-            )
+            logger.error('Could not parse annotation file')
             raise
 
-        try:
-            Annotation.createAnnotation(
-                item,
-                user,
-                data
-            )
-        except Exception:
-            logger.error(
-                'Could not create annotation object from data'
-            )
-            raise
+        if not isinstance(data, list):
+            data = [data]
+        for annotation in data:
+            try:
+                Annotation.createAnnotation(item, user, annotation)
+            except Exception:
+                logger.error('Could not create annotation object from data')
+                raise

--- a/web_client/stylesheets/body/frontPage.styl
+++ b/web_client/stylesheets/body/frontPage.styl
@@ -3,7 +3,7 @@
   background-color white
 
 .h-frontpage-section
-  padding 80px 18% 100px 18%
+  padding 80px 18% 100px
   text-align center
 
   .h-big-icon-container

--- a/web_client/stylesheets/body/image.styl
+++ b/web_client/stylesheets/body/image.styl
@@ -12,14 +12,14 @@
       width 100%
 
     .h-image-view-container:focus
-      border 0
+      border none
 
     .h-image-coordinates-container
       position absolute
       right 0
       bottom 0
       background #eee
-      padding 0px 3px
+      padding 0 3px
       border-radius 3px
 
   .h-control-panel-container
@@ -27,7 +27,7 @@
     overflow-y auto
 
     .h-control-panel.s-panel-group
-      background-color rgba(255,255,255,0.5)
+      background-color rgba(255, 255, 255, 0.5)
       border 1px solid black
       border-radius 5px
 
@@ -37,4 +37,3 @@
 
     .s-panel
       margin-right 5px
-

--- a/web_client/stylesheets/layout/layout.styl
+++ b/web_client/stylesheets/layout/layout.styl
@@ -1,5 +1,3 @@
-@import '~nib/index.styl'
-
 $headerHeight = 52px
 
 body.histomicstk-body
@@ -34,10 +32,6 @@ body.histomicstk-body
   .h-user-link-wrapper
     display inline-block
 
-  .h-current-user-text > *
-    vertical-align middle
-    line-height $headerHeight
-
   .h-current-user-wrapper
     float right
 
@@ -65,5 +59,5 @@ body.histomicstk-body
   margin 0
   margin-top $headerHeight
   min-height 0
-  padding 0px 0px
+  padding 0
   overflow hidden

--- a/web_client/templates/layout/headerAnalyses.pug
+++ b/web_client/templates/layout/headerAnalyses.pug
@@ -3,19 +3,19 @@ a.h-analyses-dropdown-link(data-toggle='dropdown')
 ul.h-analyses-dropdown.dropdown-menu(role='menu')
   each image, imageName in analyses
     li.dropdown-submenu
-      a(tabindex='0' href='#' data-name=imageName) #{imageName}
+      a(tabindex='0', href='#', data-name=imageName) #{imageName}
       ul.dropdown-menu
         each version, versionName in image
           li.dropdown-submenu
-            a(tabindex='0' href='#') #{versionName}
+            a(tabindex='0', href='#') #{versionName}
             ul.dropdown-menu
               each cli, cliName in version
                 - var api = cli.run.replace(/\/run$/, '');
                 li
                   a.h-analysis-item(
-                    tabindex='0',
-                    href='#',
-                    data-api=api,
-                    data-image=imageName,
-                    data-version=versionName,
-                    data-cli=cliName) #{cliName}
+                      tabindex='0',
+                      href='#',
+                      data-api=api,
+                      data-image=imageName,
+                      data-version=versionName,
+                      data-cli=cliName) #{cliName}

--- a/web_client/templates/panels/annotationSelector.pug
+++ b/web_client/templates/panels/annotationSelector.pug
@@ -18,8 +18,8 @@ block content
 
       span.h-annotation-right
         a(href=annotation.downloadUrl().replace(/\/download$/, ''),
-          download=name + '.json')
+            download=name + '.json')
           span.icon-download.h-download-annotation(
-            data-toggle='tooltip', title='Download annotation')
+              data-toggle='tooltip', title='Download annotation')
         span.icon-cancel.h-delete-annotation(
-          data-toggle='tooltip', title='Remove annotation')
+            data-toggle='tooltip', title='Remove annotation')

--- a/web_client/templates/panels/regionSelector.pug
+++ b/web_client/templates/panels/regionSelector.pug
@@ -1,7 +1,7 @@
 extends ./panel.pug
 
 block content
-  input.h-region-value.form-control(type="text" readonly)
+  input.h-region-value.form-control(type="text", readonly)
   .btn-group.btn-group-justified(role="group")
     .btn-group(role="group")
       button.h-select-region-button.btn.btn-primary(type="button") Select


### PR DESCRIPTION
This now works with any version of the docker or docker-py module >= 1.9, including version 2.x.  The documentation has been changed to prefer the newer version.

This resolves #354 (and allows either version to be used).