### PR TITLE
Fix the layout of dropdown submenus

### DIFF
--- a/web_client/stylesheets/layout/header.styl
+++ b/web_client/stylesheets/layout/header.styl
@@ -16,7 +16,7 @@
       right 0
       white-space nowrap
       z-index 10
-    .navbar-nav li
+    .navbar-nav > li
       float none
       display inline-block
     .navbar > .container-fluid .navbar-brand


### PR DESCRIPTION
The CSS added in #460 set float and display properties of all `li`
elements inside the header.  This messed up the layout of the dropdown
submenus used by the analysis button.  Applying the CSS to just the
child `li` elements seems to work as expected.