### PR TITLE
Add a slider to set displayed opacity in the annotation panel

### DIFF
--- a/plugin_tests/client/analysisSpec.js
+++ b/plugin_tests/client/analysisSpec.js
@@ -36,6 +36,9 @@ $(function () {
 
         it('open image', function () {
             histomicsTest.openImage('image');
+            waitsFor(function () {
+                return $('.h-analysis-item').length > 0;
+            }, 'analyses dropdown to load');
         });
     });
 

--- a/plugin_tests/client/annotationSpec.js
+++ b/plugin_tests/client/annotationSpec.js
@@ -537,8 +537,8 @@ $(function () {
                     return setGlobalAnnotationOpacityFunc.apply(this, arguments);
                 };
 
-                $('#h-annotation-opacity').slider('setValue', 0.5).trigger('slideStop');
-                expect(opacity).toBe(0.5);
+                $('#h-annotation-opacity').val(0.5).trigger('change');
+                expect(opacity).toBe('0.5');
 
                 app.bodyView.viewerWidget.setGlobalAnnotationOpacity = setGlobalAnnotationOpacityFunc;
             });

--- a/plugin_tests/client/annotationSpec.js
+++ b/plugin_tests/client/annotationSpec.js
@@ -529,6 +529,20 @@ $(function () {
                 });
             });
 
