### PR TITLE
Add a setting to set and reset the default styles in the draw panel.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -137,11 +137,11 @@ install:
 script:
     - mkdir -p $build_path/girder_testing_build
     - cd $build_path/girder_testing_build
-    - cmake -DPYTHON_COVERAGE:BOOL=${PY_COVG} -DPYTHON_VERSION:STRING=${TRAVIS_PYTHON_VERSION} -DPYTHON_COVERAGE_CONFIG="$main_path/plugin_tests/pycoverage.cfg" -DCOVERAGE_MINIMUM_PASS=19 -DJS_COVERAGE_MINIMUM_PASS=19 -DRUN_CORE_TESTS:BOOL="OFF" -DTEST_PLUGINS:STRING="HistomicsTK" $girder_path
+    - cmake -DPYTHON_COVERAGE:BOOL=${PY_COVG} -DPYTHON_VERSION:STRING=${TRAVIS_PYTHON_VERSION} -DCOVERAGE_MINIMUM_PASS=19 -DJS_COVERAGE_MINIMUM_PASS=19 -DRUN_CORE_TESTS:BOOL="OFF" -DTEST_PLUGINS:STRING="HistomicsTK" $girder_path
     - make
     - JASMINE_TIMEOUT=15000 ctest -VV
     - travis-sphinx build --source=$main_path/docs
 
 after_success:
