### PR TITLE
Remove ImageMagick build artifacts to shrink docker images.

### DIFF
--- a/ansible/Dockerfile-girder-worker
+++ b/ansible/Dockerfile-girder-worker
@@ -39,7 +39,7 @@ RUN ansible-playbook -i inventory/local docker_ansible.yml --extra-vars="docker=
                 /opt/histomicstk/openslide-* \
                 /opt/histomicstk/tiff-* \
                 /opt/histomicstk/vips-* \
-                /opt/histomicstk/ImageMagick-* \
+                /opt/histomicstk/ImageMagick* \
                 /root/.cache/pip
 
 WORKDIR /opt/girder_worker

--- a/ansible/Dockerfile-histomicstk
+++ b/ansible/Dockerfile-histomicstk
@@ -41,7 +41,7 @@ RUN ansible-playbook -i inventory/local docker_ansible.yml --extra-vars=docker=h
                 /opt/histomicstk/openslide-* \
                 /opt/histomicstk/tiff-* \
                 /opt/histomicstk/vips-* \
-                /opt/histomicstk/ImageMagick-* \
+                /opt/histomicstk/ImageMagick* \
                 /opt/histomicstk/HistomicsTK/_skbuild \
                 /opt/histomicstk/large_image/build \
                 /root/.cache/pip


### PR DESCRIPTION
@cdeepakroy and @dgutman Around a month ago we started building ImageMagick from source so we could handle more eccentric jpeg 2000 files.  The build artifacts weren't fully removed from the docker images.  This increased the docker images by about 0.25 Gb (for both the main HistomicsTK docker image and the Girder Worker image).  Moreover, it was the cause of the slow down when starting and provision images with a docker user and group that was different between the original image and the host machine.  The `chown` command that we run on provisioning caused around 4000 files to be chowned that caused docker to duplicate them between image layers.