### PR TITLE
Bump timeout cutoff on waiting for girder to report version

### DIFF
--- a/ansible/deploy_docker.py
+++ b/ansible/deploy_docker.py
@@ -747,7 +747,7 @@ def tag_with_version(key, version=None, **kwargs):
     return image
 
 
-def wait_for_girder(client, ctn, maxWait=300):
+def wait_for_girder(client, ctn, maxWait=3600):
     """
     Wait for Girder in a specific container to respond with its current
     version.
@@ -779,7 +779,9 @@ def wait_for_girder(client, ctn, maxWait=300):
         sys.stdout.flush()
     if not output:
         raise Exception('Girder never responded')
-    sys.stdout.write(' %s\n' % output['apiVersion'])
+    else:
+        sys.stdout.write(' %s\n' % output['apiVersion'])
+        sys.stdout.write('Took {} seconds\n'.format(time.time() - starttime))
 
 
 if __name__ == '__main__':

--- a/ansible/deploy_docker.py
+++ b/ansible/deploy_docker.py
@@ -779,9 +779,8 @@ def wait_for_girder(client, ctn, maxWait=3600):
         sys.stdout.flush()
     if not output:
         raise Exception('Girder never responded')
-    else:
-        sys.stdout.write(' %s\n' % output['apiVersion'])
-        sys.stdout.write('Took {} seconds\n'.format(time.time() - starttime))
+    sys.stdout.write(' %s\n' % output['apiVersion'])
+    sys.stdout.write('Took {} seconds\n'.format(time.time() - starttime))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The timeout cutoff for [Waiting for girder to report version](https://github.com/DigitalSlideArchive/HistomicsTK/blob/9dd96013780451f21682db29a0ed562bf43d0452/ansible/deploy_docker.py#L750) is currently set to 300 seconds. And this step takes ~600 seconds on my machine.This bumps it to 3600 to allow enough time to finish on most machines. 