### PR TITLE
Add the ability to generate and use predefined styles

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -8,7 +8,8 @@
     },
     "npm": {
         "dependencies": {
-            "bootstrap-submenu": "^2.0.4"
+            "bootstrap-submenu": "^2.0.4",
+            "backbone.localstorage": "^2.0.2"
         }
     }
 }

--- a/plugin_tests/client/annotationSpec.js
+++ b/plugin_tests/client/annotationSpec.js
@@ -1,4 +1,5 @@
 girderTest.importPlugin('jobs');
+girderTest.importPlugin('worker');
 girderTest.importPlugin('large_image');
 girderTest.importPlugin('slicer_cli_web');
 girderTest.importPlugin('HistomicsTK');
@@ -415,6 +416,72 @@ $(function () {
             girderTest.waitForLoad();
             runs(function () {
                 expect(girder.plugins.HistomicsTK.router.getQuery('image')).toBe(imageId);
+            });
+        });
+    });
+
+    describe('Annotation styles', function () {
+        it('open the syle group dialog', function () {
+            openImage('copy');
+            runs(function () {
+                $('.h-configure-style-group').click();
+            });
+            waitsFor(function () {
+                return $('body.modal-open').length > 0;
+            }, 'dialog to open');
+            runs(function () {
+                // ensure the default style is created on load
+                expect($('.h-style-selector :selected').val()).toBe('default');
+            });
+        });
+
+        it('create a new style group', function () {
+            $('.h-create-new-style').click();
+            $('.h-new-style-name').val('new');
+            $('.h-save-new-style').click();
+            expect($('.h-style-selector :selected').val()).toBe('new');
+
+            $('#h-element-line-width').val(1).trigger('change');
+            $('#h-element-line-color').val('rgb(255,0,0)').trigger('change');
+            $('#h-element-fill-color').val('rgb(0,0,255)').trigger('change');
+            $('.h-submit').click();
+
+            waitsFor(function () {
+                return $('body.modal-open').length === 0;
+            }, 'dialog to close');
+        });
+
+        it('draw a point', function () {
+            runs(function () {
+                $('.h-draw[data-type="point"]').removeClass('active').click();
+            });
+
+            waitsFor(function () {
+                return $('.geojs-map.annotation-input').length > 0;
+            }, 'draw mode to activate');
+            runs(function () {
+                var interactor = geojsMap.interactor();
+
+                interactor.simulateEvent('mousedown', {
+                    map: {x: 200, y: 200},
+                    button: 'left'
+                });
+                interactor.simulateEvent('mouseup', {
+                    map: {x: 200, y: 200},
+                    button: 'left'
+                });
+            });
+            waitsFor(function () {
+                return app.bodyView.drawWidget.collection.length > 0;
+            });
+            runs(function () {
+                var elements = app.bodyView.drawWidget.collection;
+                expect(elements.length).toBe(1);
+
+                var point = elements.at(0);
+                expect(point.get('lineWidth')).toBe(1);
+                expect(point.get('lineColor')).toBe('rgb(255, 0, 0)');
+                expect(point.get('fillColor')).toBe('rgb(0, 0, 255)');
             });
         });
     });

--- a/web_client/collections/StyleCollection.js
+++ b/web_client/collections/StyleCollection.js
@@ -1,0 +1,11 @@
+import Backbone from 'backbone';
+import { LocalStorage } from 'backbone.localstorage';
+
+import StyleModel from '../models/StyleModel';
+
+const StyleCollection = Backbone.Collection.extend({
+    model: StyleModel,
+    localStorage: new LocalStorage('histomicstk.draw.style')
+});
+
+export default StyleCollection;

--- a/web_client/collections/index.js
+++ b/web_client/collections/index.js
@@ -1,0 +1,5 @@
+import StyleCollection from './StyleCollection';
+
+export {
+    StyleCollection
+};

