### PR TITLE
Allow branding HistomicsTK.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -123,7 +123,7 @@ install:
     - pip install -U --upgrade-strategy eager -r $slicer_cli_web_path/requirements.txt
     - npm-install-retry
     - BABEL_ENV=cover NYC_CWD="$main_path" girder-install web --plugins=jobs,worker,large_image,slicer_cli_web,HistomicsTK --dev
-    - pip install jupyter 'sphinx<1.7' sphinx_rtd_theme nbsphinx travis-sphinx
+    - pip install jupyter sphinx sphinx_rtd_theme nbsphinx travis-sphinx
     # - pip install numpy==1.13.1  # pin numpy for now
     - pip freeze  # report what we have installed
 

--- a/plugin_tests/client/histomicstkSpec.js
+++ b/plugin_tests/client/histomicstkSpec.js
@@ -69,6 +69,14 @@ describe('Test the HistomicsTK plugin', function () {
             return $('#g-histomicstk-error-message').text().substr('must be a JSON list') >= 0;
         });
         runs(function () {
+            $('#g-histomicstk-brand-color').val('#ffffff');
+            $('#g-histomicstk-brand-default-color').click();
+            expect($('#g-histomicstk-brand-color').val() === '#777777');
+            $('#g-histomicstk-banner-color').val('#ffffff');
+            $('#g-histomicstk-banner-default-color').click();
+            expect($('#g-histomicstk-banner-color').val() === '#f8f8f8');
+        });
+        runs(function () {
             $('.g-histomicstk-buttons #g-histomicstk-cancel').click();
         });
         waitsFor(function () {

--- a/plugin_tests/histomicstk_test.py
+++ b/plugin_tests/histomicstk_test.py
@@ -27,10 +27,10 @@ def tearDownModule():
 
 class HistomicsTKCoreTest(base.TestCase):
 
-    def testSettings(self):
-        from girder.plugins.HistomicsTK import constants
+    def testHistomicsTKSettings(self):
+        from girder.plugins.HistomicsTK.constants import PluginSettings
 
-        key = constants.PluginSettings.HISTOMICSTK_DEFAULT_DRAW_STYLES
+        key = PluginSettings.HISTOMICSTK_DEFAULT_DRAW_STYLES
 
         resp = self.request(path='/HistomicsTK/settings')
         self.assertStatus(resp, 200)
@@ -53,3 +53,67 @@ class HistomicsTKCoreTest(base.TestCase):
         self.assertStatus(resp, 200)
         settings = resp.json
         self.assertEqual(json.loads(settings[key]), value)
+
+    def testGeneralSettings(self):
+        from girder.plugins.HistomicsTK.constants import PluginSettings
+
+        settings = [{
+            'key': PluginSettings.HISTOMICSTK_WEBROOT_PATH,
+            'initial': 'histomicstk',
+            'bad': {
+                'girder': 'not be "girder"',
+                '': 'not be empty'
+            },
+            'good': {'alternate1': 'alternate1'},
+        }, {
+            'key': PluginSettings.HISTOMICSTK_BRAND_NAME,
+            'initial': 'HistomicsTK',
+            'bad': {'': 'not be empty'},
+            'good': {'Alternate': 'Alternate'},
+        }, {
+            'key': PluginSettings.HISTOMICSTK_BRAND_COLOR,
+            'initial': '#777777',
+            'bad': {
+                '': 'not be empty',
+                'white': 'be a hex color',
+                '#777': 'be a hex color'
+            },
+            'good': {'#000000': '#000000'},
+        }, {
+            'key': PluginSettings.HISTOMICSTK_BANNER_COLOR,
+            'initial': '#f8f8f8',
+            'bad': {
+                '': 'not be empty',
+                'white': 'be a hex color',
+                '#777': 'be a hex color'
+            },
+            'good': {'#000000': '#000000'},
+        }]
+        for setting in settings:
+            key = setting['key']
+            self.assertEqual(Setting().get(key), setting['initial'])
+            for badval in setting['bad']:
+                with six.assertRaisesRegex(self, ValidationException, setting['bad'][badval]):
+                    Setting().set(key, badval)
+            for goodval in setting['good']:
+                self.assertEqual(Setting().set(key, goodval)['value'], setting['good'][goodval])
+
+    def testGetWebroot(self):
+        from girder.plugins.HistomicsTK.constants import PluginSettings
+
+        resp = self.request(path='/histomicstk', method='GET', isJson=False, prefix='')
+        self.assertStatusOk(resp)
+        body = self.getBody(resp)
+        assert '<title>HistomicsTK</title>' in body
+        resp = self.request(path='/alternate2', method='GET', isJson=False, prefix='')
+        self.assertStatus(resp, 404)
+        Setting().set(PluginSettings.HISTOMICSTK_WEBROOT_PATH, 'alternate2')
+        Setting().set(PluginSettings.HISTOMICSTK_BRAND_NAME, 'Alternate')
+        resp = self.request(path='/histomicstk', method='GET', isJson=False, prefix='')
+        self.assertStatusOk(resp)
+        body = self.getBody(resp)
+        assert '<title>Alternate</title>' in body
+        resp = self.request(path='/alternate2', method='GET', isJson=False, prefix='')
+        self.assertStatusOk(resp)
+        body = self.getBody(resp)
+        assert '<title>Alternate</title>' in body

--- a/server/constants.py
+++ b/server/constants.py
@@ -5,3 +5,7 @@
 # Constants representing the setting keys for this plugin
 class PluginSettings(object):
     HISTOMICSTK_DEFAULT_DRAW_STYLES = 'histomicstk.default_draw_styles'
+    HISTOMICSTK_WEBROOT_PATH = 'histomicstk.webroot_path'
+    HISTOMICSTK_BRAND_NAME = 'histomicstk.brand_name'
+    HISTOMICSTK_BRAND_COLOR = 'histomicstk.brand_color'
+    HISTOMICSTK_BANNER_COLOR = 'histomicstk.banner_color'

--- a/server/webroot.mako
+++ b/server/webroot.mako
@@ -24,7 +24,10 @@
       girder.events.trigger('g:appload.before');
       var app = new girder.plugins.HistomicsTK.App({
         el: 'body',
-        parentView: null
+        parentView: null,
+        brandName: '${htkBrandName | js}',
+        brandColor: '${htkBrandColor | js}',
+        bannerColor: '${htkBannerColor | js}',
       });
       app.bindRoutes();
       girder.events.trigger('g:appload.after');

--- a/web_client/app.js
+++ b/web_client/app.js
@@ -13,12 +13,18 @@ import layoutTemplate from './templates/layout/layout.pug';
 import './stylesheets/layout/layout.styl';
 
 var App = GirderApp.extend({
+    initialize(settings) {
+        this.settings = settings;
+        return GirderApp.prototype.initialize.apply(this, arguments);
+    },
+
     render() {
         this.$el.html(layoutTemplate());
 
         this.histomicsHeader = new HeaderView({
             el: this.$('#g-app-header-container'),
-            parentView: this
+            parentView: this,
+            settings: this.settings
         }).render();
 
         return this;

--- a/web_client/stylesheets/body/configView.styl
+++ b/web_client/stylesheets/body/configView.styl
@@ -2,3 +2,13 @@
   .g-histomicstk-description
     font-size 12px
     margin 0 0 2px
+
+#g-histomicstk-banner-color, #g-histomicstk-brand-color
+  display inline
+  max-width 160px
+
+#g-histomicstk-banner-default-color, #g-histomicstk-brand-default-color
+  width 65px
+  display inline
+  // Vertical-align is useful to avoid an 5px offset in Mozilla
+  vertical-align top

--- a/web_client/stylesheets/layout/header.styl
+++ b/web_client/stylesheets/layout/header.styl
@@ -25,7 +25,18 @@
       float none
   .navbar-header
     z-index 20
-    background #f8f8f8
     float none
     position absolute
     left 0
+  .navbar-header a#h-navbar-brand.navbar-brand
+      background-color transparent
+  .navbar-default .navbar-nav
+    &> .open > a
+      color inherit
+      background-color rgba(217, 217, 217, 0.5)
+    &> .open > a:hover
+      color inherit
+    &> .open > a:focus
+      color inherit
+    &> li > a
+      color inherit

--- a/web_client/templates/body/configView.pug
+++ b/web_client/templates/body/configView.pug
@@ -1,7 +1,35 @@
 .g-config-breadcrumb-container
 p.g-histomicstk-description
-  | Provides a tool hit for analyzing histology images.
+  | Provides a toolkit for analyzing histology images.
 form#g-histomicstk-form(role="form")
+  .form-group
+    label(for="g-histomicstk-brand-name") Root Path
+    input#g-histomicstk-webroot-path.form-control.input-sm(
+        type="text", value=settings['histomicstk.webroot_path'] || '',
+        placeholder=`Default: ${defaults['histomicstk.webroot_path'] || 'histomicstk'}`,
+        title="The relative URL of the application.")
+  .form-group
+    label(for="g-histomicstk-brand-name") Brand Name
+    input#g-histomicstk-brand-name.form-control.input-sm(
+        type="text", value=settings['histomicstk.brand_name'] || '',
+        placeholder=`Default: ${defaults['histomicstk.brand_name'] || 'none'}`,
+        title="The brand name of the application.")
+  .form-group
+    label(for="g-histomicstk-brand-color") Brand Color
+    #g-histomicstk-brand-color-container
+      input#g-histomicstk-brand-color.form-control.input-sm(
+          type="color", value=settings['histomicstk.brand_color'] || defaults['histomicstk.brand_color'],
+          title="The color of the application brand text.")
+      button#g-histomicstk-brand-default-color.form-control.input-sm(
+          type="button", title="Default color") default
+  .form-group
+    label(for="g-histomicstk-banner-color") Banner Color
+    #g-histomicstk-banner-color-container
+      input#g-histomicstk-banner-color.form-control.input-sm(
+          type="color", value=settings['histomicstk.banner_color'] || defaults['histomicstk.banner_color'],
+          title="The banner color of the application.")
+      button#g-histomicstk-banner-default-color.form-control.input-sm(
+          type="button", title="Default color") default
   .form-group
     label
       | Default styles for drawing annotations

