### PR TITLE
Don't try to set an output folder if there isn't one.

### DIFF
--- a/web_client/views/body/ImageView.js
+++ b/web_client/views/body/ImageView.js
@@ -285,22 +285,24 @@ var ImageView = View.extend({
 
     _setDefaultFileOutputs() {
         return this._getDefaultOutputFolder().done((folder) => {
-            _.each(
-                this.controlPanel.models().filter((model) => model.get('type') === 'new-file'),
-                (model) => {
-                    var analysis = _.last(router.getQuery('analysis').split('/'));
-                    var extension = (model.get('extensions') || '').split('|')[0];
-                    var name = `${analysis}-${model.id}${extension}`;
-                    model.set({
-                        path: [folder.get('name'), name],
-                        parent: folder,
-                        value: new ItemModel({
-                            name,
-                            folderId: folder.id
-                        })
-                    });
-                }
-            );
+            if (folder) {
+                _.each(
+                    this.controlPanel.models().filter((model) => model.get('type') === 'new-file'),
+                    (model) => {
+                        var analysis = _.last(router.getQuery('analysis').split('/'));
+                        var extension = (model.get('extensions') || '').split('|')[0];
+                        var name = `${analysis}-${model.id}${extension}`;
+                        model.set({
+                            path: [folder.get('name'), name],
+                            parent: folder,
+                            value: new ItemModel({
+                                name,
+                                folderId: folder.id
+                            })
+                        });
+                    }
+                );
+            }
         });
     },
 


### PR DESCRIPTION
If you are logged in and have a CLI interface that has an output folder, and log out, an exception would be thrown as the no-user condition has no output folder.  This update happens before the CLI is removed, which prevents it from occurring as expected.