### PR TITLE
Save style group to localstorage when resetting

### DIFF
--- a/web_client/dialogs/editStyleGroups.js
+++ b/web_client/dialogs/editStyleGroups.js
@@ -145,7 +145,10 @@ const EditStyleGroups = View.extend({
             styleModels = _.map(styles, function (style) {
                 return new StyleModel(style);
             });
-            this.collection.reset(styleModels, {merge: true});
+            while (this.collection.length) {
+                this.collection.first().destroy();
+            }
+            this.collection.reset(styleModels);
             // make sure we have at least a default style
             if (!this.collection.get('default')) {
                 this.collection.push(new StyleModel({id: 'default'}));

--- a/web_client/dialogs/editStyleGroups.js
+++ b/web_client/dialogs/editStyleGroups.js
@@ -154,6 +154,7 @@ const EditStyleGroups = View.extend({
             if (oldid && this.collection.get(oldid)) {
                 this.model.set(this.collection.get(oldid).toJSON());
             }
+            this.collection.each((model) => { model.save(); });
             this._newStyle = false;
             this.render();
         });


### PR DESCRIPTION
Prior to this change, resetting the style groups only applied to the
groups currently in memory.  When reloading the page, they reverted back
to the old values.