### PR TITLE
Switch to 2.x-maintenance branch of girder for testing and deployment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,7 +62,7 @@ before_install:
 
     - CACHE="$HOME/.cache" OPENJPEG_VERSION=2.1.2 OPENJPEG_FILE=v2.1.2.tar.gz OPENJPEG_DIR=openjpeg-2.1.2 LIBTIFF_VERSION=4.0.8 OPENSLIDE_VERSION=3.4.1 source .install-openslide.sh
 
-    - GIRDER_VERSION=master
+    - GIRDER_VERSION=2.x-maintenance
     - GIRDER_WORKER_VERSION=master
     - LARGE_IMAGE_VERSION=master
     - SLICER_CLI_WEB_VERSION=master
@@ -79,7 +79,7 @@ before_install:
     - girder_worker_path=$girder_path/plugins/girder_worker
     - git clone https://github.com/girder/girder_worker.git $girder_worker_path && git -C $girder_worker_path checkout $GIRDER_WORKER_VERSION
     - cp $PWD/plugin_tests/data/girder_worker.cfg $girder_worker_path/girder_worker/worker.local.cfg
-    - pip install -U -r $girder_worker_path/requirements.txt 
+    - pip install -U -r $girder_worker_path/requirements.txt
     - pip install -U -r $girder_worker_path/girder_worker/plugins/girder_io/requirements.txt
 
     - large_image_path=$girder_path/plugins/large_image

--- a/ansible/deploy_local.yml
+++ b/ansible/deploy_local.yml
@@ -8,7 +8,7 @@
     - worker
     - role: girder.girder
       girder_path: "{{ root_dir }}/girder"
-      girder_version: "master"
+      girder_version: "2.x-maintenance"
       # We build the girder web assets in girder-histomicstk
       girder_web: no
       become: true

--- a/ansible/docker_ansible.yml
+++ b/ansible/docker_ansible.yml
@@ -18,7 +18,7 @@
         - docker == "girder_worker"
     - role: girder.girder
       girder_path: "{{ root_dir }}/girder"
-      girder_version: "master"
+      girder_version: "2.x-maintenance"
       girder_web: no
       girder_daemonize: no
       become: true

--- a/ansible/group_vars/all
+++ b/ansible/group_vars/all
@@ -1,6 +1,6 @@
 ---
 ctk_cli_version: master
-girder_version: master
+girder_version: 2.x-maintenance
 slicer_cli_web_version: master
 histomicstk_version: master
 large_image_version: master

--- a/ansible/vagrant.yml
+++ b/ansible/vagrant.yml
@@ -8,7 +8,7 @@
     - worker
     - role: girder.girder
       girder_path: "{{ root_dir }}/girder"
-      girder_version: "master"
+      girder_version: "2.x-maintenance"
       # We build the girder web assets in girder-histomicstk
       girder_web: no
       become: true


### PR DESCRIPTION
I replaced all instances of `girder_version=master` that I found.  I didn't test it fully because I don't think I'm aware of all the deployment scenarios in use.  No real rush on this anyway.