### PR TITLE
Highlight hovered annotations

### DIFF
--- a/web_client/panels/AnnotationSelector.js
+++ b/web_client/panels/AnnotationSelector.js
@@ -116,9 +116,7 @@ var AnnotationSelector = Panel.extend({
         var id = $(evt.currentTarget).parents('.h-annotation').data('id');
         var model = this.collection.get(id);
         model.set('displayed', !model.get('displayed'));
-        if (model.get('displayed')) {
-            model.set('highlight', true);
-        } else {
+        if (!model.get('displayed')) {
             model.unset('highlight');
         }
     },

--- a/web_client/panels/AnnotationSelector.js
+++ b/web_client/panels/AnnotationSelector.js
@@ -183,10 +183,15 @@ var AnnotationSelector = Panel.extend({
     editAnnotation(evt) {
         var id = $(evt.currentTarget).parents('.h-annotation').data('id');
         var model = this.collection.get(id);
+
+        // deselect the annotation if it is already selected
         if (this._activeAnnotation && model && this._activeAnnotation.id === model.id) {
-            model.set('displayed', true);
+            this._activeAnnotation = null;
+            this.trigger('h:editAnnotation', null);
+            this.render();
             return;
         }
+
         if (!this._writeAccess(model)) {
             events.trigger('g:alert', {
                 text: 'You do not have write access to this annotation.',

--- a/web_client/panels/AnnotationSelector.js
+++ b/web_client/panels/AnnotationSelector.js
@@ -29,6 +29,8 @@ var AnnotationSelector = Panel.extend({
         'click .h-edit-annotation-metadata': 'editAnnotationMetadata',
         'click .h-show-all-annotations': 'showAllAnnotations',
         'click .h-hide-all-annotations': 'hideAllAnnotations',
+        'mouseenter .h-annotation': '_highlightAnnotation',
+        'mouseleave .h-annotation': '_unhighlightAnnotation',
         'change #h-toggle-labels': 'toggleLabels'
     }),
 
@@ -113,6 +115,11 @@ var AnnotationSelector = Panel.extend({
         var id = $(evt.currentTarget).parents('.h-annotation').data('id');
         var model = this.collection.get(id);
         model.set('displayed', !model.get('displayed'));
+        if (model.get('displayed')) {
+            model.set('highlight', true);
+        } else {
+            model.unset('highlight');
+        }
     },
 
     /**
@@ -131,6 +138,7 @@ var AnnotationSelector = Panel.extend({
                 onSubmit: () => {
                     this.trigger('h:deleteAnnotation', model);
                     model.unset('displayed');
+                    model.unset('highlight');
                     this.collection.remove(model);
                     model.destroy();
                 }
@@ -246,7 +254,10 @@ var AnnotationSelector = Panel.extend({
         );
     },
 
-    _saveAnnotation(annotation) {
+    _saveAnnotation(annotation, attribute, options) {
+        if (options && options.noSave) {
+            return;
+        }
         if (!this._saving && annotation === this._activeAnnotation) {
             this._saving = true;
             annotation.save().always(() => {
@@ -275,6 +286,18 @@ var AnnotationSelector = Panel.extend({
         this.collection.each((model) => {
             model.set('displayed', false);
         });
+    },
+
+    _highlightAnnotation(evt) {
+        const id = $(evt.currentTarget).data('id');
+        const model = this.collection.get(id);
+        if (model.get('displayed')) {
+            this.parentView.trigger('h:highlightAnnotation', id);
+        }
+    },
+
+    _unhighlightAnnotation() {
+        this.parentView.trigger('h:highlightAnnotation');
     }
 });
 

--- a/web_client/panels/AnnotationSelector.js
+++ b/web_client/panels/AnnotationSelector.js
@@ -43,7 +43,8 @@ var AnnotationSelector = Panel.extend({
      *     to the current image.
      */
     initialize(settings) {
-        this.listenTo(this.collection, 'all', this.render);
+        this.listenTo(this.collection, 'sync remove update reset change:displayed change:loading', this.render);
+        this.listenTo(this.collection, 'change:highlight', this._changeAnnotationHighlight);
         this.listenTo(eventStream, 'g:event.job_status', _.debounce(this._onJobUpdate, 500));
         this.listenTo(eventStream, 'g:eventStream.start', this._refreshAnnotations);
         this.listenTo(this.collection, 'change:annotation', this._saveAnnotation);
@@ -298,6 +299,10 @@ var AnnotationSelector = Panel.extend({
 
     _unhighlightAnnotation() {
         this.parentView.trigger('h:highlightAnnotation');
+    },
+
+    _changeAnnotationHighlight(model) {
+        this.$(`.h-annotation[data-id="${model.id}"]`).toggleClass('h-highlight-annotation', model.get('highlighted'));
     }
 });
 

--- a/web_client/panels/AnnotationSelector.js
+++ b/web_client/panels/AnnotationSelector.js
@@ -255,10 +255,7 @@ var AnnotationSelector = Panel.extend({
         );
     },
 
-    _saveAnnotation(annotation, attribute, options) {
-        if (options && options.noSave) {
-            return;
-        }
+    _saveAnnotation(annotation) {
         if (!this._saving && annotation === this._activeAnnotation) {
             this._saving = true;
             annotation.save().always(() => {

--- a/web_client/panels/DrawWidget.js
+++ b/web_client/panels/DrawWidget.js
@@ -53,11 +53,11 @@ var DrawWidget = Panel.extend({
                 this._groups.get(this._style.id).save();
             }
         });
-        this.on('h:mouseover', (model) => {
+        this.on('h:mouseon', (model) => {
             this._highlighted[model.id] = true;
             this.$(`.h-element[data-id="${model.id}"]`).addClass('h-highlight-element');
         });
-        this.on('h:randomevent', (model) => {
+        this.on('h:mouseoff', (model) => {
             this._highlighted[model.id] = false;
             this.$(`.h-element[data-id="${model.id}"]`).removeClass('h-highlight-element');
         });

--- a/web_client/panels/DrawWidget.js
+++ b/web_client/panels/DrawWidget.js
@@ -55,13 +55,11 @@ var DrawWidget = Panel.extend({
         });
         this.on('h:mouseover', (model) => {
             this._highlighted[model.id] = true;
-            this._skipRedraw = true;
-            this.render();
+            this.$(`.h-element[data-id="${model.id}"]`).addClass('h-highlight-element');
         });
         this.on('h:randomevent', (model) => {
             this._highlighted[model.id] = false;
-            this._skipRedraw = true;
-            this.render();
+            this.$(`.h-element[data-id="${model.id}"]`).removeClass('h-highlight-element');
         });
     },
 
@@ -72,10 +70,7 @@ var DrawWidget = Panel.extend({
             return;
         }
         const name = (this.annotation.get('annotation') || {}).name || 'Untitled';
-        if (!this._skipRedraw) {
-            this.trigger('h:redraw', this.annotation);
-        }
-        this._skipRedraw = false;
+        this.trigger('h:redraw', this.annotation);
         this.$el.html(drawWidget({
             title: 'Draw',
             elements: this.collection.models,

--- a/web_client/stylesheets/panels/annotationSelector.styl
+++ b/web_client/stylesheets/panels/annotationSelector.styl
@@ -1,4 +1,5 @@
 .h-annotation
+    border-radius 3px
     span
         cursor pointer
     .h-float-left
@@ -19,7 +20,9 @@
 
 .h-annotation.h-active-annotation
   background-color #c5cae9 !important
-  border-radius 3px
+
+.h-annotation.h-highlight-annotation
+  background-color #ccc
 
 .h-create-annotation
   float right

--- a/web_client/stylesheets/panels/drawWidget.styl
+++ b/web_client/stylesheets/panels/drawWidget.styl
@@ -6,6 +6,7 @@
     padding 3px 5px
 
     .h-element
+        border-radius 3px
         span
             cursor pointer
 
@@ -15,6 +16,8 @@
         .h-delete-element
             float right
 
+    .h-element.h-highlight-element
+        background-color #ccc
 
     .h-element:hover
         background-color #eee

--- a/web_client/templates/panels/annotationSelector.pug
+++ b/web_client/templates/panels/annotationSelector.pug
@@ -17,8 +17,12 @@ block content
     - var name = annotation.get('annotation').name;
     - var displayed = annotation.get('displayed');
     - var loading = annotation.get('loading');
-    - var activeClass = annotation.id === activeAnnotation ? 'h-active-annotation' : ''
-    .h-annotation(data-id=annotation.id, class=activeClass)
+    - var classes = [];
+    if annotation.id === activeAnnotation
+      - classes.push('h-active-annotation');
+    if annotation.get('highlight')
+      - classes.push('h-highlight-annotation')
+    .h-annotation(data-id=annotation.id, class=classes)
       if loading
         span.icon-spin3.animate-spin.h-float-left
       else if displayed

--- a/web_client/templates/panels/drawWidget.pug
+++ b/web_client/templates/panels/drawWidget.pug
@@ -33,9 +33,10 @@ block content
   if elements.length
     .h-elements-container
       each element in elements
+        - var classes = highlighted[element.id] ? ['h-highlight-element'] : [];
         - element = element.toJSON();
         - var label = (element.label || {}).value || (element.type === 'polyline' ? (element.closed ? 'polygon' : 'line') : element.type);
-        .h-element(data-id=element.id)
+        .h-element(data-id=element.id, class=classes)
           span.icon-cog.h-edit-element(data-toggle='tooltip', title='Change style')
           span.h-element-label #{label}
           span.icon-cancel.h-delete-element(data-toggle='tooltip', title='Remove')

--- a/web_client/views/body/ImageView.js
+++ b/web_client/views/body/ImageView.js
@@ -54,6 +54,7 @@ var ImageView = View.extend({
         this.listenTo(this.annotationSelector, 'h:toggleLabels', this.toggleLabels);
         this.listenTo(this.annotationSelector, 'h:editAnnotation', this._editAnnotation);
         this.listenTo(this.annotationSelector, 'h:deleteAnnotation', this._deleteAnnotation);
+        this.listenTo(this, 'h:highlightAnnotation', this._highlightAnnotation);
 
         this.listenTo(events, 's:widgetChanged:region', this.widgetRegion);
         this.listenTo(events, 'g:login g:logout.success g:logout.error', () => {
@@ -86,6 +87,8 @@ var ImageView = View.extend({
             // handle annotation mouse events
             this.listenTo(this.viewerWidget, 'g:mouseOverAnnotation', this.mouseOverAnnotation);
             this.listenTo(this.viewerWidget, 'g:mouseOutAnnotation', this.mouseOutAnnotation);
+            this.listenTo(this.viewerWidget, 'g:mouseOnAnnotation', this.mouseOnAnnotation);
+            this.listenTo(this.viewerWidget, 'g:mouseOffAnnotation', this.mouseOffAnnotation);
             this.listenTo(this.viewerWidget, 'g:mouseClickAnnotation', this.mouseClickAnnotation);
             this.listenTo(this.viewerWidget, 'g:mouseResetAnnotation', this.mouseResetAnnotation);
 
@@ -312,6 +315,10 @@ var ImageView = View.extend({
         this.viewerWidget.drawAnnotation(annotation);
     },
 
+    _highlightAnnotation(annotation, element) {
+        this.viewerWidget.highlightAnnotation(annotation, element);
+    },
+
     widgetRegion(model) {
         var value = model.get('value');
         this.showRegion({
@@ -367,6 +374,24 @@ var ImageView = View.extend({
             this.$('.h-image-coordinates').text(
                 pt.x.toFixed() + ', ' + pt.y.toFixed()
             );
+        }
+    },
+
+    mouseOnAnnotation(element, annotationId) {
+        const annotation = this.annotations.get(annotationId);
+        const elementModel = annotation.elements().get(element.id);
+        annotation.set('highlight', true);
+        if (this.drawWidget) {
+            this.drawWidget.trigger('h:mouseover', elementModel);
+        }
+    },
+
+    mouseOffAnnotation(element, annotationId) {
+        const annotation = this.annotations.get(annotationId);
+        const elementModel = annotation.elements().get(element.id);
+        annotation.unset('highlight');
+        if (this.drawWidget) {
+            this.drawWidget.trigger('h:randomevent', elementModel);
         }
     },
 

--- a/web_client/views/body/ImageView.js
+++ b/web_client/views/body/ImageView.js
@@ -383,7 +383,7 @@ var ImageView = View.extend({
         const elementModel = annotation.elements().get(element.id);
         annotation.set('highlight', true);
         if (this.drawWidget) {
-            this.drawWidget.trigger('h:mouseover', elementModel);
+            this.drawWidget.trigger('h:mouseon', elementModel);
         }
     },
 
@@ -392,7 +392,7 @@ var ImageView = View.extend({
         const elementModel = annotation.elements().get(element.id);
         annotation.unset('highlight');
         if (this.drawWidget) {
-            this.drawWidget.trigger('h:randomevent', elementModel);
+            this.drawWidget.trigger('h:mouseoff', elementModel);
         }
     },
 

--- a/web_client/views/body/ImageView.js
+++ b/web_client/views/body/ImageView.js
@@ -80,7 +80,8 @@ var ImageView = View.extend({
                 parentView: this,
                 el: this.$('.h-image-view-container'),
                 itemId: this.model.id,
-                hoverEvents: true
+                hoverEvents: true,
+                highlightFeatureSizeLimit: 1000
             });
             this.trigger('h:viewerWidgetCreated', this.viewerWidget);
 


### PR DESCRIPTION
This adds two visual indicators for the user:

1. When an annotation element is hovered on the image, the corresponding
   annotation and element are highlighted in the panels.
2. When an annotation is hovered in the annotation panel or an element
   is hovered in the draw panel, the corresponding annotation or element
   is highlighted in the image.  This uses the `highlightAnnotation`
   method on the image viewer, which by default will make all other
   annotation elements more transparent.

Depends on https://github.com/girder/large_image/pull/236