### PR TITLE
Reload annotation list after switching users.

### DIFF
--- a/web_client/panels/AnnotationSelector.js
+++ b/web_client/panels/AnnotationSelector.js
@@ -4,6 +4,7 @@ import eventStream from 'girder/utilities/EventStream';
 import { getCurrentUser } from 'girder/auth';
 import Panel from 'girder_plugins/slicer_cli_web/views/Panel';
 import AnnotationModel from 'girder_plugins/large_image/models/AnnotationModel';
+import {events as girderEvents} from 'girder';
 
 import events from '../events';
 import showSaveAnnotationDialog from '../dialogs/saveAnnotation';
@@ -51,6 +52,10 @@ var AnnotationSelector = Panel.extend({
         this.listenTo(eventStream, 'g:event.job_status', _.debounce(this._onJobUpdate, 500));
         this.listenTo(eventStream, 'g:eventStream.start', this._refreshAnnotations);
         this.listenTo(this.collection, 'change:annotation', this._saveAnnotation);
+        this.listenTo(girderEvents, 'g:login', () => {
+            this.collection.reset();
+            this._parentId = undefined;
+        });
     },
 
     render() {

--- a/web_client/views/body/ImageView.js
+++ b/web_client/views/body/ImageView.js
@@ -88,6 +88,9 @@ var ImageView = View.extend({
         this.$el.html(imageTemplate());
         if (this.model.id) {
             this._openId = this.model.id;
+            if (this.viewerWidget) {
+                this.viewerWidget.destroy();
+            }
             this.viewerWidget = new GeojsViewer({
                 parentView: this,
                 el: this.$('.h-image-view-container'),


### PR DESCRIPTION
After switching users and loading the same image, the annotation list was not refetched.  This meant that the first user's permissions were used to show the list of available annotations.