### PR TITLE
Add ACL for analysis menu.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,6 +60,14 @@ before_install:
     # https://github.com/travis-ci/travis-ci/issues/7940
     - sudo rm -f /etc/boto.cfg
 
+    - mkdir -p $HOME/.cache/node_modules || true
+    - ln -sf $HOME/.cache/node_modules .
+    - nvm install v8
+    - npm install -g npm
+    - npm install -g npm-install-retry
+    - npm --version
+    - npm prune
+
     - CACHE="$HOME/.cache" OPENJPEG_VERSION=2.1.2 OPENJPEG_FILE=v2.1.2.tar.gz OPENJPEG_DIR=openjpeg-2.1.2 LIBTIFF_VERSION=4.0.8 OPENSLIDE_VERSION=3.4.1 source .install-openslide.sh
 
     - GIRDER_VERSION=2.x-maintenance
@@ -96,13 +104,6 @@ before_install:
 
     - CACHE=$HOME/.cache CMAKE_VERSION=3.8.0 CMAKE_SHORT_VERSION=3.8 source $girder_path/scripts/install_cmake.sh
     - cmake --version
-
-    - mkdir -p $HOME/.cache/node_modules || true
-    - ln -sf $HOME/.cache/node_modules .
-    - npm install -g npm
-    - npm install -g npm-install-retry
-    - npm --version
-    - npm prune
 
 install:
     - cd $girder_path

--- a/plugin_tests/docker_test.py
+++ b/plugin_tests/docker_test.py
@@ -52,6 +52,10 @@ class DockerImageEndpointTest(base.TestCase):
         self.assertStatusOk(resp)
         # We should have no images
         self.assertEqual(resp.json, {})
+        # We should get an empty response withotu a user, too
+        resp = self.request(path='/HistomicsTK/HistomicsTK/docker_image')
+        self.assertStatusOk(resp)
+        self.assertEqual(resp.json, {})
 
     def testPutEndpoint(self):
         resp = self.request(path='/HistomicsTK/HistomicsTK/docker_image',

--- a/plugin_tests/histomicstk_test.py
+++ b/plugin_tests/histomicstk_test.py
@@ -4,10 +4,14 @@
 import json
 import os
 import six
+import time
 
 from girder import config
+from girder.constants import AccessType
+from girder.models.group import Group
 from girder.models.model_base import ValidationException
 from girder.models.setting import Setting
+from girder.models.user import User
 from tests import base
 
 
@@ -26,6 +30,13 @@ def tearDownModule():
 
 
 class HistomicsTKCoreTest(base.TestCase):
+    def setUp(self):
+        base.TestCase.setUp(self)
+        self.admin = User().findOne({'login': 'adminlogin'})
+        self.user = User().findOne({'login': 'goodlogin'})
+        self.user2 = User().findOne({'login': 'user2'})
+        self.group = Group().createGroup('test group', creator=self.user2)
+        Group().addUser(self.group, self.user2)
 
     def testHistomicsTKSettings(self):
         from girder.plugins.HistomicsTK.constants import PluginSettings
@@ -33,7 +44,7 @@ class HistomicsTKCoreTest(base.TestCase):
         key = PluginSettings.HISTOMICSTK_DEFAULT_DRAW_STYLES
 
         resp = self.request(path='/HistomicsTK/settings')
-        self.assertStatus(resp, 200)
+        self.assertStatusOk(resp)
         settings = resp.json
         self.assertEqual(settings[key], None)
 
@@ -50,7 +61,7 @@ class HistomicsTKCoreTest(base.TestCase):
         self.assertEqual(json.loads(Setting().get(key)), value)
 
         resp = self.request(path='/HistomicsTK/settings')
-        self.assertStatus(resp, 200)
+        self.assertStatusOk(resp)
         settings = resp.json
         self.assertEqual(json.loads(settings[key]), value)
 
@@ -88,15 +99,47 @@ class HistomicsTKCoreTest(base.TestCase):
                 '#777': 'be a hex color'
             },
             'good': {'#000000': '#000000'},
