### PR TITLE
Change the color of the selected drawing style.

### DIFF
--- a/web_client/stylesheets/panels/drawWidget.styl
+++ b/web_client/stylesheets/panels/drawWidget.styl
@@ -30,3 +30,8 @@
 
   .h-style-group-row
     margin 10px 0
+
+  .btn-default.active
+    background-color #5790ff
+    &:focus, &:hover
+      background-color #4672cc


### PR DESCRIPTION
I couldn't see the difference between which drawing mode was selected versus which one was focused.  This made it hard to tell if I had a drawing mode turned on or off.

Bootstrap's `.btn-default:hover` is the same color as `.btn-default.active`, and very close to `.btn-default.active:focus`.

I picked the color that my version of Chrome uses for highlighted text.  I'd be happy to use a different color, provided I can tell the difference between it and the `:hover` color.