### PR TITLE
Dask distributed doesn't work with tornado 5.0.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -21,6 +21,8 @@ tensorflow>=1.3.0
 #
 dask>=0.17.1
 distributed>=1.21.1
+# distributed doesn't work with torando>=5.0 as on 2018-03-07.  Remove this when it has been fixed (see https://github.com/dask/distributed/issues/1725)
+tornado<5
 
 #
 # Other packages


### PR DESCRIPTION
Pin the tornado version for now.