### PR TITLE
Fix working with old versions of docker-py.

### DIFF
--- a/ansible/deploy_docker.py
+++ b/ansible/deploy_docker.py
@@ -449,7 +449,12 @@ def docker_client():
     Return the current docker client in a manner that works with both the
     docker-py and docker modules.
     """
-    client = docker.from_env(version='auto')
+    try:
+        client = docker.from_env(version='auto')
+    except TypeError:
+        # On older versions of docker-py (such as 1.9), version isn't a
+        # parameter, so try without it
+        client = docker.from_env()
     client = client if not hasattr(client, 'api') else client.api
     return client
 


### PR DESCRIPTION
We claim to work with docker-py >= 1.9, but this was no longer true.  Since it is a simple fix, work with the old version.