### PR TITLE
[WIP] Add the ability to change style groups inside the context menu

### DIFF
--- a/plugin_tests/client/annotationSpec.js
+++ b/plugin_tests/client/annotationSpec.js
@@ -958,6 +958,9 @@ $(function () {
                 waitsFor(function () {
                     return $('#h-annotation-context-menu').hasClass('hidden') === false;
                 }, 'context menu to be shown');
+
+                // wait for the next animation frame so that the highlighting is finished
+                waits(30);
                 runs(function () {
                     $('#h-annotation-context-menu .h-remove-elements').click();
                     expect($('#h-annotation-context-menu').hasClass('hidden')).toBe(true);

--- a/web_client/panels/AnnotationSelector.js
+++ b/web_client/panels/AnnotationSelector.js
@@ -307,8 +307,9 @@ var AnnotationSelector = Panel.extend({
     },
 
     _saveAnnotation(annotation) {
-        if (!this._saving && annotation === this._activeAnnotation && !annotation.get('loading')) {
+        if (!this._saving && !annotation._inFetch && !annotation.get('loading')) {
             this._saving = true;
+            this.trigger('h:redraw', annotation);
             annotation.save().always(() => {
                 this._saving = false;
             });

--- a/web_client/panels/AnnotationSelector.js
+++ b/web_client/panels/AnnotationSelector.js
@@ -24,7 +24,7 @@ const MAX_ELEMENTS_LIST_LENGTH = 5000;
  */
 var AnnotationSelector = Panel.extend({
     events: _.extend(Panel.prototype.events, {
-        'click .h-annotation-name': 'editAnnotation',
+        'click .h-annotation-name': '_editAnnotation',
         'click .h-toggle-annotation': 'toggleAnnotation',
         'click .h-delete-annotation': 'deleteAnnotation',
         'click .h-create-annotation': 'createAnnotation',
@@ -54,7 +54,7 @@ var AnnotationSelector = Panel.extend({
         this.listenTo(this.collection, 'change:highlight', this._changeAnnotationHighlight);
         this.listenTo(eventStream, 'g:event.job_status', _.debounce(this._onJobUpdate, 500));
         this.listenTo(eventStream, 'g:eventStream.start', this._refreshAnnotations);
-        this.listenTo(this.collection, 'change:annotation', this._saveAnnotation);
+        this.listenTo(this.collection, 'change:annotation change:groups', this._saveAnnotation);
         this.listenTo(girderEvents, 'g:login', () => {
             this.collection.reset();
             this._parentId = undefined;
@@ -221,10 +221,12 @@ var AnnotationSelector = Panel.extend({
         return this._interactiveMode;
     },
 
-    editAnnotation(evt) {
+    _editAnnotation(evt) {
         var id = $(evt.currentTarget).parents('.h-annotation').data('id');
-        var model = this.collection.get(id);
+        this.editAnnotation(this.collection.get(id));
+    },
 
+    editAnnotation(model) {
         // deselect the annotation if it is already selected
         if (this._activeAnnotation && model && this._activeAnnotation.id === model.id) {
             this._activeAnnotation = null;

--- a/web_client/stylesheets/.stylintrc
+++ b/web_client/stylesheets/.stylintrc
@@ -1,0 +1,1 @@
+/home/jbeezley/emory/girder2/.stylintrc

--- a/web_client/templates/popover/annotationContextMenu.pug
+++ b/web_client/templates/popover/annotationContextMenu.pug
@@ -1,3 +1,12 @@
 .list-group.h-annotation-context-menu
+  if currentGroup
+    a.h-remove-group.list-group-item(href='#')
+      span.icon-cancel
+      | Remove group
+  each group in groups
+    if group && group !== currentGroup
+      a.h-set-group.list-group-item(href='#', data-group=group)
+        span.icon-right-big
+        = group
   a.list-group-item.h-remove-elements(href='#')
-    | Delete element
+    | #[span.icon-trash] Delete

--- a/web_client/templates/popover/annotationContextMenu.pug
+++ b/web_client/templates/popover/annotationContextMenu.pug
@@ -8,5 +8,7 @@
       a.h-set-group.list-group-item(href='#', data-group=group)
         span.icon-right-big
         = group
+  a.list-group-item.h-edit-elements(href='#')
+    | #[span.icon-cog] Edit
   a.list-group-item.h-remove-elements(href='#')
     | #[span.icon-trash] Delete

--- a/web_client/views/body/ImageView.js
+++ b/web_client/views/body/ImageView.js
@@ -79,6 +79,7 @@ var ImageView = View.extend({
         this.listenTo(this.annotationSelector, 'h:editAnnotation', this._editAnnotation);
         this.listenTo(this.annotationSelector, 'h:deleteAnnotation', this._deleteAnnotation);
         this.listenTo(this.annotationSelector, 'h:annotationOpacity', this._setAnnotationOpacity);
+        this.listenTo(this.annotationSelector, 'h:redraw', this._redrawAnnotation);
         this.listenTo(this, 'h:highlightAnnotation', this._highlightAnnotation);
         this.listenTo(this.contextMenu, 'h:edit', this._editElement);
         this.listenTo(this.contextMenu, 'h:redraw', this._redrawAnnotation);
@@ -636,9 +637,6 @@ var ImageView = View.extend({
         // Defer the context menu action into the next animation frame
         // to work around a problem with preventDefault on Windows
         window.setTimeout(() => {
-            if (!this.activeAnnotation || this.activeAnnotation.id !== annotation.id) {
-                this.annotationSelector.editAnnotation(annotation);
-            }
             const menu = this.$('#h-annotation-context-menu');
             const position = evt.mouse.page;
             menu.removeClass('hidden');

--- a/web_client/views/body/ImageView.js
+++ b/web_client/views/body/ImageView.js
@@ -635,7 +635,9 @@ var ImageView = View.extend({
         // Defer the context menu action into the next animation frame
         // to work around a problem with preventDefault on Windows
         window.setTimeout(() => {
-            this._editAnnotation(annotation);
+            if (!this.activeAnnotation || this.activeAnnotation.id !== annotation.id) {
+                this.annotationSelector.editAnnotation(annotation);
+            }
             const menu = this.$('#h-annotation-context-menu');
             const position = evt.mouse.page;
             menu.removeClass('hidden');
@@ -656,5 +658,4 @@ var ImageView = View.extend({
         this._contextMenuActive = false;
     }
 });
-
 export default ImageView;

--- a/web_client/views/body/ImageView.js
+++ b/web_client/views/body/ImageView.js
@@ -17,6 +17,7 @@ import AnnotationPopover from '../popover/AnnotationPopover';
 import AnnotationSelector from '../../panels/AnnotationSelector';
 import ZoomWidget from '../../panels/ZoomWidget';
 import DrawWidget from '../../panels/DrawWidget';
+import editElement from '../../dialogs/editElement';
 import router from '../../router';
 import events from '../../events';
 import View from '../View';
@@ -30,7 +31,6 @@ var ImageView = View.extend({
         'keydown .geojs-map': '_handleKeyDown'
     },
     initialize(settings) {
-        window.view = this;
         this.viewerWidget = null;
         this._openId = null;
         this._displayedRegion = null;
@@ -80,6 +80,7 @@ var ImageView = View.extend({
         this.listenTo(this.annotationSelector, 'h:deleteAnnotation', this._deleteAnnotation);
         this.listenTo(this.annotationSelector, 'h:annotationOpacity', this._setAnnotationOpacity);
         this.listenTo(this, 'h:highlightAnnotation', this._highlightAnnotation);
+        this.listenTo(this.contextMenu, 'h:edit', this._editElement);
         this.listenTo(this.contextMenu, 'h:redraw', this._redrawAnnotation);
         this.listenTo(this.contextMenu, 'h:close', this._closeContextMenu);
 
@@ -656,6 +657,10 @@ var ImageView = View.extend({
         this.popover.collection.reset();
         this.contextMenu.reset();
         this._contextMenuActive = false;
+    },
+
+    _editElement(element) {
+        editElement(element);
     }
 });
 export default ImageView;

--- a/web_client/views/popover/AnnotationContextMenu.js
+++ b/web_client/views/popover/AnnotationContextMenu.js
@@ -39,8 +39,10 @@ const AnnotationContextMenu = View.extend({
         }
         this.reset();
         this._hovered = { element, annotation };
-        this.parentView.trigger('h:highlightAnnotation', annotation.id, element.id);
         this.render();
+        window.setTimeout(() => {
+            this.parentView.trigger('h:highlightAnnotation', annotation.id, element.id);
+        }, 1);
     },
     _removeElements(evt) {
         evt.preventDefault();

--- a/web_client/views/popover/AnnotationContextMenu.js
+++ b/web_client/views/popover/AnnotationContextMenu.js
@@ -9,6 +9,7 @@ import '../../stylesheets/popover/annotationContextMenu.styl';
 const AnnotationContextMenu = View.extend({
     events: {
         'click .h-remove-elements': '_removeElements',
+        'click .h-edit-elements': '_editElements',
         'click .h-set-group': '_setGroup',
         'click .h-remove-group': '_removeGroup'
     },
@@ -52,6 +53,13 @@ const AnnotationContextMenu = View.extend({
         annotation.elements().remove(element);
         this.reset();
         this.trigger('h:close');
+    },
+    _editElements(evt) {
+        evt.preventDefault();
+        evt.stopPropagation();
+
+        const { annotation, element } = this._hovered;
+        this.trigger('h:edit', annotation.elements().get(element));
     },
     _setStyleDefinition(group) {
         const styles = new StyleCollection();

--- a/web_client/views/popover/AnnotationContextMenu.js
+++ b/web_client/views/popover/AnnotationContextMenu.js
@@ -64,7 +64,7 @@ const AnnotationContextMenu = View.extend({
     _setStyleDefinition(group) {
         const styles = new StyleCollection();
         return styles.fetch().done(() => {
-            const style = styles.get({ id: group || 'default' });
+            const style = styles.get({ id: group }) || styles.get({ id: 'default' });
             const { element } = this._hovered;
             const elementModel = this._hovered.annotation.elements().get(element);
             const styleAttrs = Object.assign({}, style.toJSON());

--- a/web_client/views/popover/AnnotationContextMenu.js
+++ b/web_client/views/popover/AnnotationContextMenu.js
@@ -71,11 +71,13 @@ const AnnotationContextMenu = View.extend({
             delete styleAttrs.id;
             if (group) {
                 styleAttrs.group = group;
+            } else {
+                // The change event will be triggered by the set call later.  Unfortunately,
+                // there is no way to unset an attribute while setting others in a single
+                // backbone call.
+                elementModel.unset('group', {silent: true}); // eslint-disable-line backbone/no-silent
             }
             elementModel.set(styleAttrs);
-            if (!group) {
-                elementModel.unset('group');
-            }
         }).always(() => {
             this.reset();
             this.trigger('h:close');


### PR DESCRIPTION
Before I spend time working on testing, I thought I would push this up to get feedback.  The context menu now has buttons to remove the current group or change to another existing group.  It will list up to ten existing groups sorted alphabetically.

![test](https://user-images.githubusercontent.com/31890/43904282-41d85e4a-9bbc-11e8-9117-f5f22dd47ccf.png)