+            it('set the global annotation opacity', function () {
+                var opacity;
+                var setGlobalAnnotationOpacityFunc = app.bodyView.viewerWidget.setGlobalAnnotationOpacity;
+                app.bodyView.viewerWidget.setGlobalAnnotationOpacity = function (_opacity) {
+                    opacity = _opacity;
+                    return setGlobalAnnotationOpacityFunc.apply(this, arguments);
+                };
+
+                $('#h-annotation-opacity').slider('setValue', 0.5).trigger('slideStop');
+                expect(opacity).toBe(0.5);
+
+                app.bodyView.viewerWidget.setGlobalAnnotationOpacity = setGlobalAnnotationOpacityFunc;
+            });
+
             it('toggle visibility of an annotation', function () {
                 runs(function () {
                     var $el = $('.h-annotation-selector .h-annotation:contains("drawn 1")');

--- a/plugin_tests/client/annotationSpec.js
+++ b/plugin_tests/client/annotationSpec.js
@@ -537,7 +537,7 @@ $(function () {
                     return setGlobalAnnotationOpacityFunc.apply(this, arguments);
                 };
 
-                $('#h-annotation-opacity').val(0.5).trigger('change');
+                $('#h-annotation-opacity').val(0.5).trigger('input');
                 expect(opacity).toBe('0.5');
 
                 app.bodyView.viewerWidget.setGlobalAnnotationOpacity = setGlobalAnnotationOpacityFunc;

--- a/web_client/panels/AnnotationSelector.js
+++ b/web_client/panels/AnnotationSelector.js
@@ -316,7 +316,7 @@ var AnnotationSelector = Panel.extend({
     _changeGlobalOpacity() {
         this._opacity = this.$('#h-annotation-opacity').val();
         this.$('.h-annotation-opacity-container')
-            .attr('title', `Annotation opacity ${this._opacity * 100}%`);
+            .attr('title', `Annotation opacity ${(this._opacity * 100).toFixed()}%`);
         this.trigger('h:annotationOpacity', this._opacity);
     }
 });

--- a/web_client/panels/AnnotationSelector.js
+++ b/web_client/panels/AnnotationSelector.js
@@ -315,6 +315,8 @@ var AnnotationSelector = Panel.extend({
 
     _changeGlobalOpacity() {
         this._opacity = this.$('#h-annotation-opacity').val();
+        this.$('.h-annotation-opacity-container')
+            .attr('title', `Annotation opacity ${this._opacity * 100}%`);
         this.trigger('h:annotationOpacity', this._opacity);
     }
 });

--- a/web_client/panels/AnnotationSelector.js
+++ b/web_client/panels/AnnotationSelector.js
@@ -31,7 +31,8 @@ var AnnotationSelector = Panel.extend({
         'click .h-hide-all-annotations': 'hideAllAnnotations',
         'mouseenter .h-annotation': '_highlightAnnotation',
         'mouseleave .h-annotation': '_unhighlightAnnotation',
-        'change #h-toggle-labels': 'toggleLabels'
+        'change #h-toggle-labels': 'toggleLabels',
+        'slideStop #h-annotation-opacity': '_changeGlobalOpacity'
     }),
 
     /**
@@ -42,7 +43,8 @@ var AnnotationSelector = Panel.extend({
      *     The collection representing the annotations attached
      *     to the current image.
      */
-    initialize(settings) {
+    initialize(settings = {}) {
+        this._opacity = settings.opacity || 0.9;
         this.listenTo(this.collection, 'sync remove update reset change:displayed change:loading', this.render);
         this.listenTo(this.collection, 'change:highlight', this._changeAnnotationHighlight);
         this.listenTo(eventStream, 'g:event.job_status', _.debounce(this._onJobUpdate, 500));
@@ -63,10 +65,13 @@ var AnnotationSelector = Panel.extend({
             activeAnnotation: this._activeAnnotation ? this._activeAnnotation.id : '',
             showLabels: this._showLabels,
             user: getCurrentUser() || {},
-            writeAccess: this._writeAccess
+            writeAccess: this._writeAccess,
+            opacity: this._opacity
         }));
         this.$('.s-panel-content').collapse({toggle: false});
         this.$('[data-toggle="tooltip"]').tooltip({container: 'body'});
+        this.$('.slider').slider();
+        this._changeGlobalOpacity();
         return this;
     },
 
@@ -307,6 +312,11 @@ var AnnotationSelector = Panel.extend({
 
     _changeAnnotationHighlight(model) {
         this.$(`.h-annotation[data-id="${model.id}"]`).toggleClass('h-highlight-annotation', model.get('highlighted'));
+    },
+
+    _changeGlobalOpacity() {
+        this._opacity = this.$('#h-annotation-opacity').slider('getValue');
+        this.trigger('h:annotationOpacity', this._opacity);
     }
 });
 

--- a/web_client/panels/AnnotationSelector.js
+++ b/web_client/panels/AnnotationSelector.js
@@ -32,7 +32,7 @@ var AnnotationSelector = Panel.extend({
         'mouseenter .h-annotation': '_highlightAnnotation',
         'mouseleave .h-annotation': '_unhighlightAnnotation',
         'change #h-toggle-labels': 'toggleLabels',
-        'change #h-annotation-opacity': '_changeGlobalOpacity'
+        'input #h-annotation-opacity': '_changeGlobalOpacity'
     }),
 
     /**

--- a/web_client/panels/AnnotationSelector.js
+++ b/web_client/panels/AnnotationSelector.js
@@ -32,7 +32,7 @@ var AnnotationSelector = Panel.extend({
         'mouseenter .h-annotation': '_highlightAnnotation',
         'mouseleave .h-annotation': '_unhighlightAnnotation',
         'change #h-toggle-labels': 'toggleLabels',
-        'slideStop #h-annotation-opacity': '_changeGlobalOpacity'
+        'change #h-annotation-opacity': '_changeGlobalOpacity'
     }),
 
     /**
@@ -70,7 +70,6 @@ var AnnotationSelector = Panel.extend({
         }));
         this.$('.s-panel-content').collapse({toggle: false});
         this.$('[data-toggle="tooltip"]').tooltip({container: 'body'});
-        this.$('.slider').slider();
         this._changeGlobalOpacity();
         return this;
     },
@@ -315,7 +314,7 @@ var AnnotationSelector = Panel.extend({
     },
 
     _changeGlobalOpacity() {
-        this._opacity = this.$('#h-annotation-opacity').slider('getValue');
+        this._opacity = this.$('#h-annotation-opacity').val();
         this.trigger('h:annotationOpacity', this._opacity);
     }
 });

--- a/web_client/stylesheets/panels/annotationSelector.styl
+++ b/web_client/stylesheets/panels/annotationSelector.styl
@@ -1,3 +1,19 @@
+.h-hide-show-buttons
+  border-bottom 1px solid #ececec
+  padding-bottom 8px
+  margin-bottom 5px
+
+  button.btn
+    padding 2px 5px
+    margin 0
+    background none
+
+  input
+    width 210px
+    float right
+    margin-left 10px
+    margin-top 2px
+
 .h-annotation
     border-radius 3px
     span
@@ -29,6 +45,3 @@
 
 .h-annotation:hover
   background-color #eee
-
-.h-hide-show-buttons
-  margin-bottom 5px

--- a/web_client/templates/panels/annotationSelector.pug
+++ b/web_client/templates/panels/annotationSelector.pug
@@ -44,6 +44,10 @@ block content
           span.icon-download.h-download-annotation(
               data-toggle='tooltip', title='Download annotation')
 
+  .form-group
+    label(for='h-annotation-opacity') Opacity
+    input#h-annotation-opacity.slider.form-control(
+        type='text', data-slider-min='0', data-slider-max='1', data-slider-step='0.01', data-slider-value=opacity)
   .checkbox.h-annotation-toggle
     label
       input#h-toggle-labels(type='checkbox', checked=showLabels)

--- a/web_client/templates/panels/annotationSelector.pug
+++ b/web_client/templates/panels/annotationSelector.pug
@@ -11,7 +11,7 @@ block content
     .btn-group.btn-group-sm(role='group')
       button.btn.btn-default.h-hide-all-annotations(type='button', title='Hide all annotations')
         | #[span.icon-eye-off]
-    span(title='Annotation opacity')
+    span.h-annotation-opacity-container(title=`Annotation opacity ${opacity * 100}%`)
       input#h-annotation-opacity(
           type="range", min="0", max="1", step="0.01", value=opacity)
 

--- a/web_client/templates/panels/annotationSelector.pug
+++ b/web_client/templates/panels/annotationSelector.pug
@@ -11,7 +11,7 @@ block content
     .btn-group.btn-group-sm(role='group')
       button.btn.btn-default.h-hide-all-annotations(type='button', title='Hide all annotations')
         | #[span.icon-eye-off]
-    span.h-annotation-opacity-container(title=`Annotation opacity ${opacity * 100}%`)
+    span.h-annotation-opacity-container(title=`Annotation opacity ${(opacity * 100).toFixed()}%`)
       input#h-annotation-opacity(
           type="range", min="0", max="1", step="0.01", value=opacity)
 

--- a/web_client/templates/panels/annotationSelector.pug
+++ b/web_client/templates/panels/annotationSelector.pug
@@ -4,13 +4,16 @@ block title
   | #[span.icon-tags] #{title}
 
 block content
-  .btn-group.btn-group-justified.h-hide-show-buttons(role='group')
+  .btn-group.h-hide-show-buttons(role='group')
     .btn-group.btn-group-sm(role='group')
-      button.btn.btn-default.h-show-all-annotations(type='button')
-        | #[span.icon-eye] Show all
+      button.btn.btn-default.h-show-all-annotations(type='button', title='Show all annotations')
+        | #[span.icon-eye]
     .btn-group.btn-group-sm(role='group')
-      button.btn.btn-default.h-hide-all-annotations(type='button')
-        | #[span.icon-eye-off] Hide all
+      button.btn.btn-default.h-hide-all-annotations(type='button', title='Hide all annotations')
+        | #[span.icon-eye-off]
+    span(title='Annotation opacity')
+      input#h-annotation-opacity(
+          type="range", min="0", max="1", step="0.01", value=opacity)
 
   - var admin = user && user.get && user.get('admin');
   each annotation in annotations
@@ -44,10 +47,6 @@ block content
           span.icon-download.h-download-annotation(
               data-toggle='tooltip', title='Download annotation')
 
-  .form-group
-    label(for='h-annotation-opacity') Opacity
-    input#h-annotation-opacity.slider.form-control(
-        type='text', data-slider-min='0', data-slider-max='1', data-slider-step='0.01', data-slider-value=opacity)
   .checkbox.h-annotation-toggle
     label
       input#h-toggle-labels(type='checkbox', checked=showLabels)

--- a/web_client/views/body/ImageView.js
+++ b/web_client/views/body/ImageView.js
@@ -60,6 +60,7 @@ var ImageView = View.extend({
         this.listenTo(this.annotationSelector, 'h:toggleLabels', this.toggleLabels);
         this.listenTo(this.annotationSelector, 'h:editAnnotation', this._editAnnotation);
         this.listenTo(this.annotationSelector, 'h:deleteAnnotation', this._deleteAnnotation);
+        this.listenTo(this.annotationSelector, 'h:annotationOpacity', this._setAnnotationOpacity);
         this.listenTo(this, 'h:highlightAnnotation', this._highlightAnnotation);
 
         this.listenTo(events, 's:widgetChanged:region', this.widgetRegion);
@@ -536,6 +537,10 @@ var ImageView = View.extend({
         if (this.activeAnnotation && this.activeAnnotation.id === model.id) {
             this._removeDrawWidget();
         }
+    },
+
+    _setAnnotationOpacity(opacity) {
+        this.viewerWidget.setGlobalAnnotationOpacity(opacity);
     }
 });
 


### PR DESCRIPTION
This adds a simple slider in the annotations panel to change the global opacity on the annotation layer itself.  The UI doesn't look very good to me (something about the color/position/spacing seems off), so I would welcome any suggestions to improve it.

Depends on https://github.com/girder/large_image/pull/264
Fixes #458
![test](https://user-images.githubusercontent.com/31890/37050184-2e6d0dba-2141-11e8-9a5f-cef898db396d.png)
