### PR TITLE
Improve annotation refresh.

### DIFF
--- a/web_client/panels/AnnotationSelector.js
+++ b/web_client/panels/AnnotationSelector.js
@@ -190,6 +190,9 @@ var AnnotationSelector = Panel.extend({
                 if (!_.has(models, model.id)) {
                     model.set('displayed', true);
                 } else {
+                    if (models[model.id].get('displayed')) {
+                        model.refresh(true);
+                    }
                     model.set('displayed', models[model.id].get('displayed'));
                 }
             });

--- a/web_client/views/body/ImageView.js
+++ b/web_client/views/body/ImageView.js
@@ -390,6 +390,10 @@ var ImageView = View.extend({
         }
 
         if (annotation.get('displayed')) {
+            var viewer = this.viewerWidget.viewer || {};
+            if (viewer.zoomRange && annotation._pageElements === true) {
+                annotation.setView(viewer.bounds(), viewer.zoom(), viewer.zoomRange().max, true);
+            }
             annotation.set('loading', true);
             annotation.fetch().then(() => {
                 this.viewerWidget.drawAnnotation(annotation);


### PR DESCRIPTION
Before, when looking at an annotation that required paging, if the browser tab were made inactive, when it was reactivated, the wrong annotations were loaded.

Also, if you have zoomed in to any area while showing a paged annotation, turn off display of the annotation, then zoom out and zoom in to another area and redisplay the paged annotation, this will load the paged area without having to load the initial overview first.

This requires https://github.com/girder/large_image/pull/302.