### PR TITLE
Only trigger a mouse click action on a single element

### DIFF
--- a/web_client/views/body/ImageView.js
+++ b/web_client/views/body/ImageView.js
@@ -32,6 +32,7 @@ var ImageView = View.extend({
     },
     initialize(settings) {
         this.viewerWidget = null;
+        this._mouseClickQueue = [];
         this._openId = null;
         this._displayedRegion = null;
         this.selectedAnnotation = new AnnotationModel({_id: 'selected'});
@@ -564,15 +565,56 @@ var ImageView = View.extend({
             return;
         }
 
-        if (evt.mouse.buttonsDown.right) {
-            this._openContextMenu(element.annotation.elements().get(element.id), annotationId, evt);
-        } else if (evt.mouse.modifiers.ctrl) {
-            this._toggleSelectElement(element.annotation.elements().get(element.id));
+        /*
+         * Click events on geojs features are triggered once per feature in a single animation frame.
+         * Here we collect all click events occurring in a single animation frame and defer processing.
+         * On the next frame, the queue is processed and the action is only performed on the "closest"
+         * feature.  Here "closest" is determined by a fast heuristic--the one with a vertex closest
+         * to the point clicked.  We can improve this heuristic as necessary.
+         */
+        this._queueMouseClickAction(element, annotationId, evt.data.geometry, evt.mouse.geo);
+        if (this._mouseClickQueue.length > 1) {
+            return;
         }
+
+        window.requestAnimationFrame(() => {
+            const { element, annotationId } = this._processMouseClickQueue();
+            if (evt.mouse.buttonsDown.right) {
+                this._openContextMenu(element.annotation.elements().get(element.id), annotationId, evt);
+            } else if (evt.mouse.modifiers.ctrl) {
+                this._toggleSelectElement(element.annotation.elements().get(element.id));
+            }
+        });
     },
 
     toggleLabels(options) {
         this.popover.toggle(options.show);
+    },
+
+    _queueMouseClickAction(element, annotationId, geometry, center) {
+        let minimumDistance = Number.POSITIVE_INFINITY;
+        if (geometry.type !== 'Polygon') {
+            // We don't current try to resolve any other geometry type, for the moment,
+            // any point or line clicked on will always be chosen over a polygon.
+            minimumDistance = 0;
+        } else {
+            const points = geometry.coordinates[0];
+            // use an explicit loop for speed
+            for (let index = 0; index < points.length; index += 1) {
+                const point = points[index];
+                const dx = point[0] - center.x;
+                const dy = point[1] - center.y;
+                const distance = dx * dx + dy * dy;
+                minimumDistance = Math.min(minimumDistance, distance);
+            }
+        }
+        this._mouseClickQueue.push({ element, annotationId, value: minimumDistance });
+    },
+
+    _processMouseClickQueue(evt) {
+        const sorted = _.sortBy(this._mouseClickQueue, _.property('value'));
+        this._mouseClickQueue = [];
+        return sorted[0];
     },
 
     _toggleInteractiveMode(interactive) {


### PR DESCRIPTION
Prior to this change, the events were triggered on *all* elements under
the mouse cursor.  In the event of a right click, the last element that
happened to be triggered by geojs was the one that was eventually
highlighted.  For multi-select, all elements were being toggled
resulting in a confusing behavior.

Now only a single element is chosen based on a fast heuristic--the
polygon with a vertex nearest the point clicked.  We can replace the
heuristic easily, but this computation necessarily adds processing that
must occur during the click event, so it will slow down the context menu
action (perhaps un-noticeably so).

Addresses #534 and #540 