### PR TITLE
Fix ansible for vagrant up.

### DIFF
--- a/ansible/deploy_local.yml
+++ b/ansible/deploy_local.yml
@@ -11,7 +11,7 @@
       girder_version: "master"
       # We build the girder web assets in girder-histomicstk
       girder_web: no
-      become: yes
+      become: true
       become_user: "{{ girder_exec_user }}"
     - girder-histomicstk
     - provision

--- a/ansible/docker_ansible.yml
+++ b/ansible/docker_ansible.yml
@@ -21,7 +21,7 @@
       girder_version: "master"
       girder_web: no
       girder_daemonize: no
-      become: yes
+      become: true
       become_user: "{{ girder_exec_user }}"
       tags: girder
       when:

--- a/ansible/roles/mq/tasks/main.yml
+++ b/ansible/roles/mq/tasks/main.yml
@@ -1,8 +1,8 @@
 ---
 - name: Install rabbitmq system package
-  sudo: yes
+  become: true
   apt: update-cache=yes name=rabbitmq-server state=present
 
 - name: Enable rabbitmq-server to survive reboot
-  sudo: yes
+  become: true
   service: name=rabbitmq-server enabled=yes

--- a/ansible/vagrant.yml
+++ b/ansible/vagrant.yml
@@ -11,7 +11,7 @@
       girder_version: "master"
       # We build the girder web assets in girder-histomicstk
       girder_web: no
-      become: yes
+      become: true
       become_user: "{{ girder_exec_user }}"
     - girder-histomicstk
     - provision
@@ -48,7 +48,7 @@
         python setup.py develop
       args:
         chdir: "{{ root_dir }}/HistomicsTK"
-      become: yes
+      become: true
 
     - name: Set up build environment (1/2)
       command: >-


### PR DESCRIPTION
The latest version of ansible invoked when doing a `vagrant up` on Windows fails if privilege escalation is done with `sudo` rather than `become`.

Ansible deprecated `sudo`.  They claim it is still available, but it isn't working for me.

Also, use `become: true` consistently rather than `become: yes` in some places.