+        }, {
+            'key': PluginSettings.HISTOMICSTK_ANALYSIS_ACCESS,
+            'initial': {'public': True},
+            'bad': {
+                '': 'must be a JSON object',
+            },
+            'badjson': [{
+                'value': ['not an object'],
+                'return': 'must be a JSON object',
+            }, {
+                'value': {
+                    'public': False,
+                    'users': [self.user, self.admin['_id']],
+                    'groups': [self.user['_id']]},
+                'return': 'No such group',
+            }],
+            'goodjson': [{
+                'value': {
+                    'public': False, 'users': [self.user, self.admin['_id']]},
+                'return': {
+                    'public': False, 'users': [self.user['_id'], self.admin['_id']]},
+            }, {
+                'value': {
+                    'public': False, 'groups': [self.group]},
+                'return': {
+                    'public': False, 'groups': [self.group['_id']]},
+            }],
         }]
         for setting in settings:
             key = setting['key']
             self.assertEqual(Setting().get(key), setting['initial'])
-            for badval in setting['bad']:
+            for badval in setting.get('bad', {}):
                 with six.assertRaisesRegex(self, ValidationException, setting['bad'][badval]):
                     Setting().set(key, badval)
-            for goodval in setting['good']:
+            for badval in setting.get('badjosn', []):
+                with six.assertRaisesRegex(self, ValidationException, badval['return']):
+                    Setting().set(key, badval['value'])
+            for goodval in setting.get('good', {}):
                 self.assertEqual(Setting().set(key, goodval)['value'], setting['good'][goodval])
+            for goodval in setting.get('goodjson', []):
+                self.assertEqual(Setting().set(key, goodval['value'])['value'], goodval['return'])
 
     def testGetWebroot(self):
         from girder.plugins.HistomicsTK.constants import PluginSettings
@@ -117,3 +160,95 @@ class HistomicsTKCoreTest(base.TestCase):
         self.assertStatusOk(resp)
         body = self.getBody(resp)
         assert '<title>Alternate</title>' in body
