### PR TITLE
Upgrade docker and ansible to handle Ubuntu 18.04.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,5 +1,5 @@
 Vagrant.configure("2") do |config|
-  config.vm.box = "bento/ubuntu-16.04"
+  config.vm.box = "bento/ubuntu-18.04"
 
 
   if Vagrant.has_plugin?("vagrant-cachier")
@@ -13,7 +13,7 @@ Vagrant.configure("2") do |config|
   config.vm.network "forwarded_port", guest: 22, host: 2209
   config.vm.network "forwarded_port", guest: 8080, host: 8009
   config.vm.provider "virtualbox" do |v|
-    v.name = "HistomicsTK Ubuntu 16.04"
+    v.name = "HistomicsTK Ubuntu 18.04"
     # You may need to configure this to run benignly on your host machine
     v.memory = 4096
     v.cpus = 4

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,6 +1,6 @@
 Vagrant.configure("2") do |config|
-  config.vm.box = "bento/ubuntu-18.04"
-
+  # 18.04 also works (change in both locations)
+  config.vm.box = "bento/ubuntu-16.04"
 
   if Vagrant.has_plugin?("vagrant-cachier")
     config.cache.scope = :box
@@ -13,7 +13,7 @@ Vagrant.configure("2") do |config|
   config.vm.network "forwarded_port", guest: 22, host: 2209
   config.vm.network "forwarded_port", guest: 8080, host: 8009
   config.vm.provider "virtualbox" do |v|
-    v.name = "HistomicsTK Ubuntu 18.04"
+    v.name = "HistomicsTK Ubuntu 16.04"
     # You may need to configure this to run benignly on your host machine
     v.memory = 4096
     v.cpus = 4

--- a/ansible/Dockerfile-girder-worker
+++ b/ansible/Dockerfile-girder-worker
@@ -1,4 +1,5 @@
-FROM ubuntu:18.04
+# 18.04 also works
+FROM ubuntu:16.04
 MAINTAINER David Manthey <david.manthey@kitware.com>
 
 RUN apt-get update && \

--- a/ansible/Dockerfile-girder-worker
+++ b/ansible/Dockerfile-girder-worker
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 MAINTAINER David Manthey <david.manthey@kitware.com>
 
 RUN apt-get update && \

--- a/ansible/Dockerfile-histomicstk
+++ b/ansible/Dockerfile-histomicstk
@@ -1,4 +1,5 @@
-FROM ubuntu:18.04
+# 18.04 also works
+FROM ubuntu:16.04
 MAINTAINER David Manthey <david.manthey@kitware.com>
 
 RUN apt-get update && \

--- a/ansible/Dockerfile-histomicstk
+++ b/ansible/Dockerfile-histomicstk
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 MAINTAINER David Manthey <david.manthey@kitware.com>
 
 RUN apt-get update && \

--- a/ansible/README.rst
+++ b/ansible/README.rst
@@ -2,7 +2,7 @@
 Install HistomicsTK
 ===================
 
-There are several ways to install HistomicsTK and the Digital Slide Archive.  If you intend to use the interface, use the Docker installation.  If you need to develop the source code, the Vagrant installation is the easiest method.  If you are using Ubuntu 16.04, you can install HistomicsTK on your local system.
+There are several ways to install HistomicsTK and the Digital Slide Archive.  If you intend to use the interface, use the Docker installation.  If you need to develop the source code, the Vagrant installation is the easiest method.  If you are using Ubuntu 16.04 or Ubuntu 18.04, you can install HistomicsTK on your local system.
 
 .. __methods
 
@@ -114,10 +114,10 @@ Inside the vagrant box, tests can be run by typing::
     cd /opt/histomicstk/build
     ctest -VV
 
-Local installation on Ubuntu 16.04
-----------------------------------
+Local installation on Ubuntu 16.04 / 18.04
+------------------------------------------
 
-Due to the library dependencies of OpenJPEG, libtiff, OpenSlide, and vips, local installation may be hard to get fully working.  The local deployment scripts assume a reasonably plain instance of Ubuntu 16.04.
+Due to the library dependencies of OpenJPEG, libtiff, OpenSlide, and vips, local installation may be hard to get fully working.  The local deployment scripts assume a reasonably plain instance of Ubuntu 16.04 or Ubuntu 18.04.
 
 Prerequisites
 #############

--- a/ansible/deploy_local.sh
+++ b/ansible/deploy_local.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-if [ $(lsb_release -cs) != "xenial" ]; then
-  echo "This script will only work on Ubuntu 16.04"
-  return 1
+if [ $(lsb_release -cs) != "xenial" ] && [ $(lsb_release -cs) != "bionic" ]; then
+  echo "This script will only work on Ubuntu 16.04 or Ubuntu 18.04"
+  return 1 || exit 1
 fi
 
 unset PYTHONPATH

--- a/ansible/roles/girder-histomicstk/tasks/main.yml
+++ b/ansible/roles/girder-histomicstk/tasks/main.yml
@@ -5,7 +5,7 @@
 
 - name: NodeJS | Add PPA
   apt_repository:
-    repo: "deb https://deb.nodesource.com/node_6.x {{ ansible_distribution_release }} main"
+    repo: "deb https://deb.nodesource.com/node_8.x {{ ansible_distribution_release }} main"
   become: true
 
 - name: NodeJS | Install package
@@ -15,7 +15,7 @@
   become: true
 
 - name: NodeJS | Update npm
-  command: "npm install -g npm"
+  command: "npm install -g npm@latest"
   become: true
 
 - name: Install system package dependencies
@@ -40,7 +40,7 @@
   become: true
 
 - name: Install node-gyp
-  shell: "npm install -g node-gyp-install && /usr/lib/node_modules/node-gyp-install/bin.js"
+  shell: "npm install -g node-gyp-install && node-gyp-install"
   become: true
 
 - name: Clone slicer_cli_web plugin

--- a/ansible/roles/openslide/tasks/main.yml
+++ b/ansible/roles/openslide/tasks/main.yml
@@ -6,7 +6,7 @@
       - libssl-dev
       - python-pip
       - python2.7-dev
-      - python-software-properties
+      - software-properties-common
       - wget
       - build-essential
       - cmake
@@ -24,7 +24,7 @@
       - libglib2.0-dev
       - libjpeg-dev
       - libxml2-dev
-      - libpng12-dev
+      - libpng-dev
       - autoconf
       - automake
       - libtool
@@ -35,7 +35,7 @@
       # To update vips
       - build-essential
       - gobject-introspection
-      - libcfitsio3-dev
+      - libcfitsio-dev
       - libexif-dev
       - libfftw3-dev
       - libgif-dev


### PR DESCRIPTION
deploy_local.sh works with both Ubuntu 16.04 and Ubuntu 18.04.  The vagrant and docker versions work with both by just changing the box/from fields.

We could a *lot* less in Ubuntu 18.04, as versions of OpenSlide, libtiff, etc. are mostly what is needed, but that requires two different techniques for 16.04/18.04 or dropping 16.04 support.