### PR TITLE
Make drawing tools stay active.

### DIFF
--- a/plugin_tests/client/annotationSpec.js
+++ b/plugin_tests/client/annotationSpec.js
@@ -131,7 +131,13 @@ $(function () {
                 }, 'point to be created');
                 runs(function () {
                     expect($('.h-elements-container .h-element .h-element-label').text()).toBe('point');
+                    expect($('.h-draw[data-type="point"]').hasClass('active')).toBe(true);
+                    // turn off point drawing.
+                    $('.h-draw[data-type="point"]').click();
                 });
+                waitsFor(function () {
+                    return !$('.h-draw[data-type="point"]').hasClass('active');
+                }, 'point drawing to be off');
             });
 
             it('edit a point element', function () {

--- a/web_client/panels/DrawWidget.js
+++ b/web_client/panels/DrawWidget.js
@@ -117,6 +117,7 @@ var DrawWidget = Panel.extend({
         var $el;
         if (evt) {
             $el = this.$(evt.currentTarget);
+            $el.tooltip('hide');
             type = $el.hasClass('active') ? null : $el.data('type');
         } else {
             $el = this.$('button.h-draw[data-type="' + type + '"]');

--- a/web_client/templates/panels/drawWidget.pug
+++ b/web_client/templates/panels/drawWidget.pug
@@ -7,19 +7,19 @@ block content
   .btn-group.btn-justified.btn-group-sm.h-draw-tools
     .btn-group.btn-group-sm
       button.h-draw.btn.btn-default(
-        type='button', data-type='point', data-toggle='tooltip', title='Draw a new point')
+        type='button', data-type='point', data-toggle='tooltip', title='Draw a new point', class=drawingType === 'point' ? 'active' : null)
         | #[span.icon-circle-empty]Point
     .btn-group.btn-group-sm
       button.h-draw.btn.btn-default(
-        type='button', data-type='rectangle', data-toggle='tooltip', title='Draw a new rectangle')
+        type='button', data-type='rectangle', data-toggle='tooltip', title='Draw a new rectangle', class=drawingType === 'rectangle' ? 'active' : null)
         | #[span.icon-check-empty]Rectangle
     .btn-group.btn-group-sm
       button.h-draw.btn.btn-default(
-        type='button', data-type='polygon', data-toggle='tooltip', title='Draw a new polygon')
+        type='button', data-type='polygon', data-toggle='tooltip', title='Draw a new polygon', class=drawingType === 'polygon' ? 'active' : null)
         | #[span.icon-star-empty]Polygon
     .btn-group.btn-group-sm
       button.h-draw.btn.btn-default(
-        type='button', data-type='line', data-toggle='tooltip', title='Draw a new line')
+        type='button', data-type='line', data-toggle='tooltip', title='Draw a new line', class=drawingType === 'line' ? 'active' : null)
         | #[span.icon-pencil]Line
 
   if elements.length


### PR DESCRIPTION
After drawing an annotation, stay in the drawing mode until the drawing button is clicked again.