### PR TITLE
Reduce the size of the generated docker files.

### DIFF
--- a/ansible/Dockerfile-girder-worker
+++ b/ansible/Dockerfile-girder-worker
@@ -1,11 +1,12 @@
 FROM ubuntu:16.04
 MAINTAINER David Manthey <david.manthey@kitware.com>
 
-RUN apt-get update
-RUN DEBIAN_FRONTEND=noninteractive apt-get --yes -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" dist-upgrade
-RUN apt-get install -y git python2.7-dev python-pip libssl-dev sudo net-tools vim locales apt-utils
-# Install some additional packages for convenience when testing with bash
-RUN apt-get install -y iputils-ping telnet-ssl tmux
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get --yes -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" dist-upgrade && \
+    apt-get install -y git python2.7-dev python-pip libssl-dev sudo net-tools vim locales apt-utils && \
+    # Install some additional packages for convenience when testing with bash
+    apt-get install -y iputils-ping telnet-ssl tmux && \
+    sudo rm -rf /var/lib/apt/lists/* /tmp/*
 RUN pip install -U pip
 RUN pip install -U ansible
 RUN locale-gen en_US.UTF-8
@@ -15,7 +16,7 @@ RUN adduser --disabled-password --gecos '' ubuntu && \
 USER ubuntu
 ENV LANG en_US.UTF-8
 WORKDIR /home/ubuntu
-RUN git clone https://github.com/DigitalSlideArchive/HistomicsTK
+RUN git clone --depth=1 https://github.com/DigitalSlideArchive/HistomicsTK
 WORKDIR /home/ubuntu/HistomicsTK
 ENV GIRDER_EXEC_USER ubuntu
 COPY . /home/ubuntu/HistomicsTK/ansible/.
@@ -28,7 +29,13 @@ ARG MONGO_WORKER_DATABASE
 # RUN ansible-playbook -i inventory/local docker_ansible.yml --tags worker --extra-vars="docker=true mongo_worker_database=${MONGO_WORKER_DATABASE:-girder_worker}"
 
 RUN ansible-galaxy install -r requirements.yml -p /home/ubuntu/HistomicsTK/ansible/roles/
-RUN ansible-playbook -i inventory/local docker_ansible.yml --extra-vars="docker=girder_worker mongo_worker_database=${MONGO_WORKER_DATABASE:-girder_worker}"
+RUN ansible-playbook -i inventory/local docker_ansible.yml --extra-vars="docker=girder_worker mongo_worker_database=${MONGO_WORKER_DATABASE:-girder_worker}" && \
+    sudo rm -rf /var/lib/apt/lists/* /tmp/* \
+                /opt/histomicstk/openjpeg-* \
+                /opt/histomicstk/openslide-* \
+                /opt/histomicstk/tiff-* \
+                /opt/histomicstk/vips-* \
+                /root/.cache/pip
 
 WORKDIR /opt/girder_worker
 

--- a/ansible/Dockerfile-histomicstk
+++ b/ansible/Dockerfile-histomicstk
@@ -1,12 +1,12 @@
 FROM ubuntu:16.04
 MAINTAINER David Manthey <david.manthey@kitware.com>
 
-RUN apt-get update
-# For a dist upgrade
-RUN DEBIAN_FRONTEND=noninteractive apt-get --yes -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" dist-upgrade
-RUN apt-get install -y git python2.7-dev python-pip libssl-dev sudo net-tools vim locales apt-utils
-# Install some additional packages for convenience when testing with bash
-RUN apt-get install -y iputils-ping telnet-ssl tmux
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get --yes -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" dist-upgrade && \
+    apt-get install -y git python2.7-dev python-pip libssl-dev sudo net-tools vim locales apt-utils && \
+    # Install some additional packages for convenience when testing with bash
+    apt-get install -y iputils-ping telnet-ssl tmux && \
+    sudo rm -rf /var/lib/apt/lists/* /tmp/*
 RUN pip install -U pip
 RUN pip install -U ansible
 RUN locale-gen en_US.UTF-8
@@ -16,7 +16,7 @@ RUN adduser --disabled-password --gecos '' ubuntu && \
 USER ubuntu
 ENV LANG en_US.UTF-8
 WORKDIR /home/ubuntu
-RUN git clone https://github.com/DigitalSlideArchive/HistomicsTK
+RUN git clone --depth=1 https://github.com/DigitalSlideArchive/HistomicsTK
 WORKDIR /home/ubuntu/HistomicsTK
 ENV GIRDER_EXEC_USER ubuntu
 COPY . /home/ubuntu/HistomicsTK/ansible/.
@@ -28,7 +28,14 @@ WORKDIR /home/ubuntu/HistomicsTK/ansible
 # RUN ansible-playbook -i inventory/local docker_ansible.yml --tags openslide
 # RUN ansible-playbook -i inventory/local docker_ansible.yml --tags girder --extra-vars=docker=true
 RUN ansible-galaxy install -r requirements.yml -p /home/ubuntu/HistomicsTK/ansible/roles/
-RUN ansible-playbook -i inventory/local docker_ansible.yml --extra-vars=docker=histomicstk
+RUN ansible-playbook -i inventory/local docker_ansible.yml --extra-vars=docker=histomicstk && \
+    sudo rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /home/ubuntu/.npm \
+                /root/.npm /opt/histomicstk/girder/node_modules \
+                /opt/histomicstk/openjpeg-* \
+                /opt/histomicstk/openslide-* \
+                /opt/histomicstk/tiff-* \
+                /opt/histomicstk/vips-* \
+                /root/.cache/pip
 
 WORKDIR /opt/histomicstk/girder
 EXPOSE 8080

--- a/ansible/deploy_docker.py
+++ b/ansible/deploy_docker.py
@@ -562,7 +562,11 @@ def images_build(retry=False, names=None):
                 decode=True,
             )
             for status in buildStatus:
-                print(status.get('status', status.get('stream', '')).strip())
+                statusLine = status.get('status', status.get('stream', '')).strip()
+                try:
+                    print(statusLine)
+                except Exception:
+                    print(repr(statusLine))
                 if 'errorDetail' in status:
                     if not retry:
                         sys.exit(1)


### PR DESCRIPTION
This deletes a variety of caches as the docker files are built.  With current master, it reduces histomicstk_main from 3.72 GB to 2.25 GB and girder_worker from 1.61 GB to 1.27 GB.

Further gains are possible: shallow cloning git repos, deleting doc, man, and locale information, etc.  Some of these will have repercussions in using the docker container for development, however.