--- a/web_client/templates/layout/header.pug
+++ b/web_client/templates/layout/header.pug
@@ -1,4 +1,4 @@
-nav.navbar.navbar-default
+nav.navbar.navbar-default(style=`color: ${brandColor}; background-color: ${bannerColor}`)
   .container-fluid
     .navbar-header
       button.navbar-toggle.collapsed(
@@ -10,7 +10,8 @@ nav.navbar.navbar-default
         span.icon-bar
         span.icon-bar
         span.icon-bar
-      a#h-navbar-brand.navbar-brand HistomicsTK
+      - console.log(brandName, brandColor, bannerColor);
+      a#h-navbar-brand.navbar-brand(style=`color: ${brandColor}`) #{brandName}
 
     #h-navbar-collapse.collapse.navbar-collapse
       ul.nav.navbar-nav.navbar-right

--- a/web_client/views/body/ConfigView.js
+++ b/web_client/views/body/ConfigView.js
@@ -1,3 +1,4 @@
+import _ from 'underscore';
 import View from 'girder/views/View';
 
 import PluginConfigBreadcrumbWidget from 'girder/views/widgets/PluginConfigBreadcrumbWidget';
@@ -15,10 +16,19 @@ var ConfigView = View.extend({
     events: {
         'click #g-histomicstk-save': function (event) {
             this.$('#g-histomicstk-error-message').text('');
-            this._saveSettings([{
-                key: 'histomicstk.default_draw_styles',
-                value: this.$('#g-histomicstk-default-draw-styles').val()
-            }]);
+            this._saveSettings(_.map(this.settingsKeys, (key) => {
+                const element = this.$('#g-' + key.replace(/[_.]/g, '-'));
+                return {
+                    key,
+                    value: element.val() || null
+                };
+            }));
+        },
+        'click #g-histomicstk-brand-default-color': function () {
+            this.$('#g-histomicstk-brand-color').val(this.defaults['histomicstk.brand_color']);
+        },
+        'click #g-histomicstk-banner-default-color': function () {
+            this.$('#g-histomicstk-banner-color').val(this.defaults['histomicstk.banner_color']);
         },
         'click #g-histomicstk-cancel': function (event) {
             router.navigate('plugins', {trigger: true});
@@ -30,23 +40,40 @@ var ConfigView = View.extend({
             parentView: this
         });
 
+        this.settingsKeys = [
+            'histomicstk.webroot_path',
+            'histomicstk.brand_name',
+            'histomicstk.brand_color',
+            'histomicstk.banner_color',
+            'histomicstk.default_draw_styles'
+        ];
         restRequest({
             method: 'GET',
             url: 'system/setting',
             data: {
-                list: JSON.stringify([
-                    'histomicstk.default_draw_styles'
-                ])
+                list: JSON.stringify(this.settingsKeys),
+                default: 'none'
             }
         }).done((resp) => {
             this.settings = resp;
-            this.render();
+            restRequest({
+                method: 'GET',
+                url: 'system/setting',
+                data: {
+                    list: JSON.stringify(this.settingsKeys),
+                    default: 'default'
+                }
+            }).done((resp) => {
+                this.defaults = resp;
+                this.render();
+            });
         });
     },
 
     render: function () {
         this.$el.html(ConfigViewTemplate({
-            settings: this.settings
+            settings: this.settings,
+            defaults: this.defaults
         }));
         this.breadcrumb.setElement(this.$('.g-config-breadcrumb-container')).render();
         return this;

--- a/web_client/views/layout/HeaderView.js
+++ b/web_client/views/layout/HeaderView.js
@@ -14,12 +14,17 @@ var HeaderView = View.extend({
         }
     },
 
-    initialize() {
+    initialize(params) {
+        this.settings = params.settings;
         return View.prototype.initialize.apply(this, arguments);
     },
 
     render() {
-        this.$el.html(headerTemplate());
+        this.$el.html(headerTemplate({
+            brandName: this.settings.brandName,
+            brandColor: this.settings.brandColor,
+            bannerColor: this.settings.bannerColor
+        }));
 
         this.$('a[title]').tooltip({
             placement: 'bottom',


### PR DESCRIPTION
To adjust the branding, this adds four settings:
- the webroot: the url fragment that goes to the main HistomicsTK interface (default is `histomicstk`).
- the brand name: default `HistomicsTK` shown in the upper left corner of the interface.
- the brand color: this is the text color of the brand name and the Analysis and user menus.
- the banner color: this is the background color of the header.