### PR TITLE
Long annotation names wrapped oddly.

### DIFF
--- a/web_client/stylesheets/panels/annotationSelector.styl
+++ b/web_client/stylesheets/panels/annotationSelector.styl
@@ -3,13 +3,19 @@
         cursor pointer
     .h-toggle-annotation
         float left
-        margin-right 1em
+        margin-right 0.5em
 
     .h-annotation-right
         float right
 
     a
         color #333
+    .h-annotation-name
+        width 195px
+        display inline-block
+        text-overflow ellipsis
+        white-space nowrap
+        overflow hidden
 
 .h-annotation:hover
     background-color #eee

--- a/web_client/templates/panels/annotationSelector.pug
+++ b/web_client/templates/panels/annotationSelector.pug
@@ -14,7 +14,7 @@ block content
       else
         span.icon-eye-off.h-toggle-annotation(
           data-toggle='tooltip', title='Show annotation')
-      span.h-annotation-name #{name}
+      span.h-annotation-name(title=name) #{name}
 
       span.h-annotation-right
         a(href=annotation.downloadUrl().replace(/\/download$/, ''),


### PR DESCRIPTION
Truncate long annotation names with ellipses and add a title (tooltip) to show the whole name.