### PR TITLE
Add annotation groups to the AnnotationSelector panel

### DIFF
--- a/plugin_tests/client/annotationSpec.js
+++ b/plugin_tests/client/annotationSpec.js
@@ -328,6 +328,7 @@ $(function () {
 
             it('check that the drawing type persists when switching annotatations', function () {
                 runs(function () {
+                    $('.h-annotation-selector .h-group-collapsed .h-annotation-group-name').click();
                     expect($('button.h-draw[data-type="point"]').hasClass('active')).toBe(true);
                     $('.h-create-annotation').click();
                 });
@@ -341,6 +342,11 @@ $(function () {
                 runs(function () {
                     expect($('button.h-draw[data-type="point"]').hasClass('active')).toBe(true);
                 });
+                waitsFor(function () {
+                    $('.h-annotation-selector .h-group-collapsed .h-annotation-group-name').click();
+                    return $('.h-annotation-selector .h-annotation:contains("drawn b")').length;
+                }, '"drawn b" control to be shown');
+
                 // delete the annotation we just created.
                 runs(function () {
                     $('.h-annotation-selector .h-annotation:contains("drawn b") .h-delete-annotation').click();
@@ -350,8 +356,12 @@ $(function () {
                     $('.h-submit').click();
                 });
                 girderTest.waitForLoad();
+                waitsFor(function () {
+                    return $('.h-annotation-selector .h-annotation:contains("drawn b")').length === 0;
+                }, '"drawn b" to be deleted');
                 // select the original annotation
                 runs(function () {
+                    expect($('.h-annotation-selector .h-annotation:contains("drawn 1") .h-annotation-name').length).toBe(1);
                     $('.h-annotation-selector .h-annotation:contains("drawn 1") .h-annotation-name').click();
                 });
                 waitsFor(function () {
@@ -497,6 +507,31 @@ $(function () {
         describe('Annotation panel', function () {
             it('panel is rendered', function () {
                 expect($('.h-annotation-selector .s-panel-title').text()).toMatch(/Annotations/);
+
+                // make sure all groups are expanded
+                $('.h-annotation-selector .h-group-collapsed .h-annotation-group-name').click();
+            });
+
+            it('collapse an annotation group', function () {
+                var $el = $('.h-annotation-selector .h-group-expanded[data-group-name="Other"]');
+                expect($el.length).toBe(1);
+                $el.find('.h-annotation-group-name').click();
+
+                $el = $('.h-annotation-selector .h-annotation-group[data-group-name="Other"]');
+                expect($el.hasClass('h-group-collapsed')).toBe(true);
+                expect($el.hasClass('h-group-expanded')).toBe(false);
+                expect($el.find('.h-annotation').length).toBe(0);
+            });
+
+            it('expand an annotation group', function () {
+                var $el = $('.h-annotation-selector .h-group-collapsed[data-group-name="Other"]');
+                expect($el.length).toBe(1);
+                $el.find('.h-annotation-group-name').click();
+
+                $el = $('.h-annotation-selector .h-annotation-group[data-group-name="Other"]');
+                expect($el.hasClass('h-group-collapsed')).toBe(false);
+                expect($el.hasClass('h-group-expanded')).toBe(true);
+                expect($el.find('.h-annotation').length).toBeGreaterThan(0);
             });
 
             it('ensure user cannot remove the admin annotation', function () {

--- a/web_client/panels/AnnotationSelector.js
+++ b/web_client/panels/AnnotationSelector.js
@@ -34,7 +34,8 @@ var AnnotationSelector = Panel.extend({
         'mouseleave .h-annotation': '_unhighlightAnnotation',
         'change #h-toggle-labels': 'toggleLabels',
         'change #h-toggle-interactive': 'toggleInteractiveMode',
-        'input #h-annotation-opacity': '_changeGlobalOpacity'
+        'input #h-annotation-opacity': '_changeGlobalOpacity',
+        'click .h-annotation-group-name': '_toggleExpandGroup'
     }),
 
     /**
@@ -46,6 +47,7 @@ var AnnotationSelector = Panel.extend({
      *     to the current image.
      */
     initialize(settings = {}) {
+        this._expandedGroups = new Set();
         this._opacity = settings.opacity || 0.9;
         this.listenTo(this.collection, 'sync remove update reset change:displayed change:loading', this.render);
         this.listenTo(this.collection, 'change:highlight', this._changeAnnotationHighlight);
@@ -59,13 +61,13 @@ var AnnotationSelector = Panel.extend({
     },
 
     render() {
+        const annotationGroups = this._getAnnotationGroups();
         this.$('[data-toggle="tooltip"]').tooltip('destroy');
         if (!this.viewer) {
             this.$el.empty();
             return;
         }
         this.$el.html(annotationSelectorWidget({
-            annotations: this.collection.sortBy('created'),
             id: 'annotation-panel-container',
             title: 'Annotations',
             activeAnnotation: this._activeAnnotation ? this._activeAnnotation.id : '',
@@ -73,7 +75,10 @@ var AnnotationSelector = Panel.extend({
             user: getCurrentUser() || {},
             writeAccess: this._writeAccess,
             opacity: this._opacity,
-            interactiveMode: this._interactiveMode
+            interactiveMode: this._interactiveMode,
+            expandedGroups: this._expandedGroups,
+            annotationGroups,
+            _
         }));
         this.$('.s-panel-content').collapse({toggle: false});
         this.$('[data-toggle="tooltip"]').tooltip({container: 'body'});
@@ -334,6 +339,39 @@ var AnnotationSelector = Panel.extend({
         this.$('.h-annotation-opacity-container')
             .attr('title', `Annotation opacity ${(this._opacity * 100).toFixed()}%`);
         this.trigger('h:annotationOpacity', this._opacity);
+    },
+
+    _toggleExpandGroup(evt) {
+        const name = $(evt.currentTarget).parent().data('groupName');
+        if (this._expandedGroups.has(name)) {
+            this._expandedGroups.delete(name);
+        } else {
+            this._expandedGroups.add(name);
+        }
+        this.render();
+    },
+
+    _getAnnotationGroups() {
+        // Annotations without elements don't have any groups, so we inject the null group
+        // so that they are displayed in the panel.
+        this.collection.each((a) => {
+            const groups = a.get('groups') || [];
+            if (!groups.length) {
+                groups.push(null);
+            }
+        });
+        const groupObject = {};
+        const groups = _.union(...this.collection.map((a) => a.get('groups')));
+        _.each(groups, (group) => {
+            const groupList = this.collection.filter(
+                (a) => _.contains(a.get('groups'), group));
+
+            if (group === null) {
+                group = 'Other';
+            }
+            groupObject[group] = _.sortBy(groupList, (a) => a.get('created'));
+        });
+        return groupObject;
     }
 });
 

--- a/web_client/panels/DrawWidget.js
+++ b/web_client/panels/DrawWidget.js
@@ -43,6 +43,7 @@ var DrawWidget = Panel.extend({
         this._groups = new StyleCollection();
         this._style = new StyleModel({id: 'default'});
         this.listenTo(this._groups, 'update', this.render);
+        this.listenTo(this.collection, 'add remove', this._recalculateGroupAggregation);
         this.listenTo(this.collection, 'change update', this.render);
         this._groups.fetch().done(() => {
             // ensure the default style exists
@@ -231,6 +232,14 @@ var DrawWidget = Panel.extend({
 
     _unhighlightElement() {
         this.parentView.trigger('h:highlightAnnotation');
+    },
+
+    _recalculateGroupAggregation() {
+        const groups = _.invoke(
+            this.collection.filter((el) => el.get('group')),
+            'get', 'group'
+        );
+        this.annotation.set('groups', groups);
     }
 });
 

--- a/web_client/stylesheets/panels/annotationSelector.styl
+++ b/web_client/stylesheets/panels/annotationSelector.styl
@@ -15,6 +15,10 @@
     margin-top 2px
 
 .h-annotation
+    padding 2px
+    line-height 1.1
+    font-weight initial
+    margin-left 5px
     border-radius 3px
     span
         cursor pointer
@@ -28,11 +32,27 @@
     a
         color #333
     .h-annotation-name
-        width 180px
+        width 170px
         display inline-block
         text-overflow ellipsis
         white-space nowrap
         overflow hidden
+
+.h-annotation-group-name
+  font-weight bold
+  text-align left
+  padding 2px
+  border-style none
+  border-width 0
+
+  i
+    margin-right 2px
+    float left
+    color #6b6b6b
+
+  &:hover
+    background-color #eee
+    cursor pointer
 
 .h-annotation.h-active-annotation
   background-color #c5cae9 !important

--- a/web_client/templates/panels/annotationSelector.pug
+++ b/web_client/templates/panels/annotationSelector.pug
@@ -15,37 +15,51 @@ block content
       input#h-annotation-opacity(
           type="range", min="0", max="1", step="0.01", value=opacity)
 
-  - var admin = user && user.get && user.get('admin');
-  each annotation in annotations
-    - var name = annotation.get('annotation').name;
-    - var displayed = annotation.get('displayed');
-    - var loading = annotation.get('loading');
-    - var classes = [];
-    if annotation.id === activeAnnotation
-      - classes.push('h-active-annotation');
-    if annotation.get('highlight')
-      - classes.push('h-highlight-annotation')
-    .h-annotation(data-id=annotation.id, class=classes)
-      if loading
-        span.icon-spin3.animate-spin.h-float-left
-      else if displayed
-        span.icon-eye.h-toggle-annotation.h-float-left(
-          data-toggle='tooltip', title='Hide annotation')
-      else
-        span.icon-eye-off.h-toggle-annotation.h-float-left(
-          data-toggle='tooltip', title='Show annotation')
-      span.h-annotation-name(title=name) #{name}
+  - var groups = _.keys(annotationGroups);
+  - groups.sort();
+  each groupName in groups
+    - var annotations = annotationGroups[groupName];
+    - var expanded = expandedGroups.has(groupName);
+    - var expandedClass = expanded ? 'h-group-expanded' : 'h-group-collapsed';
+    .h-annotation-group(class=[expandedClass], data-group-name=groupName)
+      .h-annotation-group-name.clearfix
+        = groupName
+        if expanded
+          i.icon-folder-open
+        else
+          i.icon-folder
+      if expanded
+        - var admin = user && user.get && user.get('admin');
+        each annotation in annotations
+          - var name = annotation.get('annotation').name;
+          - var displayed = annotation.get('displayed');
+          - var loading = annotation.get('loading');
+          - var classes = [];
+          if annotation.id === activeAnnotation
+            - classes.push('h-active-annotation');
+          if annotation.get('highlight')
+            - classes.push('h-highlight-annotation')
+          .h-annotation(data-id=annotation.id, class=classes)
+            if loading
+              span.icon-spin3.animate-spin.h-float-left
+            else if displayed
+              span.icon-eye.h-toggle-annotation.h-float-left(
+                data-toggle='tooltip', title='Hide annotation')
+            else
+              span.icon-eye-off.h-toggle-annotation.h-float-left(
+                data-toggle='tooltip', title='Show annotation')
+            span.h-annotation-name(title=name) #{name}
 
-      span.h-annotation-right
-        if writeAccess(annotation)
-          span.icon-cancel.h-delete-annotation(
-              data-toggle='tooltip', title='Remove annotation')
-          span.icon-cog.h-edit-annotation-metadata(
-              data-toggle='tooltip', title='Edit annotation')
-        a(href=annotation.downloadUrl().replace(/\/download$/, ''),
-            download=name + '.json')
-          span.icon-download.h-download-annotation(
-              data-toggle='tooltip', title='Download annotation')
+            span.h-annotation-right
+              if writeAccess(annotation)
+                span.icon-cancel.h-delete-annotation(
+                    data-toggle='tooltip', title='Remove annotation')
+                span.icon-cog.h-edit-annotation-metadata(
+                    data-toggle='tooltip', title='Edit annotation')
+              a(href=annotation.downloadUrl().replace(/\/download$/, ''),
+                  download=name + '.json')
+                span.icon-download.h-download-annotation(
+                    data-toggle='tooltip', title='Download annotation')
 
   .checkbox.h-annotation-toggle
     label(title='Show annotation labels when hovering with the mouse.')


### PR DESCRIPTION
This groups the annotation list in the AnnotationSelector panel by
"group" name.  In this context, the group the annotation belongs to is a
list of one or more styles applied to at least one element.  In
addition, if an element in an annotation has no style name, then it is
listed as in the "null" group which gets displayed into a single group
named "Other".

I suspect we will want to add more "group" level actions like "download all"
or "show all".  This should be easy to do with these changes in place.

Depends on https://github.com/girder/large_image/pull/276