### PR TITLE
Protect annotations from accidental deletion

### DIFF
--- a/plugin_tests/client/annotationSpec.js
+++ b/plugin_tests/client/annotationSpec.js
@@ -92,7 +92,8 @@ $(function () {
             girder.rest.restRequest({
                 url: 'annotation',
                 data: {
-                    itemId: imageId
+                    itemId: imageId,
+                    userId: girder.auth.getCurrentUser().id
                 }
             }).then(function (a) {
                 annotations = a;
@@ -105,7 +106,7 @@ $(function () {
         }, 'saved annotations to load');
         runs(function () {
             expect(annotations.length).toBe(1);
-            expect(annotations[0].annotation.name).toMatch(/admin/);
+            expect(annotations[0].annotation.name).toMatch(/user/);
             annotationInfo.annotations = annotations;
             girder.rest.restRequest({
                 url: 'annotation/' + annotations[0]._id
@@ -133,7 +134,7 @@ $(function () {
 
                 girderTest.waitForDialog();
                 runs(function () {
-                    $('#g-login').val('admin');
+                    $('#g-login').val('user');
                     $('#g-password').val('password');
                     $('#g-login-button').click();
                 });
@@ -283,13 +284,17 @@ $(function () {
 
                 girderTest.waitForLoad();
                 runs(function () {
-                    expect($('.h-annotation-selector .h-annotation-name').text()).toBe('single point');
+                    expect(
+                        $('.h-annotation-selector .h-annotation:nth-of-type(2) .h-annotation-name').text()
+                    ).toBe('single point');
+
                     expect($('.h-draw-widget .h-save-widget').length).toBe(0);
 
                     girder.rest.restRequest({
                         url: 'annotation',
                         data: {
-                            itemId: imageId
+                            itemId: imageId,
+                            userId: girder.auth.getCurrentUser().id
                         }
                     }).then(function (a) {
                         annotations = a;
@@ -317,6 +322,12 @@ $(function () {
                 expect($('.h-annotation-selector .s-panel-title').text()).toMatch(/Annotations/);
             });
 
+            it('ensure user cannot remove the admin annotation', function () {
+                var adminAnnotation = $('.h-annotation-selector .h-annotation:contains("admin annotation")');
+                expect(adminAnnotation.length).toBe(1);
+                expect(adminAnnotation.find('.h-delete-annotation').length).toBe(0);
+            });
+
             it('toggle visibility of an annotation', function () {
                 runs(function () {
                     var $el = $('.h-annotation-selector .h-annotation:contains("single point")');
@@ -341,15 +352,21 @@ $(function () {
                 var annotations = null;
                 runs(function () {
                     $('.h-annotation-selector .h-annotation:contains("single point") .h-delete-annotation').click();
-                    expect($('.h-annotation-selector .h-annotation:contains("single point")').length).toBe(0);
+                });
+
+                girderTest.waitForDialog();
+                runs(function () {
+                    $('.h-submit').click();
                 });
 
                 girderTest.waitForLoad();
                 runs(function () {
+                    expect($('.h-annotation-selector .h-annotation:contains("single point")').length).toBe(0);
                     girder.rest.restRequest({
                         url: 'annotation',
                         data: {
-                            itemId: imageId
+                            itemId: imageId,
+                            userId: girder.auth.getCurrentUser().id
                         }
                     }).then(function (a) {
                         annotations = a;
@@ -468,7 +485,7 @@ $(function () {
             it('open the original image', function () {
                 openImage('image');
                 runs(function () {
-                    expect($('.h-annotation-selector .h-annotation').length).toBe(1);
+                    expect($('.h-annotation-selector .h-annotation').length).toBe(2);
                 });
             });
         });

--- a/plugin_tests/web_client_test.py
+++ b/plugin_tests/web_client_test.py
@@ -17,13 +17,22 @@ class WebClientTestCase(web_client_test.WebClientTestCase):
     def setUp(self):
         super(WebClientTestCase, self).setUp()
 
-        user = self.model('user').createUser(
+        admin = self.model('user').createUser(
             login='admin',
             password='password',
             email='admin@email.com',
             firstName='Admin',
             lastName='Admin',
             admin=True
+        )
+
+        user = self.model('user').createUser(
+            login='user',
+            password='password',
+            email='user@email.com',
+            firstName='User',
+            lastName='User',
+            admin=False
         )
 
         publicFolder = self.model('folder').childFolders(
@@ -39,3 +48,6 @@ class WebClientTestCase(web_client_test.WebClientTestCase):
         )
         self.model('image_item', 'large_image').copyItem(
             item, user, name='copy')
+
+        self.model('annotation', 'large_image').createAnnotation(
+            item, admin, {'name': 'admin annotation'})

--- a/web_client/dialogs/confirmDialog.js
+++ b/web_client/dialogs/confirmDialog.js
@@ -1,0 +1,51 @@
+import $ from 'jquery';
+import _ from 'underscore';
+
+import View from 'girder/views/View';
+import 'girder/utilities/jquery/girderModal';
+
+import events from '../events';
+
+import template from '../templates/dialogs/confirmDialog.pug';
+// import '../stylesheets/dialogs/openAnnotatedImage.styl';
+
+let dialog = null;
+const defaultOptions = {
+    title: 'Warning',
+    message: 'Are you sure?',
+    submitButton: 'Yes',
+    onSubmit: _.noop
+
+};
+
+const ConfirmDialog = View.extend({
+    events: {
+        'click .h-submit': '_submit'
+    },
+    render() {
+        this.$el.html(template(this._options)).girderModal(this);
+        return this;
+    },
+
+    setOptions(options) {
+        this._options = _.defaults(options, defaultOptions);
+    },
+
+    _submit() {
+        this.trigger('h:submit', this._options);
+        this.$el.modal('hide');
+        this.off('h:submit');
+    }
+});
+
+events.on('h:confirmDialog', function (options = {}) {
+    if (!dialog) {
+        dialog = new ConfirmDialog({
+            parentView: null
+        });
+    }
+    dialog.off('h:submit');
+    dialog.setOptions(options);
+    dialog.on('h:submit', options.onSubmit);
+    dialog.setElement($('#g-dialog-container')).render();
+});

--- a/web_client/dialogs/index.js
+++ b/web_client/dialogs/index.js
@@ -1,9 +1,11 @@
+import confirmDialog from './confirmDialog';
 import openAnnotatedImage from './openAnnotatedImage';
 import openImage from './openImage';
 import editAnnotation from './editAnnotation';
 import saveAnnotation from './saveAnnotation';
 
 export {
+    confirmDialog,
     openAnnotatedImage,
     openImage,
     editAnnotation,

--- a/web_client/panels/AnnotationSelector.js
+++ b/web_client/panels/AnnotationSelector.js
@@ -1,6 +1,7 @@
 import _ from 'underscore';
 
 import eventStream from 'girder/utilities/EventStream';
+import { getCurrentUser } from 'girder/auth';
 import Panel from 'girder_plugins/slicer_cli_web/views/Panel';
 
 import annotationSelectorWidget from '../templates/panels/annotationSelector.pug';
@@ -48,7 +49,8 @@ var AnnotationSelector = Panel.extend({
             id: 'annotation-panel-container',
             title: 'Annotations',
             activeAnnotation: this._getActiveAnnotation ? this._getActiveAnnotation() : null,
-            showLabels: this._showLabels
+            showLabels: this._showLabels,
+            user: getCurrentUser() || {}
         }));
         this.$('.s-panel-content').collapse({toggle: false});
         this.$('[data-toggle="tooltip"]').tooltip({container: 'body'});

--- a/web_client/panels/AnnotationSelector.js
+++ b/web_client/panels/AnnotationSelector.js
@@ -4,6 +4,7 @@ import eventStream from 'girder/utilities/EventStream';
 import { getCurrentUser } from 'girder/auth';
 import Panel from 'girder_plugins/slicer_cli_web/views/Panel';
 
+import events from '../events';
 import annotationSelectorWidget from '../templates/panels/annotationSelector.pug';
 import '../stylesheets/panels/annotationSelector.styl';
 
@@ -109,12 +110,21 @@ var AnnotationSelector = Panel.extend({
      * Delete an annotation from the server.
      */
     deleteAnnotation(evt) {
-        var id = $(evt.currentTarget).parents('.h-annotation').data('id');
-        var model = this.collection.get(id);
+        const id = $(evt.currentTarget).parents('.h-annotation').data('id');
+        const model = this.collection.get(id);
+
         if (model) {
-            model.unset('displayed');
-            this.collection.remove(model);
-            model.destroy();
+            const name = (model.get('annotation') || {}).name || 'unnamed annotation';
+            events.trigger('h:confirmDialog', {
+                title: 'Warning',
+                message: `Are you sure you want to delete ${name}?`,
+                submitButton: 'Delete',
+                onSubmit: () => {
+                    model.unset('displayed');
+                    this.collection.remove(model);
+                    model.destroy();
+                }
+            });
         }
     },
 

--- a/web_client/templates/dialogs/confirmDialog.pug
+++ b/web_client/templates/dialogs/confirmDialog.pug
@@ -1,0 +1,14 @@
+.modal-dialog(role='document')
+  .modal-content
+    .modal-header
+      button.close(type='button', data-dismiss='modal', aria-label='Close')
+        span(aria-hidden='true') &times;
+      h4.modal-title
+        = title
+    .modal-body
+      p
+        = message
+    .modal-footer
+      button.btn.btn-small.btn-default(data-dismiss='modal') Cancel
+      button.btn.btn-small.btn-danger.h-submit(type='submit')
+        = submitButton

--- a/web_client/templates/panels/annotationSelector.pug
+++ b/web_client/templates/panels/annotationSelector.pug
@@ -4,10 +4,12 @@ block title
   | #[span.icon-tags] #{title}
 
 block content
+  - var admin = user.get('admin');
   each annotation in annotations
     if annotation.id !== activeAnnotation
       - var name = annotation.get('annotation').name;
       - var displayed = annotation.get('displayed');
+      - var writeAccess = admin || user.id === annotation.get('creatorId');
       .h-annotation(data-id=annotation.id)
         if displayed
           span.icon-eye.h-toggle-annotation(
@@ -18,12 +20,13 @@ block content
         span.h-annotation-name(title=name) #{name}
 
         span.h-annotation-right
+          if writeAccess
+            span.icon-cancel.h-delete-annotation(
+                data-toggle='tooltip', title='Remove annotation')
           a(href=annotation.downloadUrl().replace(/\/download$/, ''),
               download=name + '.json')
             span.icon-download.h-download-annotation(
                 data-toggle='tooltip', title='Download annotation')
-          span.icon-cancel.h-delete-annotation(
-              data-toggle='tooltip', title='Remove annotation')
 
   .checkbox.h-annotation-toggle
     label


### PR DESCRIPTION
This does two things that we previously discussed:

1. Adds a confirmation dialog that appears when trying to delete an annotation.
2. Removes the "delete annotation" button from the panel for annotations not created by the current user.  For admins, the icon will always appear.