### PR TITLE
Use extras requirements when installing large_image.

### DIFF
--- a/ansible/roles/girder-histomicstk/tasks/main.yml
+++ b/ansible/roles/girder-histomicstk/tasks/main.yml
@@ -134,6 +134,13 @@
   command: girder-install plugin -s {{ root_dir }}/large_image
   become: true
 
+- name: Install large_image extras
+  become: true
+  pip:
+    name: ""
+    extra_args: "{{ root_dir }}/large_image[memcached,openslide]"
+    state: present
+
 - name: Install our external girder plugins - HistomicsTK
   command: girder-install plugin -s {{ root_dir }}/HistomicsTK
   become: true


### PR DESCRIPTION
large_image will soon require this to be installed in the expected way (see https://github.com/girder/large_image/pull/213).  This change allows installation through ansible (via vagrant, docker, etc.) before and after that PR gets merged.