### PR TITLE
Add a checkbox to toggle annotation interactivity

### DIFF
--- a/plugin_tests/client/annotationSpec.js
+++ b/plugin_tests/client/annotationSpec.js
@@ -672,8 +672,21 @@ $(function () {
                 expect($('.h-draw-widget .h-element').hasClass('h-highlight-element')).toBe(false);
             });
 
-            it('turn on interactivity', function () {
-                $('#h-toggle-interactive').click();
+            it('trigger a mouseon event and then turn interactivity off', function () {
+                $('#h-toggle-interactive').click(); // interactive on
+                var annotation = $('.h-annotation-selector .h-annotation:contains("drawn 2")').data('id');
+                var element = app.bodyView.annotations.get(annotation).elements().get($('.h-draw-widget .h-element').data('id'));
+                app.bodyView.viewerWidget.trigger('g:mouseOnAnnotation', element, annotation);
+                expect($('.h-annotation-selector .h-annotation:contains("drawn 2")').hasClass('h-highlight-annotation')).toBe(true);
+                expect($('.h-draw-widget .h-element').hasClass('h-highlight-element')).toBe(true);
+
+                $('#h-toggle-interactive').click(); // interactive off
+                expect($('.h-annotation-selector .h-annotation:contains("drawn 2")').hasClass('h-highlight-annotation')).toBe(false);
+                expect($('.h-draw-widget .h-element').hasClass('h-highlight-element')).toBe(false);
+            });
+
+            it('turn on interactivity and trigger a mouseon event', function () {
+                $('#h-toggle-interactive').click(); // interactive on
                 var annotation = $('.h-annotation-selector .h-annotation:contains("drawn 2")').data('id');
                 var element = app.bodyView.annotations.get(annotation).elements().get($('.h-draw-widget .h-element').data('id'));
                 app.bodyView.viewerWidget.trigger('g:mouseOnAnnotation', element, annotation);

--- a/plugin_tests/client/annotationSpec.js
+++ b/plugin_tests/client/annotationSpec.js
@@ -664,7 +664,16 @@ $(function () {
                 });
             });
 
-            it('trigger a mouseon event on an element', function () {
+            it('trigger a mouseon event on an element with interactivity off', function () {
+                var annotation = $('.h-annotation-selector .h-annotation:contains("drawn 2")').data('id');
+                var element = app.bodyView.annotations.get(annotation).elements().get($('.h-draw-widget .h-element').data('id'));
+                app.bodyView.viewerWidget.trigger('g:mouseOnAnnotation', element, annotation);
+                expect($('.h-annotation-selector .h-annotation:contains("drawn 2")').hasClass('h-highlight-annotation')).toBe(false);
+                expect($('.h-draw-widget .h-element').hasClass('h-highlight-element')).toBe(false);
+            });
+
+            it('turn on interactivity', function () {
+                $('#h-toggle-interactive').click();
                 var annotation = $('.h-annotation-selector .h-annotation:contains("drawn 2")').data('id');
                 var element = app.bodyView.annotations.get(annotation).elements().get($('.h-draw-widget .h-element').data('id'));
                 app.bodyView.viewerWidget.trigger('g:mouseOnAnnotation', element, annotation);

--- a/web_client/panels/AnnotationSelector.js
+++ b/web_client/panels/AnnotationSelector.js
@@ -32,6 +32,7 @@ var AnnotationSelector = Panel.extend({
         'mouseenter .h-annotation': '_highlightAnnotation',
         'mouseleave .h-annotation': '_unhighlightAnnotation',
         'change #h-toggle-labels': 'toggleLabels',
+        'change #h-toggle-interactive': 'toggleInteractiveMode',
         'input #h-annotation-opacity': '_changeGlobalOpacity'
     }),
 
@@ -66,7 +67,8 @@ var AnnotationSelector = Panel.extend({
             showLabels: this._showLabels,
             user: getCurrentUser() || {},
             writeAccess: this._writeAccess,
-            opacity: this._opacity
+            opacity: this._opacity,
+            interactiveMode: this._interactiveMode
         }));
         this.$('.s-panel-content').collapse({toggle: false});
         this.$('[data-toggle="tooltip"]').tooltip({container: 'body'});
@@ -194,6 +196,14 @@ var AnnotationSelector = Panel.extend({
         this.trigger('h:toggleLabels', {
             show: this._showLabels
         });
+    },
+
+    toggleInteractiveMode(evt) {
+        this._interactiveMode = !this._interactiveMode;
+    },
+
+    interactiveMode() {
+        return this._interactiveMode;
     },
 
     editAnnotation(evt) {

--- a/web_client/panels/AnnotationSelector.js
+++ b/web_client/panels/AnnotationSelector.js
@@ -200,6 +200,7 @@ var AnnotationSelector = Panel.extend({
 
     toggleInteractiveMode(evt) {
         this._interactiveMode = !this._interactiveMode;
+        this.trigger('h:toggleInteractiveMode', this._interactiveMode);
     },
 
     interactiveMode() {

--- a/web_client/stylesheets/panels/annotationSelector.styl
+++ b/web_client/stylesheets/panels/annotationSelector.styl
@@ -9,7 +9,7 @@
     background none
 
   input
-    width 210px
+    width 195px
     float right
     margin-left 10px
     margin-top 2px

--- a/web_client/stylesheets/panels/annotationSelector.styl
+++ b/web_client/stylesheets/panels/annotationSelector.styl
@@ -40,8 +40,18 @@
 .h-annotation.h-highlight-annotation
   background-color #ccc
 
-.h-create-annotation
-  float right
+.h-annotation-toggle
+  margin 0
+  border-top 1px solid #ececec
+  padding-top 8px
+  padding-bottom 2px
+
+  label
+    margin 0 5px
+    padding-top 5px
+
+  .h-create-annotation
+    float right
 
 .h-annotation:hover
   background-color #eee

--- a/web_client/templates/panels/annotationSelector.pug
+++ b/web_client/templates/panels/annotationSelector.pug
@@ -48,9 +48,12 @@ block content
               data-toggle='tooltip', title='Download annotation')
 
   .checkbox.h-annotation-toggle
-    label
+    label(title='Show annotation labels when hovering with the mouse.')
       input#h-toggle-labels(type='checkbox', checked=showLabels)
-      | Show labels
+      | Labels
+    label(title='Highlight annotations when hovering with the mouse.')
+      input#h-toggle-interactive(type='checkbox', checked=interactiveMode)
+      | Interactive
     button.btn.btn-sm.btn-primary.h-create-annotation
       | #[span.icon-plus-squared] New
     .clearfix

--- a/web_client/views/body/ImageView.js
+++ b/web_client/views/body/ImageView.js
@@ -58,7 +58,7 @@ var ImageView = View.extend({
         this.listenTo(events, 'h:select-region', this.showRegion);
         this.listenTo(this.annotationSelector.collection, 'add update change:displayed', this.toggleAnnotation);
         this.listenTo(this.annotationSelector, 'h:toggleLabels', this.toggleLabels);
-        this.listenTo(this.annotationSelector, 'h:toggleInteractiveMode', this.toggleInteractiveMode);
+        this.listenTo(this.annotationSelector, 'h:toggleInteractiveMode', this._toggleInteractiveMode);
         this.listenTo(this.annotationSelector, 'h:editAnnotation', this._editAnnotation);
         this.listenTo(this.annotationSelector, 'h:deleteAnnotation', this._deleteAnnotation);
         this.listenTo(this.annotationSelector, 'h:annotationOpacity', this._setAnnotationOpacity);
@@ -506,6 +506,20 @@ var ImageView = View.extend({
 
     toggleLabels(options) {
         this.popover.toggle(options.show);
+    },
+
+    _toggleInteractiveMode(interactive) {
+        if (!interactive) {
+            this.viewerWidget.highlightAnnotation();
+            this.annotations.each((annotation) => {
+                annotation.unset('highlight');
+                if (this.drawWidget) {
+                    annotation.elements().each((element) => {
+                        this.drawWidget.trigger('h:mouseoff', element);
+                    });
+                }
+            });
+        }
     },
 
     _removeDrawWidget() {

--- a/web_client/views/body/ImageView.js
+++ b/web_client/views/body/ImageView.js
@@ -58,6 +58,7 @@ var ImageView = View.extend({
         this.listenTo(events, 'h:select-region', this.showRegion);
         this.listenTo(this.annotationSelector.collection, 'add update change:displayed', this.toggleAnnotation);
         this.listenTo(this.annotationSelector, 'h:toggleLabels', this.toggleLabels);
+        this.listenTo(this.annotationSelector, 'h:toggleInteractiveMode', this.toggleInteractiveMode);
         this.listenTo(this.annotationSelector, 'h:editAnnotation', this._editAnnotation);
         this.listenTo(this.annotationSelector, 'h:deleteAnnotation', this._deleteAnnotation);
         this.listenTo(this.annotationSelector, 'h:annotationOpacity', this._setAnnotationOpacity);
@@ -366,6 +367,9 @@ var ImageView = View.extend({
     },
 
     _highlightAnnotation(annotation, element) {
+        if (!this.annotationSelector.interactiveMode()) {
+            return;
+        }
         this.viewerWidget.highlightAnnotation(annotation, element);
     },
 
@@ -450,7 +454,7 @@ var ImageView = View.extend({
     },
 
     mouseOnAnnotation(element, annotationId) {
-        if (annotationId === 'region-selection') {
+        if (annotationId === 'region-selection' || !this.annotationSelector.interactiveMode()) {
             return;
         }
         const annotation = this.annotations.get(annotationId);
@@ -462,7 +466,7 @@ var ImageView = View.extend({
     },
 
     mouseOffAnnotation(element, annotationId) {
-        if (annotationId === 'region-selection') {
+        if (annotationId === 'region-selection' || !this.annotationSelector.interactiveMode()) {
             return;
         }
         const annotation = this.annotations.get(annotationId);


### PR DESCRIPTION
This add a new checkbox similar to the "enable labels" control to turn on or off the annotation highlighting behavior on mouse pointer hover.  There is also a small fix to the opacity slider, which I found would sometimes wrap below the show/hide buttons.

Fixes #459 
