### PR TITLE
Add the ability to change global annotation style

### DIFF
--- a/plugin_tests/client/annotationSpec.js
+++ b/plugin_tests/client/annotationSpec.js
@@ -640,6 +640,31 @@ $(function () {
                 });
             });
 
+            it('edit annotation style', function () {
+                runs(function () {
+                    $('.h-annotation-selector .h-annotation:contains("drawn 2") .h-edit-annotation-metadata').click();
+                });
+
+                girderTest.waitForDialog();
+                runs(function () {
+                    expect($('#h-annotation-name').val()).toBe('drawn 2');
+                    expect($('#h-annotation-line-color').length).toBe(1);
+                    expect($('#h-annotation-fill-color').length).toBe(1);
+                    $('#h-annotation-line-color').val('black');
+                    $('#h-annotation-fill-color').val('white');
+                    $('.h-submit').click();
+                });
+
+                girderTest.waitForLoad();
+                runs(function () {
+                    var annotation = app.bodyView.annotations.filter(function (annotation) {
+                        return annotation.get('annotation').name === 'drawn 2';
+                    })[0];
+                    expect(annotation.get('annotation').elements[0].lineColor).toBe('rgb(0, 0, 0)');
+                    expect(annotation.get('annotation').elements[0].fillColor).toBe('rgb(255, 255, 255)');
+                });
+            });
+
             it('set annotation permissions to WRITE', function () {
                 runs(function () {
                     $('.h-annotation-selector .h-annotation:contains("edited 1") .h-edit-annotation-metadata').click();

--- a/web_client/panels/AnnotationSelector.js
+++ b/web_client/panels/AnnotationSelector.js
@@ -172,7 +172,13 @@ var AnnotationSelector = Panel.extend({
         this.listenToOnce(
             showSaveAnnotationDialog(model, {title: 'Edit annotation'}),
             'g:submit',
-            () => model.save()
+            () => {
+                model.save().done(() => {
+                    if (model.get('displayed')) {
+                        this.trigger('h:redraw', model);
+                    }
+                });
+            }
         );
     },
 

--- a/web_client/templates/dialogs/saveAnnotation.pug
+++ b/web_client/templates/dialogs/saveAnnotation.pug
@@ -15,6 +15,23 @@
           textarea#h-annotation-description.form-control.input-sm(
             rows='6', placeholder='Enter an optional description')
             | #{annotation.description}
+        if showStyleEditor
+          hr
+          h4 Reset the style for all elements in this annotation
+          .form-group
+            label(for='h-annotation-line-color') Line color
+            .input-group.h-colorpicker
+              input#h-annotation-line-color.input-sm.form-control(
+                type='text')
+              span.input-group-addon
+                i
+          .form-group
+            label(for='h-annotation-fill-color') Fill color
+            .input-group.h-colorpicker
+              input#h-annotation-fill-color.input-sm.form-control(
+                type='text')
+              span.input-group-addon
+                i
         .g-validation-failed-message.hidden
       .modal-footer
         if hasAdmin


### PR DESCRIPTION
This adds color pickers to the "save annotation" dialog to bulk set the style for all elements in an annotation.  A couple of implementation notes:
* The option will not appear when either the annotation is not displayed or the annotation elements are paged.  I could add a message in place of the colorpickers telling why they are not there if it is overly confusing.
* The dialog always appears with no colors set.  I could try and detect if all elements use the same style, which would prefill the color picker, but that would require extra computation before opening the dialog.  I don't think the computation would be noticeable if the feature would be useful.
* Submitting with an invalid value (the default now) implicitly means "keep the original color".  Alternatively, I could make a checkbox next to each color picker to indicate "I wish to overwrite the colors for all elements".