### PR TITLE
Build imagemagick ourselves.

### DIFF
--- a/ansible/Dockerfile-girder-worker
+++ b/ansible/Dockerfile-girder-worker
@@ -39,6 +39,7 @@ RUN ansible-playbook -i inventory/local docker_ansible.yml --extra-vars="docker=
                 /opt/histomicstk/openslide-* \
                 /opt/histomicstk/tiff-* \
                 /opt/histomicstk/vips-* \
+                /opt/histomicstk/ImageMagick-* \
                 /root/.cache/pip
 
 WORKDIR /opt/girder_worker

--- a/ansible/Dockerfile-histomicstk
+++ b/ansible/Dockerfile-histomicstk
@@ -41,6 +41,7 @@ RUN ansible-playbook -i inventory/local docker_ansible.yml --extra-vars=docker=h
                 /opt/histomicstk/openslide-* \
                 /opt/histomicstk/tiff-* \
                 /opt/histomicstk/vips-* \
+                /opt/histomicstk/ImageMagick-* \
                 /opt/histomicstk/HistomicsTK/_skbuild \
                 /opt/histomicstk/large_image/build \
                 /root/.cache/pip

--- a/ansible/roles/openslide/tasks/main.yml
+++ b/ansible/roles/openslide/tasks/main.yml
@@ -158,6 +158,33 @@
   command: ldconfig
   become: true
 
+# ImageMagick
+- name: Download ImageMagick
+  git:
+    depth: 1
+    repo: https://github.com/ImageMagick/ImageMagick.git
+    dest: "{{ root_dir }}/ImageMagick"
+
+- name: Configure ImageMagick
+  command: ./configure --with-modules
+  args:
+    chdir: "{{ root_dir }}/ImageMagick"
+
+- name: Build ImageMagick
+  command: make -j2
+  args:
+    chdir: "{{ root_dir }}/ImageMagick"
+
+- name: Install ImageMagick
+  command: make install
+  args:
+    chdir: "{{ root_dir }}/ImageMagick"
+  become: true
+
+- name: Run ldconfig
+  command: ldconfig
+  become: true
+
 # vips
 - name: Download vips
   command: >-


### PR DESCRIPTION
This allows vips to properly handle some JPEG 2000 files.  vips delegates to imagemagick for reading JPEG 2000.  imagemagick itself delegates JPEG 2000 to openjpeg if available, but unless built after openjpeg, it doesn't use the locally built library.