### PR TITLE
Fix events and viewer state when closing the viewed image

### DIFF
--- a/web_client/views/body/ImageView.js
+++ b/web_client/views/body/ImageView.js
@@ -174,6 +174,8 @@ var ImageView = View.extend({
         } else {
             this.model.set({_id: null});
             this.render();
+            this._openId = null;
+            events.trigger('h:imageOpened', null);
         }
     },
     /**


### PR DESCRIPTION
This change fixes a few bugs that appear when clicking the "HistomicsTK"
link in the header or hitting the back/forward browser button to
redirect to a state when there is no image.  In such a case, the
internal state of the image viewer widget still marked the original
image as being open and the render method was a no-op when trying to
reopen it.  This also triggers an `h:imageOpened` event so that other
views can clean up correctly.