### PR TITLE
Open the job info page when submitting an analysis

### DIFF
--- a/plugin_tests/client/analysisSpec.js
+++ b/plugin_tests/client/analysisSpec.js
@@ -112,6 +112,25 @@ $(function () {
                 regionValue = $('#analysis_roi').val();
             });
         });
+        it('submit the job', function () {
+            var open = window.open;
+            var args;
+            window.open = function () {
+                args = arguments;
+            };
+            var $el = $('.s-info-panel-submit');
+            expect($el.length).toBe(1);
+            $el.click();
+
+            waitsFor(function () {
+                return args !== undefined;
+            }, 'job submission to return');
+            runs(function () {
+                expect(args[0]).toBe('/#job/jobid');
+                expect(args[1]).toBe('_blank');
+                window.open = open;
+            });
+        });
         it('open a new analysis', function () {
             var $el = $('.h-analyses-dropdown');
             expect($el.find('a:contains("dsarchive/histomicstk")').length).toBe(1);

--- a/plugin_tests/client/analysisSpec.js
+++ b/plugin_tests/client/analysisSpec.js
@@ -126,7 +126,7 @@ $(function () {
                 return options !== undefined;
             }, 'job submission to return');
             runs(function () {
-                expect(options.text).toBe('Analysis job submitted successfully.');
+                expect(options.text).toBe('Analysis job submitted.');
                 expect($('.s-jobs-panel .s-panel-controls .icon-up-open').length).toBe(1);
             });
         });

--- a/plugin_tests/client/analysisSpec.js
+++ b/plugin_tests/client/analysisSpec.js
@@ -113,22 +113,21 @@ $(function () {
             });
         });
         it('submit the job', function () {
-            var open = window.open;
-            var args;
-            window.open = function () {
-                args = arguments;
-            };
+            var options;
+
+            girder.events.once('g:alert', function (_options) {
+                options = _options;
+            });
             var $el = $('.s-info-panel-submit');
             expect($el.length).toBe(1);
             $el.click();
 
             waitsFor(function () {
-                return args !== undefined;
+                return options !== undefined;
             }, 'job submission to return');
             runs(function () {
-                expect(args[0]).toBe('/#job/jobid');
-                expect(args[1]).toBe('_blank');
-                window.open = open;
+                expect(options.text).toBe('Analysis job submitted successfully.');
+                expect($('.s-jobs-panel .s-panel-controls .icon-up-open').length).toBe(1);
             });
         });
         it('open a new analysis', function () {

--- a/plugin_tests/web_client_test.py
+++ b/plugin_tests/web_client_test.py
@@ -102,7 +102,7 @@ class MockSlicerCLIWebResource(Resource):
         For now, this is a no-op, but we should add some logic to generate an annotation
         output and job status events to simulate a real execution of the CLI.
         """
-        pass
+        return {'_id': 'jobid'}
 
 
 class WebClientTestCase(web_client_test.WebClientTestCase):

--- a/web_client/views/body/ImageView.js
+++ b/web_client/views/body/ImageView.js
@@ -56,8 +56,8 @@ var ImageView = View.extend({
         });
 
         this.listenTo(events, 'h:submit', (data) => {
-            // open the job info page when submitting an analysis
-            window.open(`/#job/${data._id}`, '_blank');
+            this.$('.s-jobs-panel .s-panel-controls .icon-down-open').click();
+            events.trigger('g:alert', {type: 'success', text: 'Analysis job submitted successfully.'});
         });
         this.listenTo(events, 'h:select-region', this.showRegion);
         this.listenTo(this.annotationSelector.collection, 'add update change:displayed', this.toggleAnnotation);

--- a/web_client/views/body/ImageView.js
+++ b/web_client/views/body/ImageView.js
@@ -57,7 +57,7 @@ var ImageView = View.extend({
 
         this.listenTo(events, 'h:submit', (data) => {
             this.$('.s-jobs-panel .s-panel-controls .icon-down-open').click();
-            events.trigger('g:alert', {type: 'success', text: 'Analysis job submitted successfully.'});
+            events.trigger('g:alert', {type: 'success', text: 'Analysis job submitted.'});
         });
         this.listenTo(events, 'h:select-region', this.showRegion);
         this.listenTo(this.annotationSelector.collection, 'add update change:displayed', this.toggleAnnotation);

--- a/web_client/views/body/ImageView.js
+++ b/web_client/views/body/ImageView.js
@@ -55,6 +55,10 @@ var ImageView = View.extend({
             parentView: this
         });
 
+        this.listenTo(events, 'h:submit', (data) => {
+            // open the job info page when submitting an analysis
+            window.open(`/#job/${data._id}`, '_blank');
+        });
         this.listenTo(events, 'h:select-region', this.showRegion);
         this.listenTo(this.annotationSelector.collection, 'add update change:displayed', this.toggleAnnotation);
         this.listenTo(this.annotationSelector, 'h:toggleLabels', this.toggleLabels);


### PR DESCRIPTION
The only problem with this is that opening the new window occurs asynchronously, so it is blocked by popup blockers.  At least in Chrome, you do get a notification the pop up was blocked and are given the option to disable it for the current page.

Fixes #485