### PR TITLE
Fix the blob detection filter test.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -132,6 +132,8 @@ install:
     - pip uninstall --yes Sphinx  # Interferes with sphinx from conda
     - conda install --yes jupyter sphinx sphinx_rtd_theme
     - pip install nbsphinx travis-sphinx
+    - pip install numpy==1.13.1  # pin numpy for now
+    - pip freeze  # report what we have installed
 
 script:
     - mkdir -p $build_path/girder_testing_build


### PR DESCRIPTION
In travis, numpy 1.13.2 fails on the blob detection filter.  Pinning to numpy 1.13.1 fixes it.

For now, I recommend merging this so our CI passes.  We can figure out why travis fails with 1.13.2 layer.