### PR TITLE
When a tab regains focus, update the annotation list.

### DIFF
--- a/web_client/panels/DrawWidget.js
+++ b/web_client/panels/DrawWidget.js
@@ -110,6 +110,16 @@ var DrawWidget = Panel.extend({
     },
 
     /**
+     * Return the active annotation ID.  Other widgets can query this to treat
+     * this annotation in a special manner.
+     *
+     * @return {string} The annotation id, or falsy if no current id.
+     */
+    getActiveAnnotation() {
+        return this._activeAnnotationId;
+    },
+
+    /**
      * Set the image "viewer" instance.  This should be a subclass
      * of `large_image/imageViewerWidget` that is capable of rendering
      * annotations.

--- a/web_client/templates/panels/annotationSelector.pug
+++ b/web_client/templates/panels/annotationSelector.pug
@@ -5,24 +5,25 @@ block title
 
 block content
   each annotation in annotations
-    - var name = annotation.get('annotation').name;
-    - var displayed = annotation.get('displayed');
-    .h-annotation(data-id=annotation.id)
-      if displayed
-        span.icon-eye.h-toggle-annotation(
-          data-toggle='tooltip', title='Hide annotation')
-      else
-        span.icon-eye-off.h-toggle-annotation(
-          data-toggle='tooltip', title='Show annotation')
-      span.h-annotation-name(title=name) #{name}
+    if annotation.id !== activeAnnotation
+      - var name = annotation.get('annotation').name;
+      - var displayed = annotation.get('displayed');
+      .h-annotation(data-id=annotation.id)
+        if displayed
+          span.icon-eye.h-toggle-annotation(
+            data-toggle='tooltip', title='Hide annotation')
+        else
+          span.icon-eye-off.h-toggle-annotation(
+            data-toggle='tooltip', title='Show annotation')
+        span.h-annotation-name(title=name) #{name}
 
-      span.h-annotation-right
-        a(href=annotation.downloadUrl().replace(/\/download$/, ''),
-            download=name + '.json')
-          span.icon-download.h-download-annotation(
-              data-toggle='tooltip', title='Download annotation')
-        span.icon-cancel.h-delete-annotation(
-            data-toggle='tooltip', title='Remove annotation')
+        span.h-annotation-right
+          a(href=annotation.downloadUrl().replace(/\/download$/, ''),
+              download=name + '.json')
+            span.icon-download.h-download-annotation(
+                data-toggle='tooltip', title='Download annotation')
+          span.icon-cancel.h-delete-annotation(
+              data-toggle='tooltip', title='Remove annotation')
 
   .checkbox.h-annotation-toggle
     label

--- a/web_client/views/body/ImageView.js
+++ b/web_client/views/body/ImageView.js
@@ -37,17 +37,18 @@ var ImageView = View.extend({
         this.controlPanel = new SlicerPanelGroup({
             parentView: this
         });
-        this.annotationSelector = new AnnotationSelector({
-            parentView: this,
-            collection: this.annotations,
-            image: this.model
-        });
         this.zoomWidget = new ZoomWidget({
             parentView: this
         });
         this.drawWidget = new DrawWidget({
             parentView: this,
             annotations: this.annotations,
+            image: this.model
+        });
+        this.annotationSelector = new AnnotationSelector({
+            parentView: this,
+            collection: this.annotations,
+            getActiveAnnotation: () => { return this.drawWidget.getActiveAnnotation(); },
             image: this.model
         });
         this.popover = new AnnotationPopover({


### PR DESCRIPTION
This won't add the active annotation (the one that is created by auto-save).  When the event stream reconnects, any new annotations are shown.  This allows moving to a different tab when a job is processing and coming back any time after it finishes and still seeing the results.