-    - bash <(curl -s https://codecov.io/bash) -R $main_path -s $build_path
+    - bash <(curl -s https://codecov.io/bash) -R $main_path -s $girder_path
     - travis-sphinx deploy

--- a/plugin.cmake
+++ b/plugin.cmake
@@ -39,6 +39,8 @@ add_python_style_test(
 )
 
 # API tests
+add_histomicstk_python_test(histomicstk)
+
 add_histomicstk_python_test(docker)
 
 add_histomicstk_python_test(example)
@@ -143,6 +145,7 @@ add_histomicstk_python_test(cli_results
 )
 
 # front-end tests
+
 add_web_client_test(
   annotations
   "${CMAKE_CURRENT_LIST_DIR}/plugin_tests/client/annotationSpec.js"
@@ -150,6 +153,14 @@ add_web_client_test(
   TEST_MODULE "plugin_tests.web_client_test"
   TEST_PYTHONPATH "${CMAKE_CURRENT_LIST_DIR}"
   # EXTERNAL_DATA "plugins/HistomicsTK/sample_svs_image.TCGA-DU-6399-01A-01-TS1.e8eb65de-d63e-42db-af6f-14fefbbdf7bd.svs"
+)
+
+add_web_client_test(
+  histomicstk
+  "${CMAKE_CURRENT_LIST_DIR}/plugin_tests/client/histomicstkSpec.js"
+  PLUGIN HistomicsTK
+  TEST_MODULE "plugin_tests.web_client_test"
+  TEST_PYTHONPATH "${CMAKE_CURRENT_LIST_DIR}"
 )
 
 add_eslint_test(

--- a/plugin.cmake
+++ b/plugin.cmake
@@ -148,6 +148,7 @@ add_web_client_test(
   "${CMAKE_CURRENT_LIST_DIR}/plugin_tests/client/annotationSpec.js"
   PLUGIN HistomicsTK
   TEST_MODULE "plugin_tests.web_client_test"
+  TEST_PYTHONPATH "${CMAKE_CURRENT_LIST_DIR}"
   # EXTERNAL_DATA "plugins/HistomicsTK/sample_svs_image.TCGA-DU-6399-01A-01-TS1.e8eb65de-d63e-42db-af6f-14fefbbdf7bd.svs"
 )
 

--- a/plugin_tests/client/histomicstkSpec.js
+++ b/plugin_tests/client/histomicstkSpec.js
@@ -12,6 +12,9 @@ girderTest.startApp();
 
 describe('Test the HistomicsTK plugin', function () {
     it('change the HistomicsTK settings', function () {
+        var styles = [{'lineWidth': 8, 'id': 'Sample Group'}];
+        var styleJSON = JSON.stringify(styles);
+
         girderTest.login('admin', 'Admin', 'Admin', 'password')();
         waitsFor(function () {
             return $('a.g-nav-link[g-target="admin"]').length > 0;
@@ -37,8 +40,6 @@ describe('Test the HistomicsTK plugin', function () {
             return $('#g-histomicstk-form input').length > 0;
         }, 'settings to be shown');
         girderTest.waitForLoad();
-        var styles = [{'lineWidth': 8, 'id': 'Sample Group'}];
-        var styleJSON = JSON.stringify(styles);
         runs(function () {
             $('#g-histomicstk-default-draw-styles').val(styleJSON);
             $('.g-histomicstk-buttons .btn-primary').click();

--- a/plugin_tests/client/histomicstkSpec.js
+++ b/plugin_tests/client/histomicstkSpec.js
@@ -1,0 +1,78 @@
+/* globals girder, girderTest, describe, it, expect, waitsFor, runs */
+
+girderTest.addScripts([
+    '/clients/web/static/built/plugins/jobs/plugin.min.js',
+    '/clients/web/static/built/plugins/worker/plugin.min.js',
+    '/clients/web/static/built/plugins/large_image/plugin.min.js',
+    '/clients/web/static/built/plugins/slicer_cli_web/plugin.min.js',
+    '/clients/web/static/built/plugins/HistomicsTK/plugin.min.js'
+]);
+
+girderTest.startApp();
+
+describe('Test the HistomicsTK plugin', function () {
+    it('change the HistomicsTK settings', function () {
+        girderTest.login('admin', 'Admin', 'Admin', 'password')();
+        waitsFor(function () {
+            return $('a.g-nav-link[g-target="admin"]').length > 0;
+        }, 'admin console link to load');
+        runs(function () {
+            $('a.g-nav-link[g-target="admin"]').click();
+        });
+        waitsFor(function () {
+            return $('.g-plugins-config').length > 0;
+        }, 'the admin console to load');
+        runs(function () {
+            $('.g-plugins-config').click();
+        });
+        waitsFor(function () {
+            return $('input.g-plugin-switch[key="HistomicsTK"]').length > 0;
+        }, 'the plugins page to load');
+        girderTest.waitForLoad();
+        runs(function () {
+            expect($('.g-plugin-config-link[g-route="plugins/HistomicsTK/config"]').length > 0);
+            $('.g-plugin-config-link[g-route="plugins/HistomicsTK/config"]').click();
+        });
+        waitsFor(function () {
+            return $('#g-histomicstk-form input').length > 0;
+        }, 'settings to be shown');
+        girderTest.waitForLoad();
+        var styles = [{'lineWidth': 8, 'id': 'Sample Group'}];
+        var styleJSON = JSON.stringify(styles);
+        runs(function () {
+            $('#g-histomicstk-default-draw-styles').val(styleJSON);
+            $('.g-histomicstk-buttons .btn-primary').click();
+        });
+        waitsFor(function () {
+            var resp = girder.rest.restRequest({
+                url: 'system/setting',
+                method: 'GET',
+                data: {
+                    list: JSON.stringify([
+                        'histomicstk.default_draw_styles'
+                    ])
+                },
+                async: false
+            });
+            var settings = resp.responseJSON;
+            var settingsStyles = settings && JSON.parse(settings['histomicstk.default_draw_styles']);
+            return (settingsStyles && settingsStyles.length === 1 &&
+                    settingsStyles[0].lineWidth === styles[0].lineWidth);
+        }, 'HistomicsTK settings to change');
+        girderTest.waitForLoad();
+        runs(function () {
+            $('#g-histomicstk-default-draw-styles').val('not a json list');
+            $('.g-histomicstk-buttons .btn-primary').click();
+        });
+        waitsFor(function () {
+            return $('#g-histomicstk-error-message').text().substr('must be a JSON list') >= 0;
+        });
+        runs(function () {
+            $('.g-histomicstk-buttons #g-histomicstk-cancel').click();
+        });
+        waitsFor(function () {
+            return $('input.g-plugin-switch[key="HistomicsTK"]').length > 0;
+        }, 'the plugins page to load');
+        girderTest.waitForLoad();
+    });
+});

--- a/plugin_tests/histomicstk_test.py
+++ b/plugin_tests/histomicstk_test.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import json
+import os
+import six
+
+from girder import config
+from girder.models.model_base import ValidationException
+from girder.models.setting import Setting
+from tests import base
+
+
+os.environ['GIRDER_PORT'] = os.environ.get('GIRDER_TEST_PORT', '20200')
+config.loadConfig()  # Must reload config to pickup correct port
+
+
+# boiler plate to start and stop the server
+def setUpModule():
+    base.enabledPlugins.append('HistomicsTK')
+    base.startServer()
+
+
+def tearDownModule():
+    base.stopServer()
+
+
+class HistomicsTKCoreTest(base.TestCase):
+
+    def testSettings(self):
+        from girder.plugins.HistomicsTK import constants
+
+        key = constants.PluginSettings.HISTOMICSTK_DEFAULT_DRAW_STYLES
+
+        resp = self.request(path='/HistomicsTK/settings')
+        self.assertStatus(resp, 200)
+        settings = resp.json
+        self.assertEqual(settings[key], None)
+
+        Setting().set(key, '')
+        self.assertEqual(Setting().get(key), None)
+        with six.assertRaisesRegex(self, ValidationException, 'must be a JSON'):
+            Setting().set(key, 'not valid')
+        with six.assertRaisesRegex(self, ValidationException, 'must be a JSON'):
+            Setting().set(key, json.dumps({'not': 'a list'}))
+        value = [{'lineWidth': 8, 'id': 'Group 8'}]
+        Setting().set(key, json.dumps(value))
+        self.assertEqual(json.loads(Setting().get(key)), value)
+        Setting().set(key, value)
+        self.assertEqual(json.loads(Setting().get(key)), value)
+
+        resp = self.request(path='/HistomicsTK/settings')
+        self.assertStatus(resp, 200)
+        settings = resp.json
+        self.assertEqual(json.loads(settings[key]), value)

--- a/plugin_tests/pycoverage.cfg
+++ b/plugin_tests/pycoverage.cfg
@@ -1,6 +1,0 @@
-[run]
-branch = False
-
-[report]
-omit = girder/*,clients/python/*
-

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -1,7 +1,12 @@
+import json
 import os
 
 from girder import events
+from girder.api import access
+from girder.api.describe import Description, describeRoute
+from girder.exceptions import ValidationException
 from girder.utility.webroot import Webroot
+from girder.utility import setting_utilities
 
 from girder.plugins.slicer_cli_web.rest_slicer_cli import (
     genRESTEndPointsForSlicerCLIsInDockerCache
@@ -10,12 +15,48 @@ from girder.plugins.slicer_cli_web.rest_slicer_cli import (
 from girder.plugins.slicer_cli_web.docker_resource import DockerResource
 
 from .handlers import process_annotations
+import constants
 
 from girder.models.model_base import ModelImporter
 _template = os.path.join(
     os.path.dirname(__file__),
     'webroot.mako'
 )
+
+
+@setting_utilities.validator({
+    constants.PluginSettings.HISTOMICSTK_DEFAULT_DRAW_STYLES
+})
+def validateListOrJSON(doc):
+    val = doc['value']
+    try:
+        if isinstance(val, list):
+            doc['value'] = json.dumps(val)
+        elif val is None or val.strip() == '':
+            doc['value'] = None
+        else:
+            parsed = json.loads(val)
+            if not isinstance(parsed, list):
+                raise ValueError
+            doc['value'] = val.strip()
+    except (ValueError, AttributeError):
+        raise ValidationException('%s must be a JSON list.' % doc['key'], 'value')
+
+
+class HistomicsTKResource(DockerResource):
+    def __init__(self, name, *args, **kwargs):
+        super(HistomicsTKResource, self).__init__(name, *args, **kwargs)
+        self.route('GET', ('settings',), self.getPublicSettings)
+
+    @describeRoute(
+        Description('Get public settings for HistomicsTK.')
+    )
+    @access.public
+    def getPublicSettings(self, params):
+        keys = [
+            constants.PluginSettings.HISTOMICSTK_DEFAULT_DRAW_STYLES,
+        ]
+        return {k: self.model('setting').get(k) for k in keys}
 
 
 def load(info):
@@ -29,7 +70,7 @@ def load(info):
     info['serverRoot'].girder = girderRoot
 
     # create root resource for all REST end points of HistomicsTK
-    resource = DockerResource('HistomicsTK')
+    resource = HistomicsTKResource('HistomicsTK')
     setattr(info['apiRoot'], resource.resourceName, resource)
 
     # load docker images from cache

--- a/server/constants.py
+++ b/server/constants.py
@@ -1,0 +1,7 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+
+# Constants representing the setting keys for this plugin
+class PluginSettings:
+    HISTOMICSTK_DEFAULT_DRAW_STYLES = 'histomicstk.default_draw_styles'

--- a/web_client/main.js
+++ b/web_client/main.js
@@ -1,7 +1,21 @@
+import events from 'girder/events';
+import router from 'girder/router';
+
 import { registerPluginNamespace } from 'girder/pluginUtils';
+import { exposePluginConfig } from 'girder/utilities/PluginUtils';
 
-import * as histomicstk from '.';
+// expose symbols under girder.plugins
+import * as histomicstk from 'girder_plugins/HistomicsTK';
 
-registerPluginNamespace('HistomicsTK', histomicstk);
+import ConfigView from './views/body/ConfigView';
 
-export default histomicstk;
+const pluginName = 'HistomicsTK';
+const configRoute = `plugins/${pluginName}/config`;
+
+registerPluginNamespace(pluginName, histomicstk);
+
+exposePluginConfig(pluginName, configRoute);
+
+router.route(configRoute, 'HistomicsTKConfig', function () {
+    events.trigger('g:navigateTo', ConfigView);
+});

--- a/web_client/panels/AnnotationSelector.js
+++ b/web_client/panels/AnnotationSelector.js
@@ -155,7 +155,7 @@ var AnnotationSelector = Panel.extend({
     },
 
     _refreshAnnotations() {
-        if (!this.parentItem) {
+        if (!this.parentItem || !this.parentItem.id) {
             return;
         }
         var models = this.collection.indexBy(_.property('id'));

--- a/web_client/stylesheets/body/configView.styl
+++ b/web_client/stylesheets/body/configView.styl
@@ -1,0 +1,4 @@
+#g-histomicstk-form
+  .g-histomicstk-description
+    font-size 12px
+    margin 0 0 2px

--- a/web_client/stylesheets/dialogs/editStyleGroups.styl
+++ b/web_client/stylesheets/dialogs/editStyleGroups.styl
@@ -1,2 +1,4 @@
 select.h-group-name
   appearance none
+.h-btn-left
+  float left

--- a/web_client/templates/body/configView.pug
+++ b/web_client/templates/body/configView.pug
@@ -1,0 +1,15 @@
+.g-config-breadcrumb-container
+p.g-histomicstk-description
+  | Provides a tool hit for analyzing histology images.
+form#g-histomicstk-form(role="form")
+  .form-group
+    label
+      | Default styles for drawing annotations
+    input#g-histomicstk-default-draw-styles.input-sm.form-control(
+        type="text", value=settings['histomicstk.default_draw_styles'],
+        placeholder='A JSON object listing default annotation drawing styles.',
+        title='A dictionary of drawing styles')
+  p#g-histomicstk-error-message.g-validation-failed-message
+.g-histomicstk-buttons
+  button#g-histomicstk-save.btn.btn-sm.btn-primary Save
+  button#g-histomicstk-cancel.btn.btn-sm.btn-default Cancel

--- a/web_client/templates/dialogs/editStyleGroups.pug
+++ b/web_client/templates/dialogs/editStyleGroups.pug
@@ -52,5 +52,8 @@
               i
         .g-validation-failed-message.hidden
       .modal-footer
-        button.btn.btn-small.btn-default(type='button', data-dismiss='modal') Cancel
+        button#h-reset-defaults.btn.btn-small.btn-default.h-btn-left(type='button') Reset to Defaults
+        if user.get && user.get('admin')
+          button#h-set-defaults.btn.btn-small.btn-default.h-btn-left(type='button') Save as Defaults
+        button.btn.btn-small.btn-default.h-cancel(type='button', data-dismiss='modal') Cancel
         button.btn.btn-small.btn-primary.h-submit(type='submit') Save

--- a/web_client/views/body/ConfigView.js
+++ b/web_client/views/body/ConfigView.js
@@ -26,7 +26,7 @@ var ConfigView = View.extend({
     },
     initialize: function () {
         this.breadcrumb = new PluginConfigBreadcrumbWidget({
-            pluginName: 'Database assetstore',
+            pluginName: 'HistomicsTK',
             parentView: this
         });
 

--- a/web_client/views/body/ConfigView.js
+++ b/web_client/views/body/ConfigView.js
@@ -1,0 +1,78 @@
+import View from 'girder/views/View';
+
+import PluginConfigBreadcrumbWidget from 'girder/views/widgets/PluginConfigBreadcrumbWidget';
+import { restRequest } from 'girder/rest';
+import events from 'girder/events';
+import router from 'girder/router';
+
+import ConfigViewTemplate from '../../templates/body/configView.pug';
+import '../../stylesheets/body/configView.styl';
+
+/**
+ * Show the default quota settings for users and collections.
+ */
+var ConfigView = View.extend({
+    events: {
+        'click #g-histomicstk-save': function (event) {
+            this.$('#g-histomicstk-error-message').text('');
+            this._saveSettings([{
+                key: 'histomicstk.default_draw_styles',
+                value: this.$('#g-histomicstk-default-draw-styles').val()
+            }]);
+        },
+        'click #g-histomicstk-cancel': function (event) {
+            router.navigate('plugins', {trigger: true});
+        }
+    },
+    initialize: function () {
+        this.breadcrumb = new PluginConfigBreadcrumbWidget({
+            pluginName: 'Database assetstore',
+            parentView: this
+        });
+
+        restRequest({
+            method: 'GET',
+            url: 'system/setting',
+            data: {
+                list: JSON.stringify([
+                    'histomicstk.default_draw_styles'
+                ])
+            }
+        }).done((resp) => {
+            this.settings = resp;
+            this.render();
+        });
+    },
+
+    render: function () {
+        this.$el.html(ConfigViewTemplate({
+            settings: this.settings
+        }));
+        this.breadcrumb.setElement(this.$('.g-config-breadcrumb-container')).render();
+        return this;
+    },
+
+    _saveSettings: function (settings) {
+        return restRequest({
+            method: 'PUT',
+            url: 'system/setting',
+            data: {
+                list: JSON.stringify(settings)
+            },
+            error: null
+        }).done(() => {
+            events.trigger('g:alert', {
+                icon: 'ok',
+                text: 'Settings saved.',
+                type: 'success',
+                timeout: 4000
+            });
+        }).fail((resp) => {
+            this.$('#g-histomicstk-error-message').text(
+                resp.responseJSON.message
+            );
+        });
+    }
+});
+
+export default ConfigView;

--- a/web_client/views/body/ImageView.js
+++ b/web_client/views/body/ImageView.js
@@ -56,6 +56,9 @@ var ImageView = View.extend({
         this.listenTo(this.annotationSelector, 'h:deleteAnnotation', this._deleteAnnotation);
 
         this.listenTo(events, 's:widgetChanged:region', this.widgetRegion);
+        this.listenTo(events, 'g:login g:logout.success g:logout.error', () => {
+            this._openId = null;
+        });
         this.render();
     },
     render() {

--- a/web_client/views/body/index.js
+++ b/web_client/views/body/index.js
@@ -1,7 +1,9 @@
 import FrontPageView from './FrontPageView';
 import ImageView from './ImageView';
+import ConfigView from './ConfigView';
 
 export {
     ImageView,
-    FrontPageView
+    FrontPageView,
+    ConfigView
 };


### PR DESCRIPTION
This exposes the setting in JSON in the HistomicsTK plugin configuration page, plus adds buttons to the styles panel to reset to defaults or to set the defaults to the current values.

This also adds a user-readable settings endpoint (since otherwise settings are admin-only).

Fix coverage reporting based on recent girder changes.

Fix a bug when logging out and logging in had off behavior.   Specifically, after logging out a warning could be shown because annotations could not be loaded.  If, after logging in again, the same image was selected that had been used before log out, it would not be shown.