### PR TITLE
Update the deployment README with the version of ansible required.

### DIFF
--- a/ansible/README.rst
+++ b/ansible/README.rst
@@ -124,9 +124,10 @@ Prerequisites
 
 ::
 
+    sudo apt-get update
     sudo apt-get install -y --force-yes libssl-dev git python2.7-dev python-pip
     sudo pip install -U pip
-    sudo pip install -U ansible
+    sudo pip install -U 'ansible<2.5'
     git clone https://github.com/DigitalSlideArchive/HistomicsTK
 
 Deploy
@@ -136,3 +137,5 @@ Deploy
 
     cd HistomicsTK/ansible
     ./deploy_local.sh
+
+Note that if there are network issues, this deployment script does not automatically retry installation.  It may be necessary to delete partial files and run it again.

--- a/ansible/roles/openslide/tasks/main.yml
+++ b/ansible/roles/openslide/tasks/main.yml
@@ -164,6 +164,7 @@
     depth: 1
     repo: https://github.com/ImageMagick/ImageMagick.git
     dest: "{{ root_dir }}/ImageMagick"
+    force: true
 
 - name: Configure ImageMagick
   command: ./configure --with-modules


### PR DESCRIPTION
Allow deploy_local.sh to be run multiple times by forcing the git checkout of ImageMagick.

Note that ansible 2.7 *probably* fixes the bug introduced in ansible 2.5, but as it is just a release candidate, this isn't certain.  When it is released, this should be tested again.