### PR TITLE
Show the image name and path on the header bar.

### DIFF
--- a/web_client/stylesheets/layout/header.styl
+++ b/web_client/stylesheets/layout/header.styl
@@ -1,9 +1,29 @@
-#g-app-header-container
-  #h-navbar-brand
-    font-size 25px
-    font-weight 700
-  .g-header-wrapper
-    .h-image-menu-wrapper
-      display inline
-      float right
-  z-index 1000
+.histomicstk-body
+  #g-app-header-container
+    #h-navbar-brand
+      font-size 25px
+      font-weight 700
+    .g-header-wrapper
+      .h-image-menu-wrapper
+        display inline
+        float right
+    z-index 1000
+  @media (min-width: 768px)
+    .navbar-right
+      float none
+      margin-right 0
+      position absolute
+      right 0
+      white-space nowrap
+      z-index 10
+    .navbar-nav li
+      float none
+      display inline-block
+    .navbar > .container-fluid .navbar-brand
+      margin-left 0
+  .navbar-header
+    z-index 20
+    background #f8f8f8
+    float none
+    position absolute
+    left 0

--- a/web_client/stylesheets/layout/headerImage.styl
+++ b/web_client/stylesheets/layout/headerImage.styl
@@ -1,0 +1,6 @@
+.histomicstk-body
+  .g-item-breadcrumb-container
+    display inline-block
+    padding-right 10px
+    ol.breadcrumb
+      background none

--- a/web_client/templates/layout/headerImage.pug
+++ b/web_client/templates/layout/headerImage.pug
@@ -1,3 +1,26 @@
+if parentChain
+  .g-item-breadcrumb-container
+    -
+      var parts = [];
+      parentChain.forEach(function (parent, idx) {
+        parts.push(parent.type === 'user' ? parent.object.login : parent.object.name);
+      });
+      parts.push(image.name());
+    ol.breadcrumb(title=parts.join('/'))
+      each parent in parentChain
+        li
+          span.g-item-breadcrumb-link(data-id=parent.object._id, data-type=parent.type)
+            if (parent.type === "user")
+              i.icon-user
+              = parent.object.login
+            else if (parent.type === "collection")
+              i.icon-sitemap
+              = parent.object.name
+            else
+              = parent.object.name
+      li
+        span.g-item-breadcrumb-link(data-id=image.id, data-type='item')
+          = image.name()
 button.btn.btn-default.navbar-btn.h-open-annotated-image(type='button')
   | #[span.icon-list] Annotated images...
 button.btn.btn-default.navbar-btn.h-open-image(type='button')

--- a/web_client/views/layout/HeaderImageView.js
+++ b/web_client/views/layout/HeaderImageView.js
@@ -16,15 +16,24 @@ var HeaderImageView = View.extend({
 
     initialize() {
         this.imageModel = null;
+        this.parentChain = null;
         this.listenTo(events, 'h:imageOpened', (model) => {
             this.imageModel = model;
+            this.parentChain = null;
+            if (model) {
+                this.imageModel.getRootPath((resp) => {
+                    this.parentChain = resp;
+                    this.render();
+                });
+            }
             this.render();
         });
     },
 
     render() {
         this.$el.html(headerImageTemplate({
-            image: this.imageModel
+            image: this.imageModel,
+            parentChain: this.parentChain
         }));
         return this;
     }


### PR DESCRIPTION
Adjust various styles to make sure that a narrow window or long image path still looks okay.

This doesn't reuse the Girder item breadcrumbs widget because too much needed to change.

Closes #457.