+
+    def testGetAnalysisAccess(self):
+        from girder.plugins.HistomicsTK.constants import PluginSettings
+
+        resp = self.request(path='/HistomicsTK/analysis/access', user=self.admin)
+        self.assertStatusOk(resp)
+        self.assertEqual(resp.json, {'public': True, 'users': [], 'groups': []})
+        Setting().set(PluginSettings.HISTOMICSTK_ANALYSIS_ACCESS, {
+            'public': False,
+            'users': [self.user['_id'], self.admin['_id']],
+            'groups': [self.group]})
+        resp = self.request(path='/HistomicsTK/analysis/access', user=self.admin)
+        self.assertStatusOk(resp)
+        self.assertEqual(resp.json, {
+            'public': False,
+            'users': [{
+                'id': str(self.user['_id']),
+                'login': 'goodlogin',
+                'name': 'First Last',
+                'level': AccessType.READ,
+            }, {
+                'id': str(self.admin['_id']),
+                'login': 'adminlogin',
+                'name': 'Admin Last',
+                'level': AccessType.READ,
+            }],
+            'groups': [{
+                'id': str(self.group['_id']),
+                'name': 'test group',
+                'description': '',
+                'level': AccessType.READ,
+            }]})
+        User().remove(self.user)
+        Group().remove(self.group)
+        resp = self.request(path='/HistomicsTK/analysis/access', user=self.admin)
+        self.assertStatusOk(resp)
+        self.assertEqual(resp.json, {
+            'public': False,
+            'users': [{
+                'id': str(self.admin['_id']),
+                'login': 'adminlogin',
+                'name': 'Admin Last',
+                'level': AccessType.READ,
+            }],
+            'groups': []})
+
+    def testGetDockerImage(self):
+        from girder.plugins.HistomicsTK.constants import PluginSettings
+
+        # Add a CLI
+        resp = self.request(
+            path='/HistomicsTK/HistomicsTK/docker_image',
+            user=self.admin, method='PUT',
+            params={'name': '"girder/slicer_cli_web:small"'})
+        self.assertStatusOk(resp)
+        endTime = time.time() + 180  # maxTimeout
+        while time.time() < endTime:
+            resp = self.request(path='/HistomicsTK/HistomicsTK/docker_image', user=self.admin)
+            if resp.output_status.startswith('200') and len(resp.json) == 1:
+                break
+            time.sleep(1)
+
+        # Intially, access is public, so all users should see the entry,
+        # but a missing user won't.
+        # Setting().set(PluginSettings.HISTOMICSTK_ANALYSIS_ACCESS, {'public': True})
+        for user, count in [(self.admin, 1), (self.user, 1), (self.user2, 1), (None, 0)]:
+            resp = self.request(path='/HistomicsTK/HistomicsTK/docker_image', user=user)
+            self.assertStatusOk(resp)
+            self.assertEqual(len(resp.json), count)
+        # Each user is allowed or in an allowed group
+        Setting().set(PluginSettings.HISTOMICSTK_ANALYSIS_ACCESS, {
+            'public': False,
+            'users': [self.user['_id'], self.admin['_id']],
+            'groups': [self.group]})
+        for user, count in [(self.admin, 1), (self.user, 1), (self.user2, 1), (None, 0)]:
+            resp = self.request(path='/HistomicsTK/HistomicsTK/docker_image', user=user)
+            self.assertStatusOk(resp)
+            self.assertEqual(len(resp.json), count)
+        # Remove the first user's permissions
+        Setting().set(PluginSettings.HISTOMICSTK_ANALYSIS_ACCESS, {
+            'public': False, 'users': [], 'groups': [self.group]})
+        for user, count in [(self.admin, 1), (self.user, 0), (self.user2, 1), (None, 0)]:
+            resp = self.request(path='/HistomicsTK/HistomicsTK/docker_image', user=user)
+            self.assertStatusOk(resp)
+            self.assertEqual(len(resp.json), count)
+        # Remove the group permissions
+        Setting().set(PluginSettings.HISTOMICSTK_ANALYSIS_ACCESS, {
+            'public': False, 'users': [], 'groups': []})
+        for user, count in [(self.admin, 1), (self.user, 0), (self.user2, 0), (None, 0)]:
+            resp = self.request(path='/HistomicsTK/HistomicsTK/docker_image', user=user)
+            self.assertStatusOk(resp)
+            self.assertEqual(len(resp.json), count)

--- a/plugin_tests/histomicstk_test.yml
+++ b/plugin_tests/histomicstk_test.yml
@@ -1,0 +1,23 @@
+---
+users:
+  - login: 'adminlogin'
+    email: 'admin@email.com'
+    firstName: 'Admin'
+    lastName: 'Last'
+    password: 'adminpassword'
+    admin: true
+    defaultFolders: true
+  - login: 'goodlogin'
+    email: 'good@email.com'
+    firstName: 'First'
+    lastName: 'Last'
+    password: 'goodpassword'
+    admin: false
+    defaultFolders: true
+  - login: 'user2'
+    email: 'user2@email.com'
+    firstName: 'User'
+    lastName: 'Two'
+    password: 'goodpassword'
+    admin: false
+    defaultFolders: true

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -146,7 +146,7 @@ class HistomicsTKResource(DockerResource):
         result = super(HistomicsTKResource, self).getDockerImages(*args, **kwargs)
         acList = self._accessList()
         # Use the User().hasAccess to test for access via a synthetic document
-        if not User().hasAccess({'access': acList}, user):
+        if not User().hasAccess({'access': acList, 'public': acList['public']}, user):
             return {}
         return result
 

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -5,9 +5,11 @@ import re
 from girder import events
 from girder.api import access
 from girder.api.describe import Description, describeRoute
