### PR TITLE
Allow filtering by annotation creator and name

### DIFF
--- a/plugin_tests/client/annotationSpec.js
+++ b/plugin_tests/client/annotationSpec.js
@@ -863,11 +863,15 @@ $(function () {
             runs(function () {
                 $('.h-open-annotated-image').click();
             });
-            girderTest.waitForDialog();
+
+            waitsFor(function () {
+                var imageId = histomicsTest.imageId();
+                var $el = $('.h-annotated-image[data-id="' + imageId + '"]');
+                return $el.length === 1;
+            });
             runs(function () {
                 var imageId = histomicsTest.imageId();
                 var $el = $('.h-annotated-image[data-id="' + imageId + '"]');
-                expect($el.length).toBe(1);
                 expect($el.find('.media-left img').prop('src'))
                     .toMatch(/item\/[0-9a-f]*\/tiles\/thumbnail/);
                 expect($el.find('.media-heading').text()).toBe('image');

--- a/plugin_tests/client/annotationSpec.js
+++ b/plugin_tests/client/annotationSpec.js
@@ -835,6 +835,30 @@ $(function () {
     });
 
     describe('Open recently annotated image', function () {
+        var restPromise = null;
+        var girderRestRequest = null;
+
+        beforeEach(function () {
+            restPromise = $.Deferred();
+            girderRestRequest = girder.rest.restRequest;
+            // Wrap girder's restRequest method to notify the testing code below
+            // that the image list endpoint has returned.
+            girder.rest.restRequest = function (opts) {
+                var promise = girderRestRequest.apply(this, arguments);
+                if (opts.url === 'annotation/images') {
+                    promise.done(function () {
+                        restPromise.resolve(opts);
+                    });
+                }
+                return promise;
+            };
+        });
+
+        afterEach(function () {
+            girder.rest.restRequest = girderRestRequest;
+            restPromise = null;
+        });
+
         it('open the dialog', function () {
             runs(function () {
                 $('.h-open-annotated-image').click();
@@ -848,6 +872,55 @@ $(function () {
                     .toMatch(/item\/[0-9a-f]*\/tiles\/thumbnail/);
                 expect($el.find('.media-heading').text()).toBe('image');
             });
+        });
+
+        it('assert user list exists', function () {
+            var options = $('#h-annotation-creator option');
+            expect(options.length).toBe(3);
+            expect(options[0].text).toBe('Any user');
+            expect(options[1].text).toBe('admin');
+            expect(options[2].text).toBe('user');
+        });
+
+        it('filter by creator', function () {
+            var select = $('#h-annotation-creator');
+            var userid = select.find('option:nth(1)').val();
+            select.val(userid).trigger('change');
+
+            histomicsTest.waitsForPromise(
+                restPromise.done(function (opts) {
+                    expect(opts.data.creatorId).toBe(userid);
+                }),
+                'Creator filter to update'
+            );
+
+            waitsFor(function () {
+                return $('.h-annotated-image').length === 1;
+            }, 'Dialog to rerender');
+        });
+
+        it('filter by name', function () {
+            $('#h-image-name').val('invalid name').trigger('keyup');
+
+            histomicsTest.waitsForPromise(
+                restPromise.done(function (opts) {
+                    expect(opts.data.imageName).toBe('invalid name');
+                }),
+                'Name filter to update'
+            );
+
+            waitsFor(function () {
+                return $('.h-annotated-image').length === 0;
+            }, 'Dialog to rerender');
+        });
+
+        it('reset filter', function () {
+            $('#h-image-name').val('').trigger('keyup');
+            histomicsTest.waitsForPromise(restPromise, 'Name filter to reset');
+
+            waitsFor(function () {
+                return $('.h-annotated-image').length === 1;
+            }, 'Dialog to rerender');
         });
 
         it('click on the image', function () {

--- a/plugin_tests/client/common.js
+++ b/plugin_tests/client/common.js
@@ -25,6 +25,7 @@
         girder.router.enabled(false);
         girder.events.trigger('g:appload.before');
         girder.plugins.HistomicsTK.panels.DrawWidget.throttleAutosave = false;
+        girder.plugins.HistomicsTK.dialogs.openAnnotatedImage.debounceTimeout = 0;
         app = new girder.plugins.HistomicsTK.App({
             el: 'body',
             parentView: null

--- a/plugin_tests/client/common.js
+++ b/plugin_tests/client/common.js
@@ -25,7 +25,6 @@
         girder.router.enabled(false);
         girder.events.trigger('g:appload.before');
         girder.plugins.HistomicsTK.panels.DrawWidget.throttleAutosave = false;
-        girder.plugins.HistomicsTK.dialogs.openAnnotatedImage.debounceTimeout = 0;
         app = new girder.plugins.HistomicsTK.App({
             el: 'body',
             parentView: null

--- a/web_client/dialogs/openAnnotatedImage.js
+++ b/web_client/dialogs/openAnnotatedImage.js
@@ -87,15 +87,30 @@ const OpenAnnotatedImage = View.extend({
             limit: 10
         };
         let items;
+        let changed = false;
 
-        this._creator = this.$('#h-annotation-creator').val();
-        if (this._creator) {
-            data.creatorId = this._creator;
+        const creator = this.$('#h-annotation-creator').val();
+        if (this._creator !== creator) {
+            this._creator = creator;
+            changed = true;
+
+            if (creator) {
+                data.creatorId = creator;
+            }
         }
 
-        this._imageName = (this.$('#h-image-name').val() || '').trim();
-        if (this._imageName) {
-            data.imageName = this._imageName;
+        const imageName = (this.$('#h-image-name').val() || '').trim();
+        if (this._imageName !== imageName) {
+            this._imageName = imageName;
+            changed = true;
+
+            if (imageName) {
+                data.imageName = this._imageName;
+            }
+        }
+
+        if (!changed) {
+            return $.Deferred().resolve(this.collection).promise();
         }
 
         return restRequest({
@@ -109,7 +124,7 @@ const OpenAnnotatedImage = View.extend({
             return $.when(...promises);
         }).then(() => {
             this.collection.reset(items);
-            return items;
+            return this.collection;
         });
     },
 

--- a/web_client/dialogs/openAnnotatedImage.js
+++ b/web_client/dialogs/openAnnotatedImage.js
@@ -93,7 +93,7 @@ const OpenAnnotatedImage = View.extend({
             data.creatorId = this._creator;
         }
 
-        this._imageName = this.$('#h-image-name').val();
+        this._imageName = (this.$('#h-image-name').val() || '').trim();
         if (this._imageName) {
             data.imageName = this._imageName;
         }

--- a/web_client/stylesheets/dialogs/openAnnotatedImage.styl
+++ b/web_client/stylesheets/dialogs/openAnnotatedImage.styl
@@ -6,3 +6,11 @@
 
     .media-heading
       white-space nowrap
+
+  .form-inline
+    label
+      margin 0 5px
+
+  .list-group
+    max-height calc(100vh - 250px)
+    overflow-y auto

--- a/web_client/templates/dialogs/annotatedImageList.pug
+++ b/web_client/templates/dialogs/annotatedImageList.pug
@@ -1,0 +1,12 @@
+if !items.length
+  p Sorry, no annotated images were found.
+else
+  .list-group
+    each item in items
+      a.list-group-item.h-annotated-image(data-id=item._id, data-toggle='tooltip', title=paths[item._id])
+        .media
+          .media-left.media-middle
+            img(src=`api/v1/item/${item._id}/tiles/thumbnail?height=64&width=64`)
+          .media-body
+            h4.media-heading #{item.name}
+            p #{item.description}

--- a/web_client/templates/dialogs/openAnnotatedImage.pug
+++ b/web_client/templates/dialogs/openAnnotatedImage.pug
@@ -5,15 +5,16 @@
         span(aria-hidden='true') &times;
       h4.modal-title Select a recently annotated image to open
     .modal-body
-      if !items.length
-        p Sorry, no annotated images were found.
-      else
-        .list-group
-          each item in items
-            a.list-group-item.h-annotated-image(data-id=item._id, data-toggle='tooltip', title=paths[item._id])
-              .media
-                .media-left.media-middle
-                  img(src=`api/v1/item/${item._id}/tiles/thumbnail?height=64&width=64`)
-                .media-body
-                  h4.media-heading #{item.name}
-                  p #{item.description}
+      form.form-inline
+        .form-group
+          label(for='h-image-name') Image Name
+          input#h-image-name.form-control(type='text', value=imageName)
+        .form-group
+          label(for='h-annotation-creator') Creator
+          select#h-annotation-creator.form-control(type='text')
+            option(value='', selected= !creator) Any user
+            for user in users.models
+              option(value=user.id, selected= creator === user.id)
+                = user.get('login')
+      hr
+      .h-annotated-images-list-container


### PR DESCRIPTION
This adds two form elements to the "recently annotated images dialog" allowing the user to filter by annotation creator and/or image name.  This relies on https://github.com/girder/large_image/pull/259 to perform the query.  I could (but haven't yet) add some sort of paging to this dialog so you can go back through more than the last ten images.  The endpoint does the filtering in python so it will get slow if you try load too many pages.  We'll have to see if the performance is *good enough* in the real world.

![test](https://user-images.githubusercontent.com/31890/36442191-ebe4556a-1642-11e8-9c3b-54dcac2b30a1.png)