--- a/web_client/dialogs/editStyleGroups.js
+++ b/web_client/dialogs/editStyleGroups.js
@@ -1,0 +1,167 @@
+import tinycolor from 'tinycolor2';
+
+import View from 'girder/views/View';
+
+import StyleModel from '../models/StyleModel';
+import editStyleGroups from '../templates/dialogs/editStyleGroups.pug';
+import 'girder/utilities/jquery/girderModal';
+import '../stylesheets/dialogs/editStyleGroups.styl';
+
+/**
+ * Create a modal dialog with fields to edit and create annotation
+ * style groups.
+ */
+const EditStyleGroups = View.extend({
+    events: {
+        'click .h-create-new-style': '_createNewStyle',
+        'click .h-save-new-style': '_saveNewStyle',
+        'change .h-style-def': '_updateStyle',
+        'changeColor .h-colorpicker': '_updateStyle',
+        'change select': '_setStyle'
+    },
+
+    initialize() {
+        this.listenTo(this.model, 'change', this.render);
+        this.listenTo(this.collection, 'update', this.render);
+    },
+
+    render() {
+        this.$('.h-colorpicker').colorpicker('destroy');
+        this.$el.html(
+            editStyleGroups({
+                collection: this.collection,
+                model: this.model,
+                newStyle: this._newStyle
+            })
+        );
+        this.$('.h-colorpicker').colorpicker();
+        return this;
+    },
+
+    _setStyle(evt) {
+        evt.preventDefault();
+        this.model.set(
+            this.collection.get(this.$('.h-style-selector').val()).toJSON()
+        );
+        this.render();
+    },
+
+    _updateStyle(evt) {
+        evt.preventDefault();
+
+        const data = {};
+        const label = this.$('#h-element-label').val();
+        let validation = '';
+
+        data.id = this.$('.h-style-selector :selected').val() || this.$('.h-new-style-name').val();
+        if (!data.id) {
+            validation += 'A style name is required';
+            this.$('.h-new-style-name').parent().addClass('has-error');
+        }
+
+        if (label) {
+            data.label = {
+                value: label
+            };
+        }
+
+        const lineWidth = this.$('#h-element-line-width').val();
+        if (lineWidth) {
+            data.lineWidth = parseFloat(lineWidth);
+            if (data.lineWidth < 0 || !isFinite(data.lineWidth)) {
+                validation += 'Invalid line width. ';
+                this.$('#h-element-line-width').parent().addClass('has-error');
+            }
+        }
+
+        const lineColor = this.$('#h-element-line-color').val();
+        if (lineColor) {
+            data.lineColor = this.convertColor(lineColor);
+        }
+
+        const fillColor = this.$('#h-element-fill-color').val();
+        if (fillColor) {
+            data.fillColor = this.convertColor(fillColor);
+        }
+
+        if (validation) {
+            this.$('.g-validation-failed-message').text(validation)
+                .removeClass('hidden');
+        }
+
+        this.model.set(data);
+    },
+
+    /**
+     * A helper function converting a string into normalized rgb/rgba
+     * color value.  If no value is given, then it returns a color
+     * with opacity 0.
+     */
+    convertColor(val) {
+        if (!val) {
+            return 'rgba(0,0,0,0)';
+        }
+        return tinycolor(val).toRgbString();
+    },
+
+    _createNewStyle(evt) {
+        evt.preventDefault();
+        this._newStyle = true;
+        this.render();
+    },
+
+    _saveNewStyle(evt) {
+        this._updateStyle(evt);
+        this._newStyle = false;
+        this.collection.create(this.model.toJSON());
+        this.render();
+    }
+});
+
+const EditStyleGroupsDialog = View.extend({
+    events: {
+        'click .h-submit': '_submit'
+    },
+
+    initialize() {
+        this.form = new EditStyleGroups({
+            parentView: this,
+            model: new StyleModel(this.model.toJSON()),
+            collection: this.collection
+        });
+    },
+
+    render() {
+        this.$el.html('<div class="h-style-editor"/>');
+        this.form.setElement(this.$('.h-style-editor')).render();
+        this.$el.girderModal(this);
+        return this;
+    },
+
+    _submit(evt) {
+        evt.preventDefault();
+        this.model.set(this.form.model.toJSON());
+        this.collection.add(this.form.model.toJSON(), {merge: true});
+        this.collection.get(this.model.id).save();
+        this.$el.modal('hide');
+    }
+});
+
+/**
+ * Show the edit dialog box.  Watch for change events on the passed
+ * `ElementModel` to respond to user submission of the form.
+ *
+ * @param {StyleGroupCollection} collection
+ * @returns {EditStyleGroup} The dialog's view
+ */
+function show(style, groups) {
+    const dialog = new EditStyleGroupsDialog({
+        parentView: null,
+        collection: groups,
+        model: style,
+        el: $('#g-dialog-container')
+    });
+    return dialog.render();
+}
+
+export default show;