-from girder.constants import SettingDefault
+from girder.constants import AccessType, SettingDefault
 from girder.exceptions import ValidationException
+from girder.models.group import Group
 from girder.models.setting import Setting
+from girder.models.user import User
 from girder.utility.webroot import Webroot
 from girder.utility import setting_utilities
 
@@ -71,12 +73,31 @@ def validateHistomicsTKWebrootPath(doc):
         raise ValidationException('The webroot path may not be "girder"', 'value')
 
 
+@setting_utilities.validator(PluginSettings.HISTOMICSTK_ANALYSIS_ACCESS)
+def validateHistomicsTKAnalysisAccess(doc):
+    value = doc['value']
+    if not isinstance(value, dict):
+        raise ValidationException('Analysis access policy must be a JSON object.')
+    for i, groupId in enumerate(value.get('groups', ())):
+        if isinstance(groupId, dict):
+            groupId = groupId.get('_id', groupId.get('id'))
+        group = Group().load(groupId, force=True, exc=True)
+        value['groups'][i] = group['_id']
+    for i, userId in enumerate(value.get('users', ())):
+        if isinstance(userId, dict):
+            userId = userId.get('_id', userId.get('id'))
+        user = User().load(userId, force=True, exc=True)
+        value['users'][i] = user['_id']
+    value['public'] = bool(value.get('public'))
+
+
 # Defaults that have fixed values are added to the system defaults dictionary.
 SettingDefault.defaults.update({
     PluginSettings.HISTOMICSTK_WEBROOT_PATH: 'histomicstk',
     PluginSettings.HISTOMICSTK_BRAND_NAME: 'HistomicsTK',
     PluginSettings.HISTOMICSTK_BANNER_COLOR: '#f8f8f8',
     PluginSettings.HISTOMICSTK_BRAND_COLOR: '#777777',
+    PluginSettings.HISTOMICSTK_ANALYSIS_ACCESS: {'public': True},
 })
 
 
@@ -84,6 +105,50 @@ class HistomicsTKResource(DockerResource):
     def __init__(self, name, *args, **kwargs):
         super(HistomicsTKResource, self).__init__(name, *args, **kwargs)
         self.route('GET', ('settings',), self.getPublicSettings)
+        self.route('GET', ('analysis', 'access'), self.getAnalysisAccess)
+
+    def _accessList(self):
+        access = Setting().get(PluginSettings.HISTOMICSTK_ANALYSIS_ACCESS) or {}
+        acList = {
+            'users': [{'id': x, 'level': AccessType.READ}
+                      for x in access.get('users', [])],
+            'groups': [{'id': x, 'level': AccessType.READ}
+                       for x in access.get('groups', [])],
+            'public': access.get('public', True),
+        }
+        for user in acList['users'][:]:
+            userDoc = User().load(
+                user['id'], force=True,
+                fields=['firstName', 'lastName', 'login'])
+            if userDoc is None:
+                acList['users'].remove(user)
+            else:
+                user['login'] = userDoc['login']
+                user['name'] = ' '.join((userDoc['firstName'], userDoc['lastName']))
+        for grp in acList['groups'][:]:
+            grpDoc = Group().load(
+                grp['id'], force=True, fields=['name', 'description'])
+            if grpDoc is None:
+                acList['groups'].remove(grp)
+            else:
+                grp['name'] = grpDoc['name']
+                grp['description'] = grpDoc['description']
+        return acList
+
+    @access.public
+    @describeRoute(
+        Description('List docker images and their CLIs')
+    )
+    def getDockerImages(self, *args, **kwargs):
+        user = self.getCurrentUser()
+        if not user:
+            return {}
+        result = super(HistomicsTKResource, self).getDockerImages(*args, **kwargs)
+        acList = self._accessList()
+        # Use the User().hasAccess to test for access via a synthetic document
+        if not User().hasAccess({'access': acList}, user):
+            return {}
+        return result
 
     @describeRoute(
         Description('Get public settings for HistomicsTK.')
@@ -94,6 +159,13 @@ class HistomicsTKResource(DockerResource):
             PluginSettings.HISTOMICSTK_DEFAULT_DRAW_STYLES,
         ]
         return {k: self.model('setting').get(k) for k in keys}
