### PR TITLE
Don't install optional components by default.

### DIFF
--- a/ansible/Dockerfile-girder-worker
+++ b/ansible/Dockerfile-girder-worker
@@ -2,10 +2,10 @@ FROM ubuntu:16.04
 MAINTAINER David Manthey <david.manthey@kitware.com>
 
 RUN apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get --yes -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" dist-upgrade && \
-    apt-get install -y git python2.7-dev python-pip libssl-dev sudo net-tools vim locales apt-utils && \
+    DEBIAN_FRONTEND=noninteractive apt-get --yes --no-install-recommends -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" dist-upgrade && \
+    apt-get install -y --no-install-recommends git python2.7-dev python-pip libssl-dev sudo net-tools vim locales apt-utils python-setuptools && \
     # Install some additional packages for convenience when testing with bash
-    apt-get install -y iputils-ping telnet-ssl tmux && \
+    apt-get install -y --no-install-recommends iputils-ping telnet-ssl tmux less && \
     sudo rm -rf /var/lib/apt/lists/* /tmp/*
 RUN pip install -U pip
 RUN pip install -U ansible
@@ -16,7 +16,7 @@ RUN adduser --disabled-password --gecos '' ubuntu && \
 USER ubuntu
 ENV LANG en_US.UTF-8
 WORKDIR /home/ubuntu
-RUN git clone --depth=1 https://github.com/DigitalSlideArchive/HistomicsTK
+RUN git clone --depth=1 https://github.com/DigitalSlideArchive/HistomicsTK && rm -rf HistomicsTK/.git
 WORKDIR /home/ubuntu/HistomicsTK
 ENV GIRDER_EXEC_USER ubuntu
 COPY . /home/ubuntu/HistomicsTK/ansible/.
@@ -30,7 +30,11 @@ ARG MONGO_WORKER_DATABASE
 
 RUN ansible-galaxy install -r requirements.yml -p /home/ubuntu/HistomicsTK/ansible/roles/
 RUN ansible-playbook -i inventory/local docker_ansible.yml --extra-vars="docker=girder_worker mongo_worker_database=${MONGO_WORKER_DATABASE:-girder_worker}" && \
+    sudo pyclean /usr/local/lib/python2.7/dist-packages && \
     sudo rm -rf /var/lib/apt/lists/* /tmp/* \
+                /home/ubuntu/.cache \
+                /home/ubuntu/.ansible* \
+                /home/ubuntu/.wget-hsts \
                 /opt/histomicstk/openjpeg-* \
                 /opt/histomicstk/openslide-* \
                 /opt/histomicstk/tiff-* \

--- a/ansible/Dockerfile-histomicstk
+++ b/ansible/Dockerfile-histomicstk
@@ -2,10 +2,10 @@ FROM ubuntu:16.04
 MAINTAINER David Manthey <david.manthey@kitware.com>
 
 RUN apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get --yes -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" dist-upgrade && \
-    apt-get install -y git python2.7-dev python-pip libssl-dev sudo net-tools vim locales apt-utils && \
+    DEBIAN_FRONTEND=noninteractive apt-get --yes --no-install-recommends -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" dist-upgrade && \
+    apt-get install -y --no-install-recommends git python2.7-dev python-pip libssl-dev sudo net-tools vim locales apt-utils python-setuptools && \
     # Install some additional packages for convenience when testing with bash
-    apt-get install -y iputils-ping telnet-ssl tmux && \
+    apt-get install -y --no-install-recommends iputils-ping telnet-ssl tmux less && \
     sudo rm -rf /var/lib/apt/lists/* /tmp/*
 RUN pip install -U pip
 RUN pip install -U ansible
@@ -16,7 +16,7 @@ RUN adduser --disabled-password --gecos '' ubuntu && \
 USER ubuntu
 ENV LANG en_US.UTF-8
 WORKDIR /home/ubuntu
-RUN git clone --depth=1 https://github.com/DigitalSlideArchive/HistomicsTK
+RUN git clone --depth=1 https://github.com/DigitalSlideArchive/HistomicsTK && rm -rf HistomicsTK/.git
 WORKDIR /home/ubuntu/HistomicsTK
 ENV GIRDER_EXEC_USER ubuntu
 COPY . /home/ubuntu/HistomicsTK/ansible/.
@@ -29,12 +29,20 @@ WORKDIR /home/ubuntu/HistomicsTK/ansible
 # RUN ansible-playbook -i inventory/local docker_ansible.yml --tags girder --extra-vars=docker=true
 RUN ansible-galaxy install -r requirements.yml -p /home/ubuntu/HistomicsTK/ansible/roles/
 RUN ansible-playbook -i inventory/local docker_ansible.yml --extra-vars=docker=histomicstk && \
+    git -C /opt/histomicstk/girder/plugins/xtk_demo gc && \
+    sudo pyclean /opt/histomicstk/girder && \
+    sudo pyclean /usr/local/lib/python2.7/dist-packages && \
     sudo rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /home/ubuntu/.npm \
+                /home/ubuntu/.cache \
+                /home/ubuntu/.ansible* \
+                /home/ubuntu/.wget-hsts \
                 /root/.npm /opt/histomicstk/girder/node_modules \
                 /opt/histomicstk/openjpeg-* \
                 /opt/histomicstk/openslide-* \
                 /opt/histomicstk/tiff-* \
                 /opt/histomicstk/vips-* \
+                /opt/histomicstk/HistomicsTK/_skbuild \
+                /opt/histomicstk/large_image/build \
                 /root/.cache/pip
 
 WORKDIR /opt/histomicstk/girder

--- a/ansible/roles/common/tasks/main.yml
+++ b/ansible/roles/common/tasks/main.yml
@@ -24,11 +24,11 @@
   become: true
 
 - name: Install curl
-  apt: pkg=curl state=installed
+  apt: pkg=curl state=installed install_recommends=no
   become: true
 
 - name: Install aptitude
-  apt: pkg=aptitude state=installed
+  apt: pkg=aptitude state=installed install_recommends=no
   become: true
   when: (vagrant is defined) or (docker is defined)
 
@@ -37,6 +37,7 @@
     upgrade: safe
     force: yes
     update_cache: yes
+    install_recommends: no
   become: true
   when: (vagrant is defined) or (docker is defined)
 

--- a/ansible/roles/girder-histomicstk/tasks/main.yml
+++ b/ansible/roles/girder-histomicstk/tasks/main.yml
@@ -101,9 +101,25 @@
 - name: Create directory for build
   file: state=directory path="{{ root_dir }}/girder/clients/web/static/built"
 
-
 - name: Install numpy (must be installed before large_image plugin)
-  pip: name=numpy version=1.11.3
+  pip:
+    name: numpy
+    extra_args: "-U"
+    state: present
+  become: true
+
+- name: Install scikit-build (must be installed before HistomicsTK plugin)
+  pip:
+    name: scikit-build
+    extra_args: "-U"
+    state: present
+  become: true
+
+- name: Make sure the six library is updated
+  pip:
+    name: six
+    extra_args: "-U"
+    state: present
   become: true
 
 - name: Install our external girder plugins - xtk_demo

--- a/ansible/roles/openslide/tasks/main.yml
+++ b/ansible/roles/openslide/tasks/main.yml
@@ -161,43 +161,43 @@
 # vips
 - name: Download vips
   command: >-
-    wget --retry-connrefused --waitretry=1 --read-timeout=300 https://github.com/jcupitt/libvips/releases/download/v8.5.8/vips-8.5.8.tar.gz -O vips-8.5.8.tar.gz
+    wget --retry-connrefused --waitretry=1 --read-timeout=300 https://github.com/jcupitt/libvips/releases/download/v8.5.9/vips-8.5.9.tar.gz -O vips-8.5.9.tar.gz
   args:
     chdir: "{{ root_dir }}"
-    creates: vips-8.5.8.tar.gz
+    creates: vips-8.5.9.tar.gz
 
 - name: Extract vips
   unarchive:
-    src: "{{ root_dir }}/vips-8.5.8.tar.gz"
+    src: "{{ root_dir }}/vips-8.5.9.tar.gz"
     dest: "{{ root_dir }}"
-    creates: "{{ root_dir }}/vips-8.5.8"
+    creates: "{{ root_dir }}/vips-8.5.9"
 
 - name: Configure vips
   shell: ./configure
   args:
-    chdir: "{{ root_dir }}/vips-8.5.8"
+    chdir: "{{ root_dir }}/vips-8.5.9"
 
 - name: Build vips
   command: make
   args:
-    chdir: "{{ root_dir }}/vips-8.5.8"
-    creates: "{{ root_dir }}/.built-vips-8.5.8"
+    chdir: "{{ root_dir }}/vips-8.5.9"
+    creates: "{{ root_dir }}/.built-vips-8.5.9"
 
 - name: Leave creation artifact for vips build
   file:
-    path: "{{ root_dir }}/.built-vips-8.5.8"
+    path: "{{ root_dir }}/.built-vips-8.5.9"
     state: touch
 
 - name: Install vips
   command: make install
   args:
-    chdir: "{{ root_dir }}/vips-8.5.8"
-    creates: "{{ root_dir }}/.installed-vips-8.5.8"
+    chdir: "{{ root_dir }}/vips-8.5.9"
+    creates: "{{ root_dir }}/.installed-vips-8.5.9"
   become: true
 
 - name: Leave creation artifact for vips install
   file:
-    path: "{{ root_dir }}/.installed-vips-8.5.8"
+    path: "{{ root_dir }}/.installed-vips-8.5.9"
     state: touch
 
 - name: Run ldconfig
@@ -206,7 +206,7 @@
 
 - name: Install Vips python connector
   copy:
-    src: "{{ root_dir }}/vips-8.5.8/python/packages/gi/overrides/Vips.py"
+    src: "{{ root_dir }}/vips-8.5.9/python/packages/gi/overrides/Vips.py"
     dest: /usr/lib/python2.7/dist-packages/gi/overrides/
   become: true
 

--- a/ansible/roles/provision/tasks/main.yml
+++ b/ansible/roles/provision/tasks/main.yml
@@ -10,6 +10,7 @@
   until: "ret and ret.get('gc_return') and ret.get('gc_return', {}).get('apiVersion')"
   delay: 1
   retries: 300
+  when: docker is defined
 
 - name: Create directory for logs
   file: state=directory path="{{ root_dir }}/logs"


### PR DESCRIPTION
Reduce the size of the docker image slightly more by not installing optional components.

Update vips version to 8.5.9 which marginally speed up the docker builds.

Explicitly install scikit-build before histomicstk.

Explicitly upgrade the version of six (something downgrades it to 1.10, but Cherrypy requires 1.11).

This reduces the combined docker image sizes by another 0.19 GB.

This was tested with `vagrant up` as well as with building docker files.