### PR TITLE
Allowing zooming more.

### DIFF
--- a/web_client/panels/ZoomWidget.js
+++ b/web_client/panels/ZoomWidget.js
@@ -66,9 +66,9 @@ var ZoomWidget = Panel.extend({
         max = Math.log2(this._maxMag) + 0.01;
 
         // get a list of discrete values to show as buttons
-        buttons = _.filter([1, 2.5, 5, 10, 20, 40], (v) => v <= this._maxMag);
-        buttons = _.last(buttons, 5);
-        buttons = [0].concat(buttons);
+        buttons = _.filter([1, 2.5, 5, 10, 20, 40, 80, 160], (v) => v <= this._maxMag);
+        buttons = _.last(buttons, 6);
+        buttons = buttons !== undefined ? [0].concat(buttons) : [0];
 
         this.$el.html(zoomWidget({
             id: 'zoom-panel-container',
@@ -77,6 +77,7 @@ var ZoomWidget = Panel.extend({
             title_download_area: 'Download Area',
             min: min,
             max: max,
+            maxNaturalMag: this._maxNaturalMag + 0.01,
             step: 0.01,
             value: Math.log2(value),
             disabled: !this.renderer,
@@ -117,8 +118,10 @@ var ZoomWidget = Panel.extend({
      * Set the native magnification from the current image.  This
      * is given in the /item/{id}/tiles endpoint from large_image.
      */
-    setMaxMagnification(magnification) {
-        this._maxMag = magnification;
+    setMaxMagnification(magnification, increase) {
+        this._increaseZoom2x = increase || 0;
+        this._maxNaturalMag = magnification;
+        this._maxMag = magnification * Math.pow(2, this._increaseZoom2x);
     },
 
     /**

--- a/web_client/templates/panels/zoomWidget.pug
+++ b/web_client/templates/panels/zoomWidget.pug
@@ -16,7 +16,7 @@ block content
         - var text = 'Fit';
         - val = Math.pow(2, min);
       .btn-group
-        button.btn.btn-default.h-zoom-button(type="button", data-value=val) #{text}
+        button.btn.btn-default.h-zoom-button(type="button", data-value=val, class={'btn-sm': val > maxNaturalMag}) #{text}
   .h-download-button-container
     a#download-view-link.h-download-link
       button.btn-default.h-download-button.h-download-button-view(type="button", data-toggle="tooltip", title="Download current view")

--- a/web_client/views/body/ImageView.js
+++ b/web_client/views/body/ImageView.js
@@ -31,6 +31,9 @@ var ImageView = View.extend({
         this._openId = null;
         this._displayedRegion = null;
 
+        // Allow zooming this many powers of 2 more than native pixel resolution
+        this._increaseZoom2x = 1;
+
         if (!this.model) {
             this.model = new ItemModel();
         }
@@ -123,6 +126,8 @@ var ImageView = View.extend({
                 this.setBoundsQuery();
 
                 if (this.viewer) {
+                    this.viewer.zoomRange({max: this.viewer.zoomRange().max + this._increaseZoom2x});
+
                     // update the query string on pan events
                     this.viewer.geoOn(geo.event.pan, () => {
                         this.setBoundsQuery();
@@ -234,7 +239,8 @@ var ImageView = View.extend({
             return restRequest({
                 url: 'item/' + itemId + '/tiles'
             }).then((tiles) => {
-                this.zoomWidget.setMaxMagnification(tiles.magnification || 20);
+                this.zoomWidget.setMaxMagnification(tiles.magnification || 20, this._increaseZoom2x);
+                this.zoomWidget.render();
                 return null;
             });
         };


### PR DESCRIPTION
Before, you could only zoom in until one image pixel filled one screen pixel.  This adds an internal parameter `_increaseZoom2x` that can be set to allow zooming in more.  By default it is now 1, allowing one image pixel to fill 2^1 x 2^1 screen pixels.  The zoom widget shows higher zoom levels by using smaller buttons to indicate that these are "extra zoomed".

This also fixes two minor issues: when switching to an image that had a different maximum zoom level, the zoom widget was not always updated. If an image had no magnification data the "Fit" button would be shown twice.

This resolves #520.