+
+    @describeRoute(
+        Description('Get the access list for analyses.')
+    )
+    @access.admin
+    def getAnalysisAccess(self, params):
+        return self._accessList()
 
 
 def _saveJob(event):

--- a/server/constants.py
+++ b/server/constants.py
@@ -9,3 +9,4 @@ class PluginSettings(object):
     HISTOMICSTK_BRAND_NAME = 'histomicstk.brand_name'
     HISTOMICSTK_BRAND_COLOR = 'histomicstk.brand_color'
     HISTOMICSTK_BANNER_COLOR = 'histomicstk.banner_color'
+    HISTOMICSTK_ANALYSIS_ACCESS = 'histomicstk.analysis_access'

--- a/web_client/stylesheets/body/configView.styl
+++ b/web_client/stylesheets/body/configView.styl
@@ -12,3 +12,10 @@
   display inline
   // Vertical-align is useful to avoid an 5px offset in Mozilla
   vertical-align top
+
+#g-histomicstk-analysis-access-label
+  display block
+#g-histomicstk-analysis-access
+  display inline-block
+#g-histomicstk-analysis-access-comment
+  font-size 13px

--- a/web_client/templates/body/configView.pug
+++ b/web_client/templates/body/configView.pug
@@ -37,6 +37,9 @@ form#g-histomicstk-form(role="form")
         type="text", value=settings['histomicstk.default_draw_styles'],
         placeholder='A JSON object listing default annotation drawing styles.',
         title='A dictionary of drawing styles')
+  .form-group
+    label#g-histomicstk-analysis-access-label(for="g-histomicstk-analysis-access") Analysis Access
+    #g-histomicstk-analysis-access
   p#g-histomicstk-error-message.g-validation-failed-message
 .g-histomicstk-buttons
   button#g-histomicstk-save.btn.btn-sm.btn-primary Save

--- a/web_client/templates/layout/header.pug
+++ b/web_client/templates/layout/header.pug
@@ -10,7 +10,6 @@ nav.navbar.navbar-default(style=`color: ${brandColor}; background-color: ${banne
         span.icon-bar
         span.icon-bar
         span.icon-bar
-      - console.log(brandName, brandColor, bannerColor);
       a#h-navbar-brand.navbar-brand(style=`color: ${brandColor}`) #{brandName}
 
     #h-navbar-collapse.collapse.navbar-collapse

--- a/web_client/views/layout/HeaderAnalysesView.js
+++ b/web_client/views/layout/HeaderAnalysesView.js
@@ -23,15 +23,17 @@ var HeaderUserView = View.extend({
     },
     render() {
         if (this.image) {
-            this.$el.removeClass('hidden');
             restRequest({
                 url: 'HistomicsTK/HistomicsTK/docker_image'
             }).then((analyses) => {
                 if (_.keys(analyses || {}).length > 0) {
+                    this.$el.removeClass('hidden');
                     this.$el.html(headerAnalysesTemplate({
                         analyses: analyses || {}
                     }));
                     this.$('.h-analyses-dropdown-link').submenupicker();
+                } else {
+                    this.$el.addClass('hidden');
                 }
                 return null;
             });


### PR DESCRIPTION
This adds to the HistomicsTK settings to allow analyses to be public (the default, which allows any user to access the analyses menu), or private, such that only listed users, groups, and admins can access the analyses menu.

If we ever want to expose individual analyses based on user permissions, this would extend fairly easily.  Ideally, we would check the permissions when executing or listing an individual analysis and not just on the general list (this can be future work).
