### PR TITLE
Install keras, tensorflow and check if accessible in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ WORKDIR $htk_path
 RUN pip install --upgrade --ignore-installed pip setuptools && \
     pip install --upgrade 'git+https://github.com/cdeepakroy/ctk-cli' && \
     # Install requirements.txt via pip; installing via conda causes
-    # version issues with our home-built libtif.
+    # version issues with our home-built libtiff.
     # Try twice; conda sometimes causes pip to fail the first time, but if it
     # fails twice then there is a real issue.
     pip install -r requirements.txt && \
@@ -47,6 +47,10 @@ RUN python -c "from matplotlib import pylab"
 
 # pregenerate libtiff wrapper.  This also tests libtiff for failures
 RUN python -c "import libtiff"
+
+# make sure deep learning libraries are accessible
+RUN python -c "import keras"
+RUN python -c "import tensorflow"
 
 # define entrypoint through which all CLIs can be run
 WORKDIR $htk_path/server

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,11 @@ RUN pip install --upgrade --ignore-installed pip setuptools && \
       Pillow && \
     # Install HistomicsTK
     python setup.py install && \
+    # Create separate virtual environments with CPU and GPU versions of tensorflow
+    pip install virtualenv && \
+    virtualenv --system-site-packages /venv-gpu && \
+    chmod +x /venv-gpu/bin/activate && \
+    /venv-gpu/bin/pip install tensorflow-gpu>=1.3.0
     # clean up
     conda clean -i -l -t -y && \
     rm -rf /root/.cache/pip/*
@@ -56,4 +61,4 @@ WORKDIR $htk_path/server
 RUN python /build/slicer_cli_web/server/cli_list_entrypoint.py --list_cli
 RUN python /build/slicer_cli_web/server/cli_list_entrypoint.py ColorDeconvolution --help
 
-ENTRYPOINT ["/build/miniconda/bin/python", "/build/slicer_cli_web/server/cli_list_entrypoint.py"]
+ENTRYPOINT ["/bin/bash", "docker-entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ RUN pip install --upgrade --ignore-installed pip setuptools && \
     pip install virtualenv && \
     virtualenv --system-site-packages /venv-gpu && \
     chmod +x /venv-gpu/bin/activate && \
-    /venv-gpu/bin/pip install tensorflow-gpu>=1.3.0
+    /venv-gpu/bin/pip install tensorflow-gpu>=1.3.0 && \
     # clean up
     conda clean -i -l -t -y && \
     rm -rf /root/.cache/pip/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,10 +48,6 @@ RUN python -c "from matplotlib import pylab"
 # pregenerate libtiff wrapper.  This also tests libtiff for failures
 RUN python -c "import libtiff"
 
-# make sure deep learning libraries are accessible
-RUN python -c "import keras"
-RUN python -c "import tensorflow"
-
 # define entrypoint through which all CLIs can be run
 WORKDIR $htk_path/server
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -34,6 +34,10 @@ installed as follows::
     $ pip install --no-cache-dir -r requirements.txt
     $ pip install -e .
 
+If you want the keras/tensorflow based functions of HistomicsTK to take advantage of the GPU,
+then you will have to install the GPU version of tensorflow (tensorflow-gpu) after
+installing HistomicsTK. See tensorflow installation instructions `here https://www.tensorflow.org/install/`__.
+
 If you build libtiff or openjpeg locally, ensure that the appropriate pip files
 have also been installed locally so that they use the correct libraries::
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -36,7 +36,7 @@ installed as follows::
 
 If you want the keras/tensorflow based functions of HistomicsTK to take advantage of the GPU,
 then you will have to install the GPU version of tensorflow (tensorflow-gpu) after
-installing HistomicsTK. See tensorflow installation instructions `here https://www.tensorflow.org/install/`__.
+installing HistomicsTK. See tensorflow installation instructions `here <https://www.tensorflow.org/install/>`_.
 
 If you build libtiff or openjpeg locally, ensure that the appropriate pip files
 have also been installed locally so that they use the correct libraries::

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,10 @@ scikit-image>=0.12.3
 scikit-learn>=0.18.1
 scipy>=0.19.0
 
+h5py>=2.7.1
+keras>=2.0.8
+tensorflow-gpu>=1.3.0
+
 #
 # dask packages
 #

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,9 @@ scikit-image>=0.12.3
 scikit-learn>=0.18.1
 scipy>=0.19.0
 
+#
+# deep learning packages
+#
 h5py>=2.7.1
 keras>=2.0.8
 tensorflow-gpu>=1.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ scipy>=0.19.0
 #
 h5py>=2.7.1
 keras>=2.0.8
-tensorflow-gpu>=1.3.0
+tensorflow>=1.3.0
 
 #
 # dask packages

--- a/server/docker-entrypoint.sh
+++ b/server/docker-entrypoint.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 
-if type nvidia-smi > /dev/null;
+if type nvidia-smi >/dev/null 2>/dev/null;
 then
     source /venv-gpu/bin/activate
 fi
 
-python /build/slicer_cli_web/server/cli_list_entrypoint.py
+python /build/slicer_cli_web/server/cli_list_entrypoint.py "$@"

--- a/server/docker-entrypoint.sh
+++ b/server/docker-entrypoint.sh
@@ -3,6 +3,7 @@
 if type nvidia-smi >/dev/null 2>/dev/null;
 then
     source /venv-gpu/bin/activate
+    echo "NOTE: GPU available" >&2
 fi
 
 python /build/slicer_cli_web/server/cli_list_entrypoint.py "$@"

--- a/server/docker-entrypoint.sh
+++ b/server/docker-entrypoint.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+if type nvidia-smi > /dev/null;
+then
+    source /venv-gpu/bin/activate
+fi
+
+python /build/slicer_cli_web/server/cli_list_entrypoint.py


### PR DESCRIPTION
This PR:

* Adds keras and tensorflow to requirements.txt. Note that only CPU version of tensorflow is in requirements.txt. If the user wants to take advantage of the GPU, then the GPU version (`tensorflow-gpu`), the user is responsible for uninstalling the CPU version and installing the GPU version explicitly after installing HistomicsTK. This is clarified in the documentation for installing HistomicsTK as a python toolkit.

* Creates a separate virtual environment called `venv-gpu` and installs `tensorflow-gpu` in the Dockerfile with HistomicsTK CLIs.

* Adds a new shell script called `server/docker-entrypoint.sh` that activates the `venv-gpu` environment only if the docker container is run with `nvidia-docker` and if `nvidia-smi` works. This is to ensure that the CLIs run on all machines (with or without GPU) irrespective of whether they are run with plain `docker run` or `nvidia-docker run`.

Note that the CLIs in the docker container will take advantage of the GPU only if run with `nvidia-docker` that is expected to be pre-installed on the machine.