### PR TITLE
Add a permissions editor dialog for annotations

### DIFF
--- a/plugin_tests/client/annotationSpec.js
+++ b/plugin_tests/client/annotationSpec.js
@@ -626,6 +626,42 @@ $(function () {
                 });
             });
 
+            it('set annotation permissions to WRITE', function () {
+                runs(function () {
+                    $('.h-annotation-selector .h-annotation:contains("edited 1") .h-edit-annotation-metadata').click();
+                });
+
+                girderTest.waitForDialog();
+                runs(function () {
+                    expect($('#g-dialog-container .h-access').length).toBe(1);
+                    $('#g-dialog-container .h-access').click();
+                });
+
+                girderTest.waitForDialog();
+                runs(function () {
+                    var $el = $('#g-dialog-container');
+                    expect($el.find('.modal-title').text()).toBe('Access control');
+
+                    // set edit-only access
+                    expect($el.find('.g-user-access-entry').length).toBe(1);
+                    $el.find('.g-user-access-entry .g-access-col-right select').val(1);
+                    $el.find('.g-save-access-list').click();
+                });
+
+                girderTest.waitForLoad();
+                runs(function () {
+                    // the user should still have the edit button
+                    expect($('.h-annotation-selector .h-annotation:contains("edited 1") .h-edit-annotation-metadata').length).toBe(1);
+                    $('.h-annotation-selector .h-annotation:contains("edited 1") .h-edit-annotation-metadata').click();
+                });
+
+                girderTest.waitForDialog();
+                runs(function () {
+                    // admin access should be removed
+                    expect($('#g-dialog-container .h-access').length).toBe(0);
+                });
+            });
+
             it('delete an annotation', function () {
                 var annotations = null;
                 runs(function () {

--- a/plugin_tests/web_client_test.py
+++ b/plugin_tests/web_client_test.py
@@ -144,5 +144,9 @@ class WebClientTestCase(web_client_test.WebClientTestCase):
         self.model('image_item', 'large_image').copyItem(
             item, user, name='copy')
 
-        self.model('annotation', 'large_image').createAnnotation(
+        annotation = self.model('annotation', 'large_image').createAnnotation(
             item, admin, {'name': 'admin annotation'})
+        annotation = self.model('annotation', 'large_image').setAccessList(
+            annotation, {}, force=True, save=False)
+        annotation = self.model('annotation', 'large_image').setPublic(
+            annotation, True, save=True)

--- a/web_client/dialogs/saveAnnotation.js
+++ b/web_client/dialogs/saveAnnotation.js
@@ -31,6 +31,7 @@ var SaveAnnotation = View.extend({
 
     access(evt) {
         evt.preventDefault();
+        this.annotation.off('g:accessListSaved');
         new AccessWidget({
             el: $('#g-dialog-container'),
             type: 'annotation',

--- a/web_client/dialogs/saveAnnotation.js
+++ b/web_client/dialogs/saveAnnotation.js
@@ -1,8 +1,11 @@
 import _ from 'underscore';
 
+import AccessWidget from 'girder/views/widgets/AccessWidget';
 import View from 'girder/views/View';
+import { AccessType } from 'girder/constants';
 
 import saveAnnotation from '../templates/dialogs/saveAnnotation.pug';
+import '../stylesheets/dialogs/saveAnnotation.styl';
 
 /**
  * Create a modal dialog with fields to edit the properties of
@@ -10,6 +13,7 @@ import saveAnnotation from '../templates/dialogs/saveAnnotation.pug';
  */
 var SaveAnnotation = View.extend({
     events: {
+        'click .h-access': 'access',
         'click .h-cancel': 'cancel',
         'submit form': 'save'
     },
@@ -18,10 +22,24 @@ var SaveAnnotation = View.extend({
         this.$el.html(
             saveAnnotation({
                 title: this.options.title,
+                hasAdmin: this.annotation.get('_accessLevel') >= AccessType.ADMIN,
                 annotation: this.annotation.toJSON().annotation
             })
         ).girderModal(this);
         return this;
+    },
+
+    access(evt) {
+        evt.preventDefault();
+        new AccessWidget({
+            el: $('#g-dialog-container'),
+            type: 'annotation',
+            hideRecurseOption: true,
+            parentView: this,
+            model: this.annotation
+        }).on('g:accessListSaved', () => {
+            this.annotation.fetch();
+        });
     },
 
     cancel(evt) {

--- a/web_client/panels/AnnotationSelector.js
+++ b/web_client/panels/AnnotationSelector.js
@@ -1,5 +1,6 @@
 import _ from 'underscore';
 
+import { AccessType } from 'girder/constants';
 import eventStream from 'girder/utilities/EventStream';
 import { getCurrentUser } from 'girder/auth';
 import Panel from 'girder_plugins/slicer_cli_web/views/Panel';
@@ -297,13 +298,7 @@ var AnnotationSelector = Panel.extend({
     },
 
     _writeAccess(annotation) {
-        const user = getCurrentUser();
-        if (!user || !annotation) {
-            return false;
-        }
-        const admin = user.get && user.get('admin');
-        const creator = user.id === annotation.get('creatorId');
-        return admin || creator;
+        return annotation.get('_accessLevel') >= AccessType.ADMIN;
     },
 
     showAllAnnotations() {

--- a/web_client/stylesheets/dialogs/saveAnnotation.styl
+++ b/web_client/stylesheets/dialogs/saveAnnotation.styl
@@ -1,0 +1,3 @@
+#g-dialog-container
+  .h-access
+    float left

--- a/web_client/templates/dialogs/saveAnnotation.pug
+++ b/web_client/templates/dialogs/saveAnnotation.pug
@@ -17,5 +17,7 @@
             | #{annotation.description}
         .g-validation-failed-message.hidden
       .modal-footer
+        if hasAdmin
+          button.btn.btn-small.btn-warning.h-access(type='button') Permissions
         button.btn.btn-small.btn-default.h-cancel(type='button', data-dismiss='modal') Cancel
         button.btn.btn-small.btn-primary.h-submit(type='submit') Save


### PR DESCRIPTION
This the changes from https://github.com/girder/large_image/pull/282 to add a "Permissions" button to the edit annotation dialog for users with admin access to the annotation document.  I added the button to the annotation editor dialog to avoid cluttering the main panel.  I know this isn't easiest place to find, but I couldn't come up with anything better.