### PR TITLE
Don't automatically sort the recently annotated image list.

### DIFF
--- a/web_client/dialogs/openAnnotatedImage.js
+++ b/web_client/dialogs/openAnnotatedImage.js
@@ -22,6 +22,8 @@ const OpenAnnotatedImage = View.extend({
 
     initialize() {
         this.collection = new ItemCollection();
+        // disable automatic sorting of this collection
+        this.collection.comparator = null;
         this.listenTo(this.collection, 'reset', this.render);
     },
 


### PR DESCRIPTION
Item collections automatically get sorted by name.  Stop that so we have them sorted by most recent annotation (as the list is returned by the end point).