### PR TITLE
Use annotation model save/delete rather than custom restRequests

### DIFF
--- a/web_client/dialogs/saveAnnotation.js
+++ b/web_client/dialogs/saveAnnotation.js
@@ -1,3 +1,5 @@
+import _ from 'underscore';
+
 import View from 'girder/views/View';
 
 import saveAnnotation from '../templates/dialogs/saveAnnotation.pug';
@@ -36,7 +38,7 @@ var SaveAnnotation = View.extend({
             return;
         }
 
-        this.annotation.set({
+        _.extend(this.annotation.get('annotation'), {
             name: this.$('#h-annotation-name').val(),
             description: this.$('#h-annotation-description').val()
         });

--- a/web_client/panels/DrawWidget.js
+++ b/web_client/panels/DrawWidget.js
@@ -190,10 +190,12 @@ var DrawWidget = Panel.extend({
     },
 
     /**
-     * Empty all element from the `ElementCollection`.
+     * Empty all element from the `ElementCollection` and restore the current annotation
+     * to its default state.
      */
     reset() {
         this.collection.reset();
+        this.annotation.clear();
     },
 
     /**


### PR DESCRIPTION
This simplifies much of the auto saving logic by relying on more easily tested methods on the annotation model itself.  These changes are intended to make it easier to pass annotation models between the Annotation and Draw widgets for editing previously saved annotations.