### PR TITLE
Update the pinned versions of the docker images.

### DIFF
--- a/ansible/deploy_docker.py
+++ b/ansible/deploy_docker.py
@@ -32,18 +32,18 @@ ImageList = collections.OrderedDict([
         'tag': 'dsarchive/girder_worker',
         'name': 'histomicstk_girder_worker',
         'dockerfile': 'Dockerfile-girder-worker',
-        'pinned': 'v0.1.3',
+        'pinned': 'v0.1.5',
     }),
     ('histomicstk', {
         'tag': 'dsarchive/histomicstk_main',
         'name': 'histomicstk_histomicstk',
         'dockerfile': 'Dockerfile-histomicstk',
-        'pinned': 'v0.1.3',
+        'pinned': 'v0.1.5',
     }),
     ('cli', {
         'tag': 'dsarchive/histomicstk',
         'pull': True,
-        'pinned': 'v0.1.5',
+        'pinned': 'v0.1.6',
     }),
 ])
 


### PR DESCRIPTION
The older versions don't play well with the changes made to handle docker ID issues.