### PR TITLE
Add a default file extension for color deconvolution.

### DIFF
--- a/server/ColorDeconvolution/ColorDeconvolution.xml
+++ b/server/ColorDeconvolution/ColorDeconvolution.xml
@@ -18,21 +18,21 @@
       <index>0</index>
       <description>Input image to be deconvolved</description>
     </image>
-    <image>
+    <image fileExtensions='.png'>
       <name>outputStainImageFile_1</name>
       <label>Output Image of Stain 1</label>
       <channel>output</channel>
       <index>1</index>
       <description>Output Image of Stain 1</description>
     </image>
-    <image>
+    <image fileExtensions='.png'>
       <name>outputStainImageFile_2</name>
       <label>Output Image of Stain 2</label>
       <channel>output</channel>
       <index>2</index>
       <description>Output Image of Stain 2</description>
     </image>
-    <image>
+    <image fileExtensions='.png'>
       <name>outputStainImageFile_3</name>
       <label>Output Image of Stain 3</label>
       <channel>output</channel>


### PR DESCRIPTION
This lets the color deconvolution analysis work without setting any parameters (other than ROI if the image is large enough).