### PR TITLE
Attempt to prevent the context menu from overflowing

### DIFF
--- a/web_client/panels/AnnotationSelector.js
+++ b/web_client/panels/AnnotationSelector.js
@@ -385,7 +385,20 @@ var AnnotationSelector = Panel.extend({
             }
             groupObject[group] = _.sortBy(groupList, (a) => a.get('created'));
         });
+        this._triggerGroupCountChange(groupObject);
         return groupObject;
+    },
+
+    _triggerGroupCountChange(groups) {
+        const groupCount = {};
+        _.each(groups, (annotations, name) => {
+            if (name !== 'Other') {
+                groupCount[name] = annotations.length;
+            } else {
+                groupCount.default = annotations.length;
+            }
+        });
+        this.trigger('h:groupCount', groupCount);
     }
 });
 

--- a/web_client/views/body/ImageView.js
+++ b/web_client/views/body/ImageView.js
@@ -659,6 +659,7 @@ var ImageView = View.extend({
         // Defer the context menu action into the next animation frame
         // to work around a problem with preventDefault on Windows
         window.setTimeout(() => {
+            const $window = $(window);
             const menu = this.$('#h-annotation-context-menu');
             const position = evt.mouse.page;
             menu.removeClass('hidden');
@@ -666,11 +667,21 @@ var ImageView = View.extend({
             // adjust the vertical position of the context menu
             // == 0, above the bottom; < 0, number of pixels below the bottom
             // the menu height is bigger by 20 pixels due to extra padding
-            const belowWindow = Math.min(0, $(window).height() - position.y - menu.height() + 20);
+            const belowWindow = Math.min(0, $window.height() - position.y - menu.height() + 20);
             // ensure the top is not above the top of the window
             const top = Math.max(0, position.y + belowWindow);
 
-            menu.css({ left: position.x, top });
+            // Put the context menu to the left of the cursor if it is too close
+            // to the right edge.
+            const windowWidth = $window.width();
+            const menuWidth = menu.width();
+            let left = position.x;
+            if (left + menuWidth > windowWidth) {
+                left -= menuWidth;
+            }
+            left = Math.max(left, 0);
+
+            menu.css({ left, top });
             this.popover.collection.reset();
             this._contextMenuActive = true;
             // this.contextMenu.setHovered(element, annotation);

--- a/web_client/views/body/ImageView.js
+++ b/web_client/views/body/ImageView.js
@@ -659,7 +659,15 @@ var ImageView = View.extend({
             const menu = this.$('#h-annotation-context-menu');
             const position = evt.mouse.page;
             menu.removeClass('hidden');
-            menu.css({ left: position.x, top: position.y });
+
+            // adjust the vertical position of the context menu
+            // == 0, above the bottom; < 0, number of pixels below the bottom
+            // the menu height is bigger by 20 pixels due to extra padding
+            const belowWindow = Math.min(0, $(window).height() - position.y - menu.height() + 20);
+            // ensure the top is not above the top of the window
+            const top = Math.max(0, position.y + belowWindow);
+
+            menu.css({ left: position.x, top });
             this.popover.collection.reset();
             this._contextMenuActive = true;
             // this.contextMenu.setHovered(element, annotation);

--- a/web_client/views/body/ImageView.js
+++ b/web_client/views/body/ImageView.js
@@ -684,7 +684,6 @@ var ImageView = View.extend({
             menu.css({ left, top });
             this.popover.collection.reset();
             this._contextMenuActive = true;
-            // this.contextMenu.setHovered(element, annotation);
         }, 1);
     },
 

--- a/web_client/views/body/ImageView.js
+++ b/web_client/views/body/ImageView.js
@@ -71,6 +71,9 @@ var ImageView = View.extend({
             collection: this.selectedElements
         });
 
+        this.listenTo(this.annotationSelector, 'h:groupCount', (obj) => {
+            this.contextMenu.setGroupCount(obj);
+        });
         this.listenTo(events, 'h:submit', (data) => {
             this.$('.s-jobs-panel .s-panel-controls .icon-down-open').click();
             events.trigger('g:alert', {type: 'success', text: 'Analysis job submitted.'});

--- a/web_client/views/popover/AnnotationContextMenu.js
+++ b/web_client/views/popover/AnnotationContextMenu.js
@@ -48,8 +48,6 @@ const AnnotationContextMenu = View.extend({
                 element.unset('group', {silent: true});
             }
             element.set(styleAttrs, {silent: true});
-            // test
-            JSON.stringify(element.toJSON());
         });
         this.collection.trigger('h:save');
         this.trigger('h:close');

--- a/web_client/views/popover/AnnotationContextMenu.js
+++ b/web_client/views/popover/AnnotationContextMenu.js
@@ -12,6 +12,7 @@ const AnnotationContextMenu = View.extend({
         'click .h-remove-group': '_removeGroup'
     },
     initialize(settings) {
+        this._cachedGroupCount = {};
         this.styles = new StyleCollection();
         this.styles.fetch().done(() => this.render());
         this.listenTo(this.collection, 'add remove reset', this.render);
@@ -22,6 +23,9 @@ const AnnotationContextMenu = View.extend({
             numberSelected: this.collection.length
         }));
         return this;
+    },
+    setGroupCount(groupCount) {
+        this._cachedGroupCount = groupCount;
     },
     _removeElements(evt) {
         evt.preventDefault();
@@ -54,7 +58,20 @@ const AnnotationContextMenu = View.extend({
     },
     _getAnnotationGroups() {
         const groups = this.styles.map((style) => style.id);
-        groups.sort();
+        groups.sort((a, b) => {
+            const countA = this._cachedGroupCount[a] || 0;
+            const countB = this._cachedGroupCount[b] || 0;
+            if (countA !== countB) {
+                return countB - countA;
+            }
+            if (a < b) {
+                return -1;
+            } else if (a > b) {
+                return 1;
+            } else {
+                return 0;
+            }
+        });
         return groups.slice(0, 10);
     },
     _setGroup(evt) {


### PR DESCRIPTION
This adjusts the y coordinate of the context menu so that the bottom is
no lower than the bottom edge of the visible window.  The context menu
can still overflow if the vertical size of the window is too small to
fit the context menu.  If this becomes an issue we can make further
adjustments, e.g. put it in a scrolling container or add a "show more"
button.