--- a/web_client/dialogs/editStyleGroups.js
+++ b/web_client/dialogs/editStyleGroups.js
@@ -20,11 +20,6 @@ const EditStyleGroups = View.extend({
         'change select': '_setStyle'
     },
 
-    initialize() {
-        this.listenTo(this.model, 'change', this.render);
-        this.listenTo(this.collection, 'update', this.render);
-    },
-
     render() {
         this.$('.h-colorpicker').colorpicker('destroy');
         this.$el.html(

--- a/web_client/dialogs/editStyleGroups.js
+++ b/web_client/dialogs/editStyleGroups.js
@@ -58,6 +58,8 @@ const EditStyleGroups = View.extend({
             data.label = {
                 value: label
             };
+        } else {
+            data.label = {};
         }
 
         const lineWidth = this.$('#h-element-line-width').val();

--- a/web_client/index.js
+++ b/web_client/index.js
@@ -1,15 +1,20 @@
 import App from './app.js';
-import * as views from './views';
-import * as dialogs from './dialogs';
-import * as panels from './panels';
 import router from './router';
 import events from './events';
 
+import * as collections from './collections';
+import * as dialogs from './dialogs';
+import * as models from './models';
+import * as panels from './panels';
+import * as views from './views';
+
 export {
     App,
-    views,
-    dialogs,
     router,
     events,
-    panels
+    collections,
+    dialogs,
+    models,
+    panels,
+    views
 };

--- a/web_client/models/StyleModel.js
+++ b/web_client/models/StyleModel.js
@@ -1,0 +1,11 @@
+import Backbone from 'backbone';
+
+const StyleModel = Backbone.Model.extend({
+    defaults: {
+        lineWidth: 2,
+        lineColor: 'rgb(0,0,0)',
+        fillColor: 'rgba(0,0,0,0)'
+    }
+});
+
+export default StyleModel;

--- a/web_client/models/index.js
+++ b/web_client/models/index.js
@@ -1,0 +1,5 @@
+import StyleModel from './StyleModel';
+
+export {
+    StyleModel
+};

--- a/web_client/panels/DrawWidget.js
+++ b/web_client/panels/DrawWidget.js
@@ -5,7 +5,10 @@ import events from 'girder/events';
 import AnnotationModel from 'girder_plugins/large_image/models/AnnotationModel';
 import Panel from 'girder_plugins/slicer_cli_web/views/Panel';
 
+import StyleCollection from '../collections/StyleCollection';
+import StyleModel from '../models/StyleModel';
 import editAnnotation from '../dialogs/editAnnotation';
+import editStyleGroups from '../dialogs/editStyleGroups';
 import saveAnnotation from '../dialogs/saveAnnotation';
 import drawWidget from '../templates/panels/drawWidget.pug';
 import '../stylesheets/panels/drawWidget.styl';
@@ -19,7 +22,9 @@ var DrawWidget = Panel.extend({
         'click .h-save-annotation': 'saveAnnotation',
         'click .h-edit-element': 'editElement',
         'click .h-delete-element': 'deleteElement',
-        'click .h-draw': 'drawElement'
+        'click .h-draw': 'drawElement',
+        'change .h-style-group': '_setStyleGroup',
+        'click .h-configure-style-group': '_styleGroupEditor'
     }),
 
     /**
@@ -37,6 +42,19 @@ var DrawWidget = Panel.extend({
         this.collection = this.annotation.elements();
         this.listenTo(this.collection, 'add remove change reset', this._onCollectionChange);
         this._drawingType = null;
+
+        this._groups = new StyleCollection();
+        this._style = new StyleModel({id: 'default'});
+        this.listenTo(this._groups, 'update', this.render);
+        this._groups.fetch().done(() => {
+            // ensure the default style exists
+            if (this._groups.has('default')) {
+                this._style.set(this._groups.get('default').toJSON());
+            } else {
+                this._groups.add(this._style.toJSON());
+                this._groups.get(this._style.id).save();
+            }
+        });
     },
 
     render() {
@@ -48,7 +66,9 @@ var DrawWidget = Panel.extend({
         this.$el.html(drawWidget({
             title: 'Draw',
             elements: this.collection.toJSON(),
-            drawingType: this._drawingType
+            drawingType: this._drawingType,
+            groups: this._groups,
+            style: this._style.id
         }));
         this.$('.s-panel-content').collapse({toggle: false});
         this.$('[data-toggle="tooltip"]').tooltip({container: 'body'});
@@ -153,7 +173,12 @@ var DrawWidget = Panel.extend({
         if (type) {
             this._drawingType = type;
             this.viewer.startDrawMode(type)
-                .then((element) => this.collection.add(element));
+                .then((element) => {
+                    this.collection.add(
+                        _.map(element, (el) => _.extend(el, _.omit(this._style.toJSON(), 'id')))
+                    );
+                    return undefined;
+                });
         }
     },
 
@@ -200,6 +225,16 @@ var DrawWidget = Panel.extend({
             this.reset();
             return null;
         });
+    },
+
+    _setStyleGroup() {
+        this._style.set(
+            this._groups.get(this.$('.h-style-group').val()).toJSON()
+        );
+    },
+
+    _styleGroupEditor() {
+        editStyleGroups(this._style, this._groups);
     }
 });
 

--- a/web_client/stylesheets/dialogs/editStyleGroups.styl
+++ b/web_client/stylesheets/dialogs/editStyleGroups.styl
@@ -1,4 +1,2 @@
-@import "~nib/index.styl"
-
 select.h-style-selector
   appearance none

--- a/web_client/stylesheets/dialogs/editStyleGroups.styl
+++ b/web_client/stylesheets/dialogs/editStyleGroups.styl
@@ -1,0 +1,4 @@
+@import "~nib/index.styl"
+
+select.h-style-selector
+  appearance none

--- a/web_client/stylesheets/panels/drawWidget.styl
+++ b/web_client/stylesheets/panels/drawWidget.styl
@@ -27,3 +27,6 @@
     .btn-group-sm>.btn
       padding-left 3px
       padding-right 7px
+
+  .h-style-group-row
+    margin 10px 0

--- a/web_client/templates/dialogs/editStyleGroups.pug
+++ b/web_client/templates/dialogs/editStyleGroups.pug
@@ -1,0 +1,53 @@
+.modal-dialog(role='document')
+  .modal-content
+    form.modal-form(role='form')
+      .modal-header
+        button.close(type='button', data-dismiss='modal', aria-label='Close')
+          span(aria-hidden='true') &times;
+        h4.modal-title Edit annotation styles
+      .modal-body
+        - var label = model.get('label') || {};
+        .form-group
+          label(for='h-group-name') Name
+          if newStyle
+            .input-group
+              input.form-control.input-sm.h-new-style-name(type='text')
+              .input-group-btn
+                button.btn.btn-default.btn-sm.h-save-new-style
+                  span.icon-ok
+          else
+            .input-group
+              select.form-control.h-style-selector
+                each style in collection.sortBy('id')
+                  - var selected = model.id === style.id
+                  option(value=style.get('id'), selected=selected)
+                    = style.get('id')
+              .input-group-btn
+                button.btn.btn-default.h-create-new-style
+                  span.icon-plus(data-toggle='tooltip', title='Create a new style')
+        .form-group
+          label(for='h-element-label') Label
+          input#h-element-label.h-style-def.input-sm.form-control(
+            type='text', placeholder='Enter an optional label applied to all elements', value=label.value)
+        .form-group
+          label(for='h-element-line-width') Line width
+          input#h-element-line-width.h-style-def.input-sm.form-control(
+            type='number', min=0, step=0.1, value=model.get('lineWidth'))
+        .form-group
+          label(for='h-element-line-color') Line color
+          .input-group.h-colorpicker
+            input#h-element-line-color.input-sm.form-control(
+              type='text', value=model.get('lineColor'))
+            span.input-group-addon
+              i
+        .form-group
+          label(for='h-element-fill-color') Fill color
+          .input-group.h-colorpicker
+            input#h-element-fill-color.input-sm.form-control(
+              type='text', value=model.get('fillColor'))
+            span.input-group-addon
+              i
+        .g-validation-failed-message.hidden
+      .modal-footer
+        button.btn.btn-small.btn-default(data-dismiss='modal') Cancel
+        button.btn.btn-small.btn-primary.h-submit(type='submit') Save

--- a/web_client/templates/panels/drawWidget.pug
+++ b/web_client/templates/panels/drawWidget.pug
@@ -4,6 +4,14 @@ block title
   | #[span.icon-pencil] #{title}
 
 block content
+  .input-group.input-group-sm.h-style-group-row
+    select.form-control.h-style-group
+      each group in groups.sortBy('id')
+        option(value=group.id, selected=group.id === style)
+          = group.id
+    .input-group-btn
+      button.btn.btn-default.h-configure-style-group(type='button')
+        span.icon-cog(data-toggle='tooltip', title='Configure style group')
   .btn-group.btn-justified.btn-group-sm.h-draw-tools
     .btn-group.btn-group-sm
       button.h-draw.btn.btn-default(


### PR DESCRIPTION
For the moment, the styles defined are stored in localstorage, which means they aren't shared across users or browsers, but they will be saved between sessions.  The styles are only applied to newly drawn elements.  I could see this work extended to actually group the elements that are drawn with different styles and add the ability to change the style for each group in bulk, but I will leave that for future work if it is desired.

![dialog](https://user-images.githubusercontent.com/31890/30881208-fd434066-a2d2-11e7-94c4-cf58797bce2a.png)

![menu](https://user-images.githubusercontent.com/31890/30881204-f9a226ca-a2d2-11e7-89cc-13ee31ba0096.png)