### PR TITLE
Add a hotkey to toggle visibility of all annotations

### DIFF
--- a/web_client/views/body/ImageView.js
+++ b/web_client/views/body/ImageView.js
@@ -23,7 +23,9 @@ import imageTemplate from '../../templates/body/image.pug';
 import '../../stylesheets/body/image.styl';
 
 var ImageView = View.extend({
-    events: {},
+    events: {
+        'keydown .h-image-body': '_onKeyDown'
+    },
     initialize(settings) {
         this.viewerWidget = null;
         this._openId = null;
@@ -571,6 +573,20 @@ var ImageView = View.extend({
 
     _setAnnotationOpacity(opacity) {
         this.viewerWidget.setGlobalAnnotationOpacity(opacity);
+    },
+
+    _onKeyDown(evt) {
+        if (evt.key === 'a') {
+            this._showOrHideAnnotations();
+        }
+    },
+
+    _showOrHideAnnotations() {
+        if (this.annotations.any((a) => a.get('displayed'))) {
+            this.annotationSelector.hideAllAnnotations();
+        } else {
+            this.annotationSelector.showAllAnnotations();
+        }
     }
 });
 


### PR DESCRIPTION
This is probably the most simple possible implementation of a "toggle all" hotkey.  I considered making it temporarily hide only the currently visible annotations, but that leads to state management complications that I would rather avoid unless it is specifically requested.

I bound the hotkey to "a", but that is easy to change.  Also, it only listens to events on the image element... meaning you need to have it selected (click on it) for it to work.  I considered binding to `document` so it would always respond to the hotkey, but I would want to use a meta-key to avoid firing it when typing into forms.