### PR TITLE
Recover after auto-save error.

### DIFF
--- a/web_client/panels/DrawWidget.js
+++ b/web_client/panels/DrawWidget.js
@@ -308,6 +308,17 @@ var DrawWidget = Panel.extend({
                     } else {
                         delete this._activeAnnotationId;
                     }
+                }).fail((resp) => {
+                    // if we fail for any reason, create a new save promise
+                    // so we can try again
+                    this._savePromise = $.Deferred().resolve().promise();
+                    // if the active annotation was deleted by another window,
+                    // mark that it is gone so we can create a new one, and
+                    // recall the auto save function.
+                    if (this._activeAnnotationId && ((resp.responseJSON || {}).message || '').indexOf('Invalid annotation id') === 0) {
+                        delete this._activeAnnotationId;
+                        this._autoSaveAnnotation();
+                    }
                 });
             }
             return null;


### PR DESCRIPTION
If auto save fails for any reason, it will never work again.  For instance, if a second tab is opened with the same image, and the auto-saved annotation is deleted, the annotation can no longer be auto-saved.  In this case, the save is immediately retired.

If there is an error for any other reason, the save is not tried again until something else (changing the annotations) triggers it.  For instance, this recovers if the server is briefly unreachable when the save is being attempted.