### PR TITLE
Install large_image dependencies from setup.py

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -117,7 +117,7 @@ install:
     - pip install --no-cache-dir numpy>=1.12.1
     - pip install --upgrade --no-cache-dir --force-reinstall --ignore-installed openslide-python Pillow
 
-    - pip install -U -r requirements.txt
+    - pip install -U -e .
     - python setup.py install
     - cd $main_path
     - pip install --upgrade 'git+https://github.com/cdeepakroy/ctk-cli'

--- a/.travis.yml
+++ b/.travis.yml
@@ -117,7 +117,7 @@ install:
     - pip install --no-cache-dir numpy>=1.12.1
     - pip install --upgrade --no-cache-dir --force-reinstall --ignore-installed openslide-python Pillow
 
-    - pip install -U -e .
+    - pip install -U .[memcached,openslide]
     - python setup.py install
     - cd $main_path
     - pip install --upgrade 'git+https://github.com/cdeepakroy/ctk-cli'


### PR DESCRIPTION
The requirements file was removed in https://github.com/girder/large_image/pull/213, so just get the dependencies from the `setup.py`.