### PR TITLE
Fix race conditions in analysis client test

### DIFF
--- a/plugin_tests/client/analysisSpec.js
+++ b/plugin_tests/client/analysisSpec.js
@@ -73,7 +73,7 @@ $(function () {
             });
 
             waitsFor(function () {
-                return !!$('#outputNucleiAnnotationFile');
+                return !!$('#outputNucleiAnnotationFile').val();
             }, 'Output annotation file to auto fill');
 
             runs(function () {

--- a/web_client/views/body/ImageView.js
+++ b/web_client/views/body/ImageView.js
@@ -33,9 +33,9 @@ var ImageView = View.extend({
             this.model = new ItemModel();
         }
         this.listenTo(this.model, 'g:fetched', this.render);
-        this.listenTo(events, 'h:analysis', this._setImageInput);
-        this.listenTo(events, 'h:analysis', this._setDefaultFileOutputs);
-        this.listenTo(events, 'h:analysis', this._resetRegion);
+        this.listenTo(events, 'h:analysis:rendered', this._setImageInput);
+        this.listenTo(events, 'h:analysis:rendered', this._setDefaultFileOutputs);
+        this.listenTo(events, 'h:analysis:rendered', this._resetRegion);
         events.trigger('h:imageOpened', null);
         this.listenTo(events, 'query:image', this.openImage);
         this.annotations = new AnnotationCollection();
@@ -260,7 +260,7 @@ var ImageView = View.extend({
     _getDefaultOutputFolder() {
         const user = getCurrentUser();
         if (!user) {
-            return;
+            return $.Deferred().resolve().promise();
         }
         const userFolders = new FolderCollection();
         return userFolders.fetch({
@@ -398,12 +398,13 @@ var ImageView = View.extend({
     },
 
     showRegion(region) {
-        if (this.viewerWidget) {
-            this.viewerWidget.removeAnnotation(
-                new AnnotationModel({_id: 'region-selection'})
-            );
+        if (!this.viewerWidget) {
+            return;
         }
 
+        this.viewerWidget.removeAnnotation(
+            new AnnotationModel({_id: 'region-selection'})
+        );
         if (!region) {
             return;
         }


### PR DESCRIPTION
There were three race conditions occuring.

1. Values where injected into the control panel by the ImageView before
the control panels were rendered because `h:analysis` was being
triggered before an asynchronous render call.  This connects to the new
event slicer_cli_web that is triggered inside the render function
itself.

2. The output file test was not correctly waiting for the input element
to change.

3. Setting the ROI sometimes occurs before the image feature layer is
created.  This protects against that and make the draw a no-op because
the region is always drawn when the feature layer is generated.

Depends on https://github.com/girder/slicer_cli_web/pull/58