### PR TITLE
Increase the width of the right panel

### DIFF
--- a/web_client/stylesheets/body/image.styl
+++ b/web_client/stylesheets/body/image.styl
@@ -34,6 +34,7 @@
   #h-annotation-selector-container
     right 0
     overflow-y auto
+    width 300px
 
     .s-panel
       margin-right 5px


### PR DESCRIPTION
This prevents undesired wrapping of the panel content when a scrollbar appears due to overflowing the window height.