### PR TITLE
Expose the Dask Bokeh port.

### DIFF
--- a/server/cli_common/utils.py
+++ b/server/cli_common/utils.py
@@ -198,8 +198,9 @@ def create_dask_client(args):
     if not scheduler_address:
 
         scheduler_address = dask.distributed.LocalCluster(
+            ip='0.0.0.0',  # Allow reaching the diagnostics port externally
+            scheduler_port=0,  # Don't expose the scheduler port
             n_workers=multiprocessing.cpu_count()-1,
-            scheduler_port=0,
             silence_logs=False
         )
 


### PR DESCRIPTION
When we run a CLI which has a scheduler_address, expose port 8787 to an arbitrary host port.  This uses an arbitrary port to allow multiple jobs to run, each exposing that port.