### PR TITLE
Update ansible and travis for pip 10 changes.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -79,7 +79,7 @@ before_install:
     - girder_worker_path=$girder_path/plugins/girder_worker
     - git clone https://github.com/girder/girder_worker.git $girder_worker_path && git -C $girder_worker_path checkout $GIRDER_WORKER_VERSION
     - cp $PWD/plugin_tests/data/girder_worker.cfg $girder_worker_path/girder_worker/worker.local.cfg
-    - pip install --no-cache-dir -U $girder_worker_path'[girder_io,docker]'
+    - pip install --no-cache-dir -U --upgrade-strategy eager $girder_worker_path'[girder_io,docker]'
 
     - large_image_path=$girder_path/plugins/large_image
     - git clone https://github.com/girder/large_image.git $large_image_path && git -C $large_image_path checkout $LARGE_IMAGE_VERSION
@@ -106,13 +106,13 @@ before_install:
 
 install:
     - cd $girder_path
-    - pip install -U -r requirements-dev.txt
-    - pip install -U -e .[worker]
+    - pip install -U --upgrade-strategy eager -r requirements-dev.txt
+    - pip install -U --upgrade-strategy eager -e .[worker]
     - cd $large_image_path
     - pip install --no-cache-dir numpy>=1.12.1
     - pip install --upgrade --no-cache-dir --force-reinstall --ignore-installed openslide-python Pillow
 
-    - pip install -U .[memcached,openslide]
+    - pip install -U --upgrade-strategy eager .[memcached,openslide]
     - python setup.py install
     - cd $main_path
     - pip install --upgrade 'git+https://github.com/cdeepakroy/ctk-cli'
@@ -120,7 +120,7 @@ install:
     # needs to be installed in dev mode for it to place binaries of cython/c extensions in place
     - pip install -e .
     - cd $girder_path
-    - pip install -U -r $slicer_cli_web_path/requirements.txt
+    - pip install -U --upgrade-strategy eager -r $slicer_cli_web_path/requirements.txt
     - npm-install-retry
     - BABEL_ENV=cover NYC_CWD="$main_path" girder-install web --plugins=jobs,worker,large_image,slicer_cli_web,HistomicsTK --dev
     - pip install jupyter 'sphinx<1.7' sphinx_rtd_theme nbsphinx travis-sphinx

--- a/ansible/Dockerfile-girder-worker
+++ b/ansible/Dockerfile-girder-worker
@@ -8,7 +8,7 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends iputils-ping telnet-ssl tmux less && \
     sudo rm -rf /var/lib/apt/lists/* /tmp/*
 RUN pip install -U pip
-RUN pip install -U ansible
+RUN pip install -U --upgrade-strategy eager ansible
 RUN locale-gen en_US.UTF-8
 RUN adduser --disabled-password --gecos '' ubuntu && \
     adduser ubuntu sudo && \

--- a/ansible/Dockerfile-histomicstk
+++ b/ansible/Dockerfile-histomicstk
@@ -8,7 +8,7 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends iputils-ping telnet-ssl tmux less && \
     sudo rm -rf /var/lib/apt/lists/* /tmp/*
 RUN pip install -U pip
-RUN pip install -U 'ansible<2.5'
+RUN pip install -U --upgrade-strategy eager 'ansible<2.5'
 RUN locale-gen en_US.UTF-8
 RUN adduser --disabled-password --gecos '' ubuntu && \
     adduser ubuntu sudo && \

--- a/ansible/roles/girder-histomicstk/tasks/main.yml
+++ b/ansible/roles/girder-histomicstk/tasks/main.yml
@@ -104,21 +104,21 @@
 - name: Install numpy (must be installed before large_image plugin)
   pip:
     name: numpy
-    extra_args: "-U"
+    extra_args: "-U --upgrade-strategy eager"
     state: present
   become: true
 
 - name: Install scikit-build (must be installed before HistomicsTK plugin)
   pip:
     name: scikit-build
-    extra_args: "-U"
+    extra_args: "-U --upgrade-strategy eager"
     state: present
   become: true
 
 - name: Make sure the six library is updated
   pip:
     name: six
-    extra_args: "-U"
+    extra_args: "-U --upgrade-strategy eager"
     state: present
   become: true
 

--- a/ansible/roles/openslide/tasks/main.yml
+++ b/ansible/roles/openslide/tasks/main.yml
@@ -225,18 +225,27 @@
 - name: Purge pip cache
   command: |
     python -c '
-    import pip.locations, shutil
-    shutil.rmtree(pip.locations.USER_CACHE_DIR, True)
+    try:
+    ''  import pip.locations as locations
+    except ImportError:
+    ''  import pip._internal.locations as locations
+    import shutil
+    shutil.rmtree(locations.USER_CACHE_DIR, True)
     '
   become: true
 
 - name: Reinstall python modules that depend on OpenJPEG and libtiff if they are installed.
   command: |
     python -c '
-    import pip
+    try:
+    ''  import pip.commands as commands
+    ''  from pip import main
+    except ImportError:
+    ''  import pip._internal.commands as commands
+    ''  from pip._internal import main
     packages = ["Pillow", "libtiff"]
-    for package in pip.commands.show.search_packages_info(packages):
-    ''  pip.main(["install", "--force-reinstall", "--ignore-installed",
+    for package in commands.show.search_packages_info(packages):
+    ''  main(["install", "--force-reinstall", "--ignore-installed",
     ''           "%s==%s" % (package["name"], package["version"])])
     '
   become: true

--- a/ansible/roles/openslide/tasks/main.yml
+++ b/ansible/roles/openslide/tasks/main.yml
@@ -223,29 +223,9 @@
   become: true
 
 - name: Purge pip cache
-  command: |
-    python -c '
-    try:
-    ''  import pip.locations as locations
-    except ImportError:
-    ''  import pip._internal.locations as locations
-    import shutil
-    shutil.rmtree(locations.USER_CACHE_DIR, True)
-    '
+  shell: rm -rf ~/.cache/pip
   become: true
 
 - name: Reinstall python modules that depend on OpenJPEG and libtiff if they are installed.
-  command: |
-    python -c '
-    try:
-    ''  import pip.commands as commands
-    ''  from pip import main
-    except ImportError:
-    ''  import pip._internal.commands as commands
-    ''  from pip._internal import main
-    packages = ["Pillow", "libtiff"]
-    for package in commands.show.search_packages_info(packages):
-    ''  main(["install", "--force-reinstall", "--ignore-installed",
-    ''           "%s==%s" % (package["name"], package["version"])])
-    '
+  shell: for pkg in `pip freeze | egrep '^(libtiff|Pillow)='`; do pip install --force-reinstall --ignore-installed "$pkg"; done
   become: true


### PR DESCRIPTION
We use some of the pip internals for cache management and ensuring we update the current versions of modules that depend on locally built libraries.  Unfortunately, pip doesn't have any cache management exposed publicly, which means either hardcoding paths or using now internal functions.