### PR TITLE
Remove unnecessary source directory environment variable requirement

### DIFF
--- a/devops/README.rst
+++ b/devops/README.rst
@@ -8,11 +8,9 @@ Description
 This folder contains a set of scripts that are convenient to develop
 histomicsTK inside its docker container.
 
-The following environment variables need to be defined for these scripts
+The following environment variable need to be defined for these scripts
 to run:
 
-* ``HISTOMICS_SOURCE_FOLDER``: Points to the location of your HistomicsTK
-  source directory.
 * ``HISTOMICS_TESTDATA_FOLDER``: Folder in which the test data will be installed
   on the host computer. This allows to not download the test data every time,
   but instead keep it directly on the host computer. If the container is removed,
@@ -50,7 +48,6 @@ can now use ``deploy.sh`` in the ``devops`` folder. This will mount their local 
 folder in their container::
 
   $ cd HistomicsTK
-  $ export HISTOMICS_SOURCE_FOLDER=`pwd`
   $ export HISTOMICS_TESTDATA_FOLDER=~/data/histomicsTK
   $ mkdir -p $HISTOMICS_TESTDATA_FOLDER
   $ devops/deploy.sh start --build

--- a/devops/deploy.sh
+++ b/devops/deploy.sh
@@ -1,10 +1,8 @@
 #!/bin/bash
 
-if [[ -z "$HISTOMICS_SOURCE_FOLDER" ]]
-then
-  echo "Set environment variable HISTOMICS_SOURCE_FOLDER to HistomicsTK source directory"
-  exit 1
-fi
+# The following line does not work for symbolic link. Do not create a symbolic link
+# of this file to run it.
+HISTOMICS_SOURCE_FOLDER="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )/.."
 
 if [[ -z "$HISTOMICS_TESTDATA_FOLDER" ]]
 then


### PR DESCRIPTION
Now that de devops scripts have been directly integrated within this
project, it is not necessary to specify in an environment variable
the directory of HistomicsTK source directory. This path can be
automatically deduced.