### PR TITLE
Moving `detect_nuclei_kofahi` method to histomicstk

### DIFF
--- a/histomicstk/segmentation/nuclear/__init__.py
+++ b/histomicstk/segmentation/nuclear/__init__.py
@@ -7,8 +7,10 @@ from .gaussian_voting import gaussian_voting
 from .gvf_tracking import gvf_tracking
 from .max_clustering import max_clustering
 from .min_model import min_model
+from .detect_nuclei_kofahi import detect_nuclei_kofahi
 
 __all__ = (
+    'detect_nuclei_kofahi',
     'gaussian_voting',
     'gvf_tracking',
     'max_clustering',

--- a/histomicstk/segmentation/nuclear/detect_nuclei_kofahi.py
+++ b/histomicstk/segmentation/nuclear/detect_nuclei_kofahi.py
@@ -1,0 +1,79 @@
+import numpy as np
+import scipy as sp
+import skimage.morphology
+import histomicstk.filters.shape as htk_shape_filters
+import histomicstk as htk
+
+
+def detect_nuclei_kofahi(im_nuclei_stain, foreground_threshold, min_radius,
+                         max_radius, min_nucleus_area, local_max_search_radius):
+
+    """Performs a nuclear segmentation using kofahi's method.
+
+    This method uses scale-adaptive multi-scale Laplacian-of-Gaussian filtering
+    for blob enhancement and a local maximum clustering for segmentation. The
+    original implementation described by Al-Kofahi et al. uses Laplacian of Gaussian
+    but this function replaces it with Difference of Gaussian to improve speed.
+
+    Parameters
+    ----------
+    im_nuclei_stain : array_like
+        A hematoxylin intensity image obtained from ColorDeconvolution.
+    foreground_threshold : float
+        Intensity value to use as threshold to segment foreground in nuclear stain image
+    min_radius : float
+        Minimum nuclear radius (used to set min sigma of the multiscale LoG filter)
+    max_radius : float
+        Maximum nuclear radius (used to set max sigma of the multiscale LoG filter)
+    min_nucleus_area : int
+        Minimum area that each nucleus should have
+    local_max_search_radius : float
+        Local max search radius used for detection seed points in nuclei
+
+    Returns
+    -------
+    im_nuclei_seg_mask : array_like
+        A 2D array mask of the nuclei segmentation.
+
+    References
+    ----------
+    .. [#] Y. Al-Kofahi et al "Improved Automatic Detection and Segmentation of
+       Cell Nuclei in Histopathology Images" in IEEE Transactions on Biomedical
+       Engineering, Volume: 57, Issue: 4, doi: 10.1109/TBME.2009.2035102,
+       April 2010.
+
+    """
+
+    # segment nuclear foreground mask
+    # (assumes nuclei are darker on a bright background)
+    im_nuclei_fgnd_mask = im_nuclei_stain < foreground_threshold
+
+    # smooth foreground mask with closing and opening
+    im_nuclei_fgnd_mask = skimage.morphology.closing(
+        im_nuclei_fgnd_mask, skimage.morphology.disk(3))
+
+    im_nuclei_fgnd_mask = skimage.morphology.opening(
+        im_nuclei_fgnd_mask, skimage.morphology.disk(3))
+
+    im_nuclei_fgnd_mask = sp.ndimage.morphology.binary_fill_holes(
+        im_nuclei_fgnd_mask)
+
+    # run adaptive multi-scale LoG filter
+    im_log_max, im_sigma_max = htk_shape_filters.cdog(
+        im_nuclei_stain, im_nuclei_fgnd_mask,
+        sigma_min=min_radius / np.sqrt(2),
+        sigma_max=max_radius / np.sqrt(2)
+    )
+
+    # apply local maximum clustering
+    im_nuclei_seg_mask, seeds, maxima = htk.segmentation.nuclear.max_clustering(
+        im_log_max, im_nuclei_fgnd_mask, local_max_search_radius)
+
+    # split any objects with disconnected fragments
+    im_nuclei_seg_mask = htk.segmentation.label.split(im_nuclei_seg_mask, conn=8)
+
+    # filter out small objects
+    im_nuclei_seg_mask = htk.segmentation.label.area_open(
+        im_nuclei_seg_mask, min_nucleus_area).astype(np.int)
+
+    return im_nuclei_seg_mask

--- a/plugin_tests/cli_common_test.py
+++ b/plugin_tests/cli_common_test.py
@@ -34,6 +34,7 @@ import large_image
 
 import histomicstk.preprocessing.color_deconvolution as htk_cdeconv
 import histomicstk.preprocessing.color_normalization as htk_cnorm
+import histomicstk.segmentation.nuclear as htk_nuclear
 import histomicstk.utils as htk_utils
 
 sys.path.append(os.path.normpath(os.path.join(os.path.dirname(__file__), '../server')))
@@ -203,8 +204,12 @@ class CliCommonTest(unittest.TestCase):
             im_nuclei_stain = im_stains[:, :, 0].astype(np.float)
 
             # segment nuclei
-            im_nuclei_seg_mask = cli_utils.detect_nuclei_kofahi(
-                im_nuclei_stain, args)
+            im_nuclei_seg_mask = htk_nuclear.detect_nuclei_kofahi(im_nuclei_stain,
+                                                                  args.foreground_threshold,
+                                                                  args.min_radius,
+                                                                  args.max_radius,
+                                                                  args.min_nucleus_area,
+                                                                  args.local_max_search_radius)
 
             # generate nuclei annotations as bboxes
             cur_bbox_annot_list = cli_utils.create_tile_nuclei_annotations(

--- a/plugin_tests/feature_extraction_test.py
+++ b/plugin_tests/feature_extraction_test.py
@@ -9,10 +9,11 @@ import collections
 
 import histomicstk.preprocessing.color_normalization as htk_cnorm
 import histomicstk.preprocessing.color_deconvolution as htk_cdeconv
+import histomicstk.segmentation.nuclear as htk_nuclear
 import histomicstk.features as htk_features
 
-sys.path.append(os.path.normpath(os.path.join(os.path.dirname(__file__), '../server')))
-from cli_common import utils as cli_utils  # noqa
+sys.path.append(os.path.normpath(os.path.join(
+    os.path.dirname(__file__), '../server')))
 
 
 TEST_DATA_DIR = os.path.join(os.environ['GIRDER_TEST_DATA_PREFIX'], 'plugins/HistomicsTK')
@@ -64,8 +65,12 @@ class FeatureExtractionTest(unittest.TestCase):
             np.float)
 
         # segment nuclei
-        im_nuclei_seg_mask = cli_utils.detect_nuclei_kofahi(
-            im_nuclei_stain, args)
+        im_nuclei_seg_mask = htk_nuclear.detect_nuclei_kofahi(im_nuclei_stain,
+                                                              args.foreground_threshold,
+                                                              args.min_radius,
+                                                              args.max_radius,
+                                                              args.min_nucleus_area,
+                                                              args.local_max_search_radius)
 
         # perform connected component analysis
         nuclei_rprops = skimage.measure.regionprops(im_nuclei_seg_mask)

--- a/server/ComputeNucleiFeatures/ComputeNucleiFeatures.py
+++ b/server/ComputeNucleiFeatures/ComputeNucleiFeatures.py
@@ -11,6 +11,7 @@ import histomicstk.preprocessing.color_normalization as htk_cnorm
 import histomicstk.preprocessing.color_deconvolution as htk_cdeconv
 import histomicstk.features as htk_features
 import histomicstk.utils as htk_utils
+import histomicstk.segmentation.nuclear as htk_nuclear
 
 import large_image
 
@@ -53,7 +54,12 @@ def compute_tile_nuclei_features(slide_path, tile_position, args, it_kwargs,
     im_nuclei_stain = im_stains[:, :, 0].astype(np.float)
 
     # segment nuclei
-    im_nuclei_seg_mask = cli_utils.detect_nuclei_kofahi(im_nuclei_stain, args)
+    im_nuclei_seg_mask = htk_nuclear.detect_nuclei_kofahi(im_nuclei_stain,
+                                                          args.foreground_threshold,
+                                                          args.min_radius,
+                                                          args.max_radius,
+                                                          args.min_nucleus_area,
+                                                          args.local_max_search_radius)
 
     # generate nuclei annotations
     nuclei_annot_list = cli_utils.create_tile_nuclei_annotations(

--- a/server/NucleiDetection/NucleiDetection.py
+++ b/server/NucleiDetection/NucleiDetection.py
@@ -9,6 +9,7 @@ import dask
 
 import histomicstk.preprocessing.color_normalization as htk_cnorm
 import histomicstk.preprocessing.color_deconvolution as htk_cdeconv
+import histomicstk.segmentation.nuclear as htk_nuclear
 import histomicstk.utils as htk_utils
 
 import large_image
@@ -18,7 +19,8 @@ from ctk_cli import CLIArgumentParser
 import logging
 logging.basicConfig(level=logging.CRITICAL)
 
-sys.path.append(os.path.normpath(os.path.join(os.path.dirname(__file__), '..')))
+sys.path.append(os.path.normpath(
+    os.path.join(os.path.dirname(__file__), '..')))
 from cli_common import utils as cli_utils  # noqa
 
 
@@ -52,7 +54,12 @@ def detect_tile_nuclei(slide_path, tile_position, args, it_kwargs,
     im_nuclei_stain = im_stains[:, :, 0].astype(np.float)
 
     # segment nuclei
-    im_nuclei_seg_mask = cli_utils.detect_nuclei_kofahi(im_nuclei_stain, args)
+    im_nuclei_seg_mask = htk_nuclear.detect_nuclei_kofahi(im_nuclei_stain,
+                                                          args.foreground_threshold,
+                                                          args.min_radius,
+                                                          args.max_radius,
+                                                          args.min_nucleus_area,
+                                                          args.local_max_search_radius)
 
     # generate nuclei annotations
     nuclei_annot_list = cli_utils.create_tile_nuclei_annotations(


### PR DESCRIPTION
`detect_nuclei_kofahi` was implemented on the server-side. It was moved directly
into histomicstk, as a new function, to facilitate access to the algorithm.