### PR TITLE
Add autosaving of annotations to the DrawWidget

### DIFF
--- a/plugin_tests/client/annotationSpec.js
+++ b/plugin_tests/client/annotationSpec.js
@@ -147,6 +147,11 @@ $(function () {
                 var annotation;
 
                 girderTest.waitForLoad();
+
+                // If the next rest request happens too quickly after saving the
+                // annotation, the database might not be synced.  Ref:
+                // https://travis-ci.org/DigitalSlideArchive/HistomicsTK/builds/283691041
+                waits(100);
                 runs(function () {
                     girder.rest.restRequest({
                         url: 'annotation',
@@ -231,6 +236,11 @@ $(function () {
                 var annotation;
 
                 girderTest.waitForLoad();
+
+                // If the next rest request happens too quickly after saving the
+                // annotation, the database might not be synced.  Ref:
+                // https://travis-ci.org/DigitalSlideArchive/HistomicsTK/builds/283691041
+                waits(100);
                 runs(function () {
                     girder.rest.restRequest({
                         url: 'annotation',

--- a/plugin_tests/client/annotationSpec.js
+++ b/plugin_tests/client/annotationSpec.js
@@ -12,6 +12,7 @@ girderTest.promise.then(function () {
     $('body').css('overflow', 'hidden');
     girder.router.enabled(false);
     girder.events.trigger('g:appload.before');
+    girder.plugins.HistomicsTK.panels.DrawWidget.throttleAutosave = false;
     app = new girder.plugins.HistomicsTK.App({
         el: 'body',
         parentView: null
@@ -141,6 +142,44 @@ $(function () {
                 }, 'point drawing to be off');
             });
 
+            it('ensure point was autosaved', function () {
+                var annotations;
+                var annotation;
+
+                girderTest.waitForLoad();
+                runs(function () {
+                    girder.rest.restRequest({
+                        url: 'annotation',
+                        data: {
+                            itemId: imageId
+                        }
+                    }).then(function (a) {
+                        annotations = a;
+                        return null;
+                    });
+                });
+
+                waitsFor(function () {
+                    return annotations !== undefined;
+                }, 'saved annotations to load');
+                runs(function () {
+                    expect(annotations.length).toBe(1);
+                    expect(annotations[0].annotation.name).toMatch(/admin/);
+                    girder.rest.restRequest({
+                        url: 'annotation/' + annotations[0]._id
+                    }).done(function (a) {
+                        annotation = a;
+                    });
+                });
+
+                waitsFor(function () {
+                    return annotation !== undefined;
+                }, 'annotation to load');
+                runs(function () {
+                    expect(annotation.annotation.elements.length).toBe(1);
+                });
+            });
+
             it('edit a point element', function () {
                 runs(function () {
                     $('.h-elements-container .h-edit-element').click();
@@ -184,6 +223,44 @@ $(function () {
                 }, 'rectangle to be created');
                 runs(function () {
                     expect($('.h-elements-container .h-element:last .h-element-label').text()).toBe('point');
+                });
+            });
+
+            it('ensure the second point was autosaved', function () {
+                var annotations;
+                var annotation;
+
+                girderTest.waitForLoad();
+                runs(function () {
+                    girder.rest.restRequest({
+                        url: 'annotation',
+                        data: {
+                            itemId: imageId
+                        }
+                    }).then(function (a) {
+                        annotations = a;
+                        return null;
+                    });
+                });
+
+                waitsFor(function () {
+                    return annotations !== undefined;
+                }, 'saved annotations to load');
+                runs(function () {
+                    expect(annotations.length).toBe(1);
+                    expect(annotations[0].annotation.name).toMatch(/admin/);
+                    girder.rest.restRequest({
+                        url: 'annotation/' + annotations[0]._id
+                    }).done(function (a) {
+                        annotation = a;
+                    });
+                });
+
+                waitsFor(function () {
+                    return annotation !== undefined;
+                }, 'annotation to load');
+                runs(function () {
+                    expect(annotation.annotation.elements.length).toBe(2);
                 });
             });
 


### PR DESCRIPTION
Fixes #390.

This pushes the drawn annotations to the server at most every 1 second.  If you reload the page without saving, the annotations will appear in the annotation panel with an autogenerated name containing your user name and a time stamp.  I suspect we will also want to allow one to edit saved annotations in a future PR.  This will at least prevent drawn annotations from being lost entirely.