### PR TITLE
Use memcached by default in the CLI.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,11 @@ MAINTAINER Deepak Chittajallu <deepak.chittajallu@kitware.com>
 # copy HistomicsTK files
 ENV htk_path=$PWD/HistomicsTK
 RUN mkdir -p $htk_path
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends memcached && \
+    apt-get autoremove && \
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 COPY . $htk_path/
 WORKDIR $htk_path
 
@@ -25,7 +30,7 @@ RUN pip install --upgrade --ignore-installed pip setuptools && \
     pip install -r requirements.txt && \
     pip install bokeh>=0.12.14 && \
     # Install large_image
-    pip install 'git+https://github.com/girder/large_image#egg=large_image' && \
+    pip install 'git+https://github.com/girder/large_image#egg=large_image[openslide,memcached]' && \
     # Ensure we have a locally built Pillow and openslide in conda's environment
     pip install --upgrade --no-cache-dir --force-reinstall --ignore-installed \
       openslide-python \

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,16 +21,16 @@ WORKDIR $htk_path
 # Install HistomicsTK and its dependencies
 #   Upgrade setuptools, as the version in Conda won't upgrade cleanly unless it
 # is ignored.
-RUN pip install --upgrade --ignore-installed pip setuptools && \
-    pip install --upgrade 'git+https://github.com/cdeepakroy/ctk-cli' && \
+RUN pip install --no-cache-dir --upgrade --ignore-installed pip setuptools && \
+    pip install --no-cache-dir --upgrade 'git+https://github.com/cdeepakroy/ctk-cli' && \
     # Install requirements.txt via pip; installing via conda causes
     # version issues with our home-built libtiff.
     # Try twice; conda sometimes causes pip to fail the first time, but if it
     # fails twice then there is a real issue.
-    pip install -r requirements.txt && \
-    pip install bokeh>=0.12.14 && \
+    pip install --no-cache-dir -r requirements.txt && \
+    pip install --no-cache-dir 'bokeh>=0.12.14' && \
     # Install large_image
-    pip install 'git+https://github.com/girder/large_image#egg=large_image[openslide,memcached]' && \
+    pip install --no-cache-dir 'git+https://github.com/girder/large_image#egg=large_image[openslide,memcached]' && \
     # Ensure we have a locally built Pillow and openslide in conda's environment
     pip install --upgrade --no-cache-dir --force-reinstall --ignore-installed \
       openslide-python \
@@ -38,10 +38,10 @@ RUN pip install --upgrade --ignore-installed pip setuptools && \
     # Install HistomicsTK
     python setup.py install && \
     # Create separate virtual environments with CPU and GPU versions of tensorflow
-    pip install virtualenv && \
+    pip install --no-cache-dir virtualenv && \
     virtualenv --system-site-packages /venv-gpu && \
     chmod +x /venv-gpu/bin/activate && \
-    /venv-gpu/bin/pip install tensorflow-gpu>=1.3.0 && \
+    /venv-gpu/bin/pip install --no-cache-dir tensorflow-gpu>=1.3.0 && \
     # clean up
     conda clean -i -l -t -y && \
     rm -rf /root/.cache/pip/*

--- a/ansible/Dockerfile-histomicstk
+++ b/ansible/Dockerfile-histomicstk
@@ -8,7 +8,7 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends iputils-ping telnet-ssl tmux less && \
     sudo rm -rf /var/lib/apt/lists/* /tmp/*
 RUN pip install -U pip
-RUN pip install -U ansible
+RUN pip install -U 'ansible<2.5'
 RUN locale-gen en_US.UTF-8
 RUN adduser --disabled-password --gecos '' ubuntu && \
     adduser ubuntu sudo && \

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,9 +20,8 @@ tensorflow>=1.3.0
 # dask packages
 #
 dask>=0.17.1
-distributed>=1.21.1
-# distributed doesn't work with torando>=5.0 as on 2018-03-07.  Remove this when it has been fixed (see https://github.com/dask/distributed/issues/1725)
-tornado<5
+distributed>=1.21.3
+tornado
 
 #
 # Other packages

--- a/server/cli_common/utils.py
+++ b/server/cli_common/utils.py
@@ -14,6 +14,14 @@ import histomicstk.utils as htk_utils
 import large_image
 
 
+# These defaults are only used if girder is not present
+# Use memcached by default.
+large_image.cache_util.cachefactory.defaultConfig['cache_backend'] = 'memcached'
+# If memcached is unavilable, specify the fraction of memory that python
+# caching is allowed to use.  This is deliberately small.
+large_image.cache_util.cachefactory.defaultConfig['cache_python_memory_portion'] = 32
+
+
 def get_stain_vector(args, index):
     """Get the stain corresponding to args.stain_$index and
     args.stain_$index_vector.  If the former is not "custom", all the

--- a/server/docker-entrypoint.sh
+++ b/server/docker-entrypoint.sh
@@ -6,4 +6,7 @@ then
     echo "NOTE: GPU available" >&2
 fi
 
+# Try to start a local version memcached, but fail gracefully if we can't.
+memcached -u root -d -m 1024 || true
+
 python /build/slicer_cli_web/server/cli_list_entrypoint.py "$@"


### PR DESCRIPTION
Also, modify the cli_test script to provide some more options.

If we move to a more recent version of distributed, we can unpin tornado.