### PR TITLE
Install bokeh to enable dask diagnostics web-interface

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN pip install --upgrade --ignore-installed pip setuptools && \
     # Try twice; conda sometimes causes pip to fail the first time, but if it
     # fails twice then there is a real issue.
     pip install -r requirements.txt && \
-    pip install -r bokeh>=0.12.14 && \
+    pip install bokeh>=0.12.14 && \
     # Install large_image
     pip install 'git+https://github.com/girder/large_image#egg=large_image' && \
     # Ensure we have a locally built Pillow and openslide in conda's environment

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,7 @@ RUN pip install --upgrade --ignore-installed pip setuptools && \
     # Try twice; conda sometimes causes pip to fail the first time, but if it
     # fails twice then there is a real issue.
     pip install -r requirements.txt && \
+    pip install -r bokeh>=0.12.14 && \
     # Install large_image
     pip install 'git+https://github.com/girder/large_image#egg=large_image' && \
     # Ensure we have a locally built Pillow and openslide in conda's environment

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,6 +21,7 @@ tensorflow>=1.3.0
 #
 dask>=0.14.2
 distributed>=1.16.3
+bokeh>=0.12.14
 
 #
 # Other packages

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,8 +19,8 @@ tensorflow>=1.3.0
 #
 # dask packages
 #
-dask>=0.14.2
-distributed>=1.16.3
+dask>=0.17.1
+distributed>=1.21.1
 bokeh>=0.12.14
 
 #

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,6 @@ tensorflow>=1.3.0
 #
 dask>=0.17.1
 distributed>=1.21.1
-bokeh>=0.12.14
 
 #
 # Other packages


### PR DESCRIPTION
This PR
* Adds `bokeh` to `requirements.txt` to enable [Dask diagnostics web interface](http://distributed.readthedocs.io/en/latest/web.html) that is very useful in evaluating the parallelization throughput of our algorithms.
* Bumps the versions of dask packages: `dask, distributed`.