### PR TITLE
Refactor Dockerfile to use less memory.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,16 +16,16 @@ WORKDIR $htk_path
 # Install HistomicsTK and its dependencies
 #   Upgrade setuptools, as the version in Conda won't upgrade cleanly unless it
 # is ignored.
-RUN pip install --upgrade --ignore-installed pip setuptools && \
-    pip install --upgrade 'git+https://github.com/cdeepakroy/ctk-cli' && \
+RUN pip install --no-cache-dir --upgrade --ignore-installed pip setuptools && \
+    pip install --no-cache-dir --upgrade 'git+https://github.com/cdeepakroy/ctk-cli' && \
     # Install requirements.txt via pip; installing via conda causes
     # version issues with our home-built libtiff.
     # Try twice; conda sometimes causes pip to fail the first time, but if it
     # fails twice then there is a real issue.
-    pip install -r requirements.txt && \
-    pip install bokeh>=0.12.14 && \
+    pip install --no-cache-dir -r requirements.txt && \
+    pip install --no-cache-dir 'bokeh>=0.12.14' && \
     # Install large_image
-    pip install 'git+https://github.com/girder/large_image#egg=large_image' && \
+    pip install --no-cache-dir 'git+https://github.com/girder/large_image#egg=large_image[openslide,memcached]' && \
     # Ensure we have a locally built Pillow and openslide in conda's environment
     pip install --upgrade --no-cache-dir --force-reinstall --ignore-installed \
       openslide-python \
@@ -33,10 +33,10 @@ RUN pip install --upgrade --ignore-installed pip setuptools && \
     # Install HistomicsTK
     python setup.py install && \
     # Create separate virtual environments with CPU and GPU versions of tensorflow
-    pip install virtualenv && \
+    pip install --no-cache-dir virtualenv && \
     virtualenv --system-site-packages /venv-gpu && \
     chmod +x /venv-gpu/bin/activate && \
-    /venv-gpu/bin/pip install tensorflow-gpu>=1.3.0 && \
+    /venv-gpu/bin/pip install --no-cache-dir tensorflow-gpu>=1.3.0 && \
     # clean up
     conda clean -i -l -t -y && \
     rm -rf /root/.cache/pip/*


### PR DESCRIPTION
Before this refactor, the docker build process had a peak memory use of between 1.5 and 1.75 Gb.  Afterwards, the build process peaks at less than 0.5 Gb.  Dockerhub's build is limited in memory, so this should allow it to build there.