### PR TITLE
Fix image links for annotation images dialog.

### DIFF
--- a/web_client/templates/dialogs/openAnnotatedImage.pug
+++ b/web_client/templates/dialogs/openAnnotatedImage.pug
@@ -13,7 +13,7 @@
             a.list-group-item.h-annotated-image(data-id=item._id, data-toggle='tooltip', title=paths[item._id])
               .media
                 .media-left.media-middle
-                  img(src=`../api/v1/item/${item._id}/tiles/thumbnail?height=64&width=64`)
+                  img(src=`api/v1/item/${item._id}/tiles/thumbnail?height=64&width=64`)
                 .media-body
                   h4.media-heading #{item.name}
                   p #{item.description}


### PR DESCRIPTION
Under a proxy, this was referencing a path above where it should have been.  This change works locally and under the proxy.