### PR TITLE
Change how the command yaml is structured.

### DIFF
--- a/ansible/roles/provision/tasks/main.yml
+++ b/ansible/roles/provision/tasks/main.yml
@@ -235,18 +235,18 @@
   tags: data_import
 
 - name: Install CLI
-  command: >-
-    python cli_test.py --username "{{ girder_admin_user|quote }}" --password "{{ girder_admin_password|quote }}" --apiurl "{{ girder_socket_scheme|quote }}://127.0.0.1:{{ girder_socket_port }}/api/v1" "{{ cli_image|quote }}"
+  command: python cli_test.py --username {{ girder_admin_user|quote }} --password {{ girder_admin_password|quote }} --apiurl {{ girder_socket_scheme|quote }}://127.0.0.1:{{ girder_socket_port }}/api/v1 {{ cli_image|quote }}
   args:
     chdir: "{{ root_dir }}"
+  no_log: true
   when: docker is defined and cli_image is defined and cli_image_test is undefined
 
 - name: Install and test CLI
-  command: >-
-    python cli_test.py --username "{{ girder_admin_user|quote }}" --password "{{ girder_admin_password|quote }}" --apiurl "{{ girder_socket_scheme|quote }}://127.0.0.1:{{ girder_socket_port }}/api/v1" --test "{{ cli_image|quote }}"
+  shell: python cli_test.py --username {{ girder_admin_user|quote }} --password {{ girder_admin_password|quote }} --apiurl {{ girder_socket_scheme|quote }}://127.0.0.1:{{ girder_socket_port }}/api/v1 --test {{ cli_image|quote }}
   args:
     chdir: "{{ root_dir }}"
   register: test_output
+  no_log: true
   when: docker is defined and cli_image is defined and cli_image_test is defined
 
 - name: Show test CLI results
@@ -256,4 +256,3 @@
 - name: Show test CLI results
   debug: var=test_output.stderr_lines
   when: docker is defined and cli_image is defined and cli_image_test is defined
-


### PR DESCRIPTION
When a command in a yaml >- block, it is quoted differently than when it
is on the same line as the command: keyword.  It works with proper
quoting on one line, but fails for reasons I don't fully get in multiple
lines.  Switch to the one-line version to get the expected quoting
behavior.

Also, do not log ansible commands where a password is used.