### PR TITLE
Fix anonymous annotation viewing.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ addons:
       - libxml2-dev
       - libsqlite3-dev
       # girder worker
-      - rabbitmq-server
+      # - rabbitmq-server
       # pandoc for displaying jupyter notebook examples on ReadTheDocs
       - pandoc
       - pandoc-citeproc
@@ -140,7 +140,7 @@ script:
     - cmake -DPYTHON_COVERAGE:BOOL=${PY_COVG} -DPYTHON_VERSION:STRING=${TRAVIS_PYTHON_VERSION} -DPYTHON_COVERAGE_CONFIG="$main_path/plugin_tests/pycoverage.cfg" -DCOVERAGE_MINIMUM_PASS=19 -DJS_COVERAGE_MINIMUM_PASS=19 -DRUN_CORE_TESTS:BOOL="OFF" -DTEST_PLUGINS:STRING="HistomicsTK" $girder_path
     - make
     - JASMINE_TIMEOUT=15000 ctest -VV
-    - travis-sphinx build --source=$main_path/docs 
+    - travis-sphinx build --source=$main_path/docs
 
 after_success:
     - bash <(curl -s https://codecov.io/bash) -R $main_path -s $build_path

--- a/web_client/templates/panels/annotationSelector.pug
+++ b/web_client/templates/panels/annotationSelector.pug
@@ -4,12 +4,12 @@ block title
   | #[span.icon-tags] #{title}
 
 block content
-  - var admin = user.get('admin');
+  - var admin = user && user.get && user.get('admin');
   each annotation in annotations
     if annotation.id !== activeAnnotation
       - var name = annotation.get('annotation').name;
       - var displayed = annotation.get('displayed');
-      - var writeAccess = admin || user.id === annotation.get('creatorId');
+      - var writeAccess = admin || (user && user.id === annotation.get('creatorId'));
       .h-annotation(data-id=annotation.id)
         if displayed
           span.icon-eye.h-toggle-annotation(


### PR DESCRIPTION
If the user isn't defined, a console error would be thrown and annotations were not visible.