### PR TITLE
Various changes to work on OSX.

### DIFF
--- a/ansible/roles/common/set_environment.py
+++ b/ansible/roles/common/set_environment.py
@@ -21,6 +21,8 @@ def adjust_ids(user_name):  # noqa
     if os.path.exists(sockpath):
         # make the gid a string for later use
         sock_docker_gid = str(os.stat(sockpath).st_gid)
+        escapedSockPath = "'%s'" % (sockpath.replace("'", "'\\''"))
+        os.system('sudo chmod 777 %s' % escapedSockPath)
     # Get environment UID and GIDs.  These are not required to be set.
     host_uid = os.environ.get('HOST_UID')
     host_gid = os.environ.get('HOST_GID')


### PR DESCRIPTION
OSX doesn't have getent, so use stat if possible.  Don't assume the location of the docker command.  Adjust docker.sock permissions inside the container.