### PR TITLE
Add a context menu to delete annotation elements

### DIFF
--- a/plugin_tests/client/annotationSpec.js
+++ b/plugin_tests/client/annotationSpec.js
@@ -923,6 +923,39 @@ $(function () {
                 });
             });
 
+            it('open and close the context menu', function () {
+                var interactor = histomicsTest.geojsMap().interactor();
+                interactor.simulateEvent('mousedown', {
+                    map: {x: 50, y: 50},
+                    button: 'right'
+                });
+                interactor.simulateEvent('mouseup', {
+                    map: {x: 50, y: 50},
+                    button: 'right'
+                });
+                expect($('#h-annotation-context-menu').hasClass('hidden')).toBe(false);
+                $(document).trigger('mousedown');
+                $(document).trigger('mouseup');
+
+                expect($('#h-annotation-context-menu').hasClass('hidden')).toBe(true);
+            });
+
+            it('delete an element from the context menu', function () {
+                var interactor = histomicsTest.geojsMap().interactor();
+                interactor.simulateEvent('mousedown', {
+                    map: {x: 50, y: 50},
+                    button: 'right'
+                });
+                interactor.simulateEvent('mouseup', {
+                    map: {x: 50, y: 50},
+                    button: 'right'
+                });
+                expect($('#h-annotation-context-menu').hasClass('hidden')).toBe(false);
+                $('#h-annotation-context-menu .h-remove-elements').click();
+
+                expect($('#h-annotation-context-menu').hasClass('hidden')).toBe(true);
+            });
+
             it('open a different image', function () {
                 histomicsTest.waitsForPromise(
                     histomicsTest.openImage('copy').done(function () {

--- a/plugin_tests/client/annotationSpec.js
+++ b/plugin_tests/client/annotationSpec.js
@@ -933,11 +933,15 @@ $(function () {
                     map: {x: 50, y: 50},
                     button: 'right'
                 });
-                expect($('#h-annotation-context-menu').hasClass('hidden')).toBe(false);
-                $(document).trigger('mousedown');
-                $(document).trigger('mouseup');
 
-                expect($('#h-annotation-context-menu').hasClass('hidden')).toBe(true);
+                waitsFor(function () {
+                    return $('#h-annotation-context-menu').hasClass('hidden') === false;
+                }, 'context menu to be shown');
+                runs(function () {
+                    $(document).trigger('mousedown');
+                    $(document).trigger('mouseup');
+                    expect($('#h-annotation-context-menu').hasClass('hidden')).toBe(true);
+                });
             });
 
             it('delete an element from the context menu', function () {
@@ -950,10 +954,14 @@ $(function () {
                     map: {x: 50, y: 50},
                     button: 'right'
                 });
-                expect($('#h-annotation-context-menu').hasClass('hidden')).toBe(false);
-                $('#h-annotation-context-menu .h-remove-elements').click();
 
-                expect($('#h-annotation-context-menu').hasClass('hidden')).toBe(true);
+                waitsFor(function () {
+                    return $('#h-annotation-context-menu').hasClass('hidden') === false;
+                }, 'context menu to be shown');
+                runs(function () {
+                    $('#h-annotation-context-menu .h-remove-elements').click();
+                    expect($('#h-annotation-context-menu').hasClass('hidden')).toBe(true);
+                });
             });
 
             it('open a different image', function () {

--- a/web_client/stylesheets/body/image.styl
+++ b/web_client/stylesheets/body/image.styl
@@ -38,3 +38,7 @@
 
     .s-panel
       margin-right 5px
+
+#h-annotation-context-menu
+    position absolute
+    z-index 1000

--- a/web_client/templates/body/image.pug
+++ b/web_client/templates/body/image.pug
@@ -10,3 +10,4 @@
     .h-annotation-selector.s-panel
     .h-draw-widget.s-panel.hidden
   #h-annotation-popover-container
+  #h-annotation-context-menu.hidden

--- a/web_client/templates/popover/annotationContextMenu.pug
+++ b/web_client/templates/popover/annotationContextMenu.pug
@@ -1,0 +1,3 @@
+.list-group.h-annotation-context-menu
+  a.list-group-item.h-remove-elements(href='#')
+    | Delete element

--- a/web_client/views/body/ImageView.js
+++ b/web_client/views/body/ImageView.js
@@ -622,14 +622,18 @@ var ImageView = View.extend({
             return;
         }
 
-        this._editAnnotation(annotation);
-        const menu = this.$('#h-annotation-context-menu');
-        const position = evt.mouse.page;
-        menu.removeClass('hidden');
-        menu.css({ left: position.x, top: position.y });
-        this.popover.collection.reset();
-        this._contextMenuActive = true;
-        this.contextMenu.setHovered(element, annotation);
+        // Defer the context menu action into the next animation frame
+        // to work around a problem with preventDefault on Windows
+        window.setTimeout(() => {
+            this._editAnnotation(annotation);
+            const menu = this.$('#h-annotation-context-menu');
+            const position = evt.mouse.page;
+            menu.removeClass('hidden');
+            menu.css({ left: position.x, top: position.y });
+            this.popover.collection.reset();
+            this._contextMenuActive = true;
+            this.contextMenu.setHovered(element, annotation);
+        }, 1);
     },
 
     _closeContextMenu() {

--- a/web_client/views/body/ImageView.js
+++ b/web_client/views/body/ImageView.js
@@ -3,6 +3,7 @@ import _ from 'underscore';
 
 import { restRequest } from 'girder/rest';
 import { getCurrentUser } from 'girder/auth';
+import { AccessType } from 'girder/constants';
 import ItemModel from 'girder/models/ItemModel';
 import FileModel from 'girder/models/FileModel';
 import FolderCollection from 'girder/collections/FolderCollection';
@@ -11,6 +12,7 @@ import SlicerPanelGroup from 'girder_plugins/slicer_cli_web/views/PanelGroup';
 import AnnotationModel from 'girder_plugins/large_image/models/AnnotationModel';
 import AnnotationCollection from 'girder_plugins/large_image/collections/AnnotationCollection';
 
+import AnnotationContextMenu from '../popover/AnnotationContextMenu';
 import AnnotationPopover from '../popover/AnnotationPopover';
 import AnnotationSelector from '../../panels/AnnotationSelector';
 import ZoomWidget from '../../panels/ZoomWidget';
@@ -24,9 +26,11 @@ import '../../stylesheets/body/image.styl';
 
 var ImageView = View.extend({
     events: {
-        'keydown .h-image-body': '_onKeyDown'
+        'keydown .h-image-body': '_onKeyDown',
+        'keydown .geojs-map': '_handleKeyDown'
     },
     initialize(settings) {
+        window.view = this;
         this.viewerWidget = null;
         this._openId = null;
         this._displayedRegion = null;
@@ -56,6 +60,10 @@ var ImageView = View.extend({
         this.popover = new AnnotationPopover({
             parentView: this
         });
+        this.contextMenu = new AnnotationContextMenu({
+            parentView: this,
+            collection: this.annotations
+        });
 
         this.listenTo(events, 'h:submit', (data) => {
             this.$('.s-jobs-panel .s-panel-controls .icon-down-open').click();
@@ -69,10 +77,24 @@ var ImageView = View.extend({
         this.listenTo(this.annotationSelector, 'h:deleteAnnotation', this._deleteAnnotation);
         this.listenTo(this.annotationSelector, 'h:annotationOpacity', this._setAnnotationOpacity);
         this.listenTo(this, 'h:highlightAnnotation', this._highlightAnnotation);
+        this.listenTo(this.contextMenu, 'h:redraw', this._redrawAnnotation);
+        this.listenTo(this.contextMenu, 'h:close', this._closeContextMenu);
 
         this.listenTo(events, 's:widgetChanged:region', this.widgetRegion);
         this.listenTo(events, 'g:login g:logout.success g:logout.error', () => {
             this._openId = null;
+        });
+        $(document).on('mousedown.h-image-view', (evt) => {
+            // let the context menu close itself
+            if ($(evt.target).parents('#h-annotation-context-menu').length) {
+                return;
+            }
+            this._closeContextMenu();
+        });
+        $(document).on('keydown.h-image-view', (evt) => {
+            if (evt.keyCode === 27) {
+                this._closeContextMenu();
+            }
         });
         this.render();
     },
@@ -88,6 +110,8 @@ var ImageView = View.extend({
             return;
         }
         this.$el.html(imageTemplate());
+        this.contextMenu.setElement(this.$('#h-annotation-context-menu')).render();
+
         if (this.model.id) {
             this._openId = this.model.id;
             if (this.viewerWidget) {
@@ -178,6 +202,7 @@ var ImageView = View.extend({
         }
         this.viewerWidget = null;
         events.trigger('h:imageOpened', null);
+        $(document).off('.h-image-view');
         return View.prototype.destroy.apply(this, arguments);
     },
     openImage(id) {
@@ -381,7 +406,7 @@ var ImageView = View.extend({
     },
 
     _highlightAnnotation(annotation, element) {
-        if (!this.annotationSelector.interactiveMode()) {
+        if (!this.annotationSelector.interactiveMode() && !this._contextMenuActive) {
             return;
         }
         this.viewerWidget.highlightAnnotation(annotation, element);
@@ -515,7 +540,10 @@ var ImageView = View.extend({
         this.popover.collection.reset();
     },
 
-    mouseClickAnnotation(/* element, annotationId */) {
+    mouseClickAnnotation(element, annotationId, evt) {
+        if (evt.mouse.buttonsDown.right) {
+            this._rightClickElement(element, this.annotations.get(annotationId), evt);
+        }
     },
 
     toggleLabels(options) {
@@ -587,6 +615,30 @@ var ImageView = View.extend({
         } else {
             this.annotationSelector.showAllAnnotations();
         }
+    },
+
+    _rightClickElement(element, annotation, evt) {
+        if (annotation.get('_accessLevel') < AccessType.WRITE) {
+            return;
+        }
+
+        const menu = this.$('#h-annotation-context-menu');
+        const position = evt.mouse.page;
+        menu.removeClass('hidden');
+        menu.css({ left: position.x, top: position.y });
+        this.popover.collection.reset();
+        this._contextMenuActive = true;
+        this.contextMenu.setHovered(element, annotation);
+    },
+
+    _closeContextMenu() {
+        if (!this._contextMenuActive) {
+            return;
+        }
+        this.$('#h-annotation-context-menu').addClass('hidden');
+        this.popover.collection.reset();
+        this.contextMenu.reset();
+        this._contextMenuActive = false;
     }
 });
 

--- a/web_client/views/body/ImageView.js
+++ b/web_client/views/body/ImageView.js
@@ -622,6 +622,7 @@ var ImageView = View.extend({
             return;
         }
 
+        this._editAnnotation(annotation);
         const menu = this.$('#h-annotation-context-menu');
         const position = evt.mouse.page;
         menu.removeClass('hidden');

--- a/web_client/views/popover/AnnotationContextMenu.js
+++ b/web_client/views/popover/AnnotationContextMenu.js
@@ -1,0 +1,45 @@
+import View from '../View';
+
+import template from '../../templates/popover/annotationContextMenu.pug';
+import '../../stylesheets/popover/annotationContextMenu.styl';
+
+const AnnotationContextMenu = View.extend({
+    events: {
+        'click .h-remove-elements': '_removeElements'
+    },
+    initialize() {
+        this.reset();
+    },
+    render() {
+        this.$el.html(template());
+        return this;
+    },
+    reset() {
+        if (!this._hovered) {
+            return;
+        }
+        this.parentView.trigger('h:highlightAnnotation');
+        this._hovered = null;
+    },
+    setHovered(element, annotation) {
+        const elementModel = annotation.elements().get(element.id);
+        if (annotation._pageElements || !elementModel) {
+            // ignore context menu actions on paged annotations
+            return;
+        }
+        this.reset();
+        this._hovered = { element, annotation };
+        this.parentView.trigger('h:highlightAnnotation', annotation.id, element.id);
+    },
+    _removeElements(evt) {
+        evt.preventDefault();
+        evt.stopPropagation();
+
+        const { annotation, element } = this._hovered;
+        annotation.elements().remove(element);
+        this.reset();
+        this.trigger('h:close');
+    }
+});
+
+export default AnnotationContextMenu;

--- a/web_client/views/popover/index.js
+++ b/web_client/views/popover/index.js
@@ -1,5 +1,7 @@
+import AnnotationContextMenu from './AnnotationContextMenu';
 import AnnotationPopover from './AnnotationPopover';
 
 export {
+    AnnotationContextMenu,
     AnnotationPopover
 };


### PR DESCRIPTION
This could be extended to do things like "shift-click to select multiple elements", but for now it will just add a right-click context menu to delete one annotation element.

In the case where the mouse is hovering over more than one annotation element, only one is acted on.  There is a visual highlight that indicates which element is going to be deleted.  This could make the feature difficult to use if many annotation elements are on top of each other, but I don't think that's a common enough occurrence to worry about for the moment.