### PR TITLE
Work around an Ansible 2.5 bug by pinning the version.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -36,6 +36,8 @@ Vagrant.configure("2") do |config|
 
     if provisioner_type == "ansible_local"
       ansible.provisioning_path = "/vagrant"
+      ansible.install_mode = "pip"
+      ansible.version = "2.4.4.0"
     end
   end
 end


### PR DESCRIPTION
Ansible 2.5 introduced a bug installing local requirements in a non-virtualenv.  Until this is fixed or the Grider role implements a work-around, we have to pin the ansible version.  See https://github.com/ansible/ansible/issues/37912, https://github.com/girder/girder/issues/2690.