### PR TITLE
Update Python code style to match new PEP-8 requirements

### DIFF
--- a/histomicstk/preprocessing/color_normalization/reinhard.py
+++ b/histomicstk/preprocessing/color_normalization/reinhard.py
@@ -75,8 +75,8 @@ def reinhard(im_src, target_mu, target_sigma, src_mu=None, src_sigma=None):
 
     # calculate src_sigma if not provided
     if src_sigma is None:
-        src_sigma = ((im_lab * im_lab).sum(axis=0).sum(axis=0) /
-                     (m * n - 1)) ** 0.5
+        src_sigma = ((im_lab * im_lab).sum(axis=0).sum(axis=0)
+                     / (m * n - 1)) ** 0.5
 
     # scale to unit variance
     for i in range(3):

--- a/histomicstk/segmentation/level_set/chan_vese.py
+++ b/histomicstk/segmentation/level_set/chan_vese.py
@@ -89,7 +89,7 @@ def kappa(im_phi):
     dPhi = np.gradient(im_phi)  # calculate gradient of level set image
     xdPhi = np.gradient(dPhi[1])
     ydPhi = np.gradient(dPhi[0])
-    K = (xdPhi[1]*(dPhi[0]**2) - 2*xdPhi[0]*dPhi[0]*dPhi[1] +
-         ydPhi[0]*(dPhi[1]**2)) / ((dPhi[0]**2 + dPhi[1]**2 + 1e-10)**(3/2))
+    K = (xdPhi[1]*(dPhi[0]**2) - 2*xdPhi[0]*dPhi[0]*dPhi[1]
+         + ydPhi[0]*(dPhi[1]**2)) / ((dPhi[0]**2 + dPhi[1]**2 + 1e-10)**(3/2))
     K *= (xdPhi[1]**2 + ydPhi[0]**2)**(1/2)
     return K

--- a/histomicstk/segmentation/level_set/reg_edge.py
+++ b/histomicstk/segmentation/level_set/reg_edge.py
@@ -93,8 +93,8 @@ def reg_edge(im_input, im_phi, well='double', sigma=1.5, dt=1.0, mu=0.2,
         # area and boundary-length energy function terms
         iPhi = impulse(im_phi, epsilon)
         Area = iPhi * G
-        Edge = iPhi * (dG[0] * (dPhi[0] / (mPhi + 1e-10)) +
-                       dG[1] * (dPhi[1] / (mPhi + 1e-10))) + iPhi * G * Curve
+        Edge = iPhi * (dG[0] * (dPhi[0] / (mPhi + 1e-10))
+                       + dG[1] * (dPhi[1] / (mPhi + 1e-10))) + iPhi * G * Curve
 
         # evolve level-set function
         im_phi = im_phi + dt * (mu * Reg + lamda * Edge + alpha * Area)

--- a/histomicstk/segmentation/nuclear/gaussian_voting.py
+++ b/histomicstk/segmentation/nuclear/gaussian_voting.py
@@ -79,10 +79,10 @@ def gaussian_voting(I, rmax=35, rmin=10, sSigma=5, Tau=5, bw=15, Psi=0.3):
     for i in range(Voting[0].size):
 
         # calculate center point of voting region
-        mux = round(Voting[1][i] + r * Grad.dX[Voting[0][i]][Voting[1][i]] /
-                    dMag[Voting[0][i]][Voting[1][i]])
-        muy = round(Voting[0][i] + r * Grad.dY[Voting[0][i]][Voting[1][i]] /
-                    dMag[Voting[0][i]][Voting[1][i]])
+        mux = round(Voting[1][i] + r * Grad.dX[Voting[0][i]][Voting[1][i]]
+                    / dMag[Voting[0][i]][Voting[1][i]])
+        muy = round(Voting[0][i] + r * Grad.dY[Voting[0][i]][Voting[1][i]]
+                    / dMag[Voting[0][i]][Voting[1][i]])
 
         # enter weighted votes at these locations
         Votes[r+muy, r+mux] = Votes[r+muy, r+mux] + \

--- a/histomicstk/segmentation/nuclear/gvf_tracking.py
+++ b/histomicstk/segmentation/nuclear/gvf_tracking.py
@@ -111,10 +111,10 @@ def gvf_tracking(I, Mask, K=1000, Diffusions=10, Mu=5, Lambda=5, Iterations=10,
                                 Trajectory[points-1, 0]])
 
             # check image edge
-            if ((Trajectory[points-1, 0] + xStep < 0) or
-                (Trajectory[points-1, 0] + xStep > N-1) or
-                (Trajectory[points-1, 1] + yStep < 0) or
-                    (Trajectory[points-1, 1] + yStep > M-1)):
+            if ((Trajectory[points-1, 0] + xStep < 0)
+                or (Trajectory[points-1, 0] + xStep > N-1)
+                or (Trajectory[points-1, 1] + yStep < 0)
+                    or (Trajectory[points-1, 1] + yStep > M-1)):
                         break
 
             # add new point to trajectory list
@@ -150,13 +150,13 @@ def gvf_tracking(I, Mask, K=1000, Diffusions=10, Mu=5, Lambda=5, Iterations=10,
                 phi = np.pi
             else:
                 phi = np.arccos(dy[Trajectory[points-1, 1],
-                                   Trajectory[points-1, 0]] *
-                                dy[Trajectory[points, 1],
-                                   Trajectory[points, 0]] +
-                                dx[Trajectory[points-1, 1],
-                                   Trajectory[points-1, 0]] *
-                                dx[Trajectory[points, 1],
-                                   Trajectory[points, 0]])
+                                   Trajectory[points-1, 0]]
+                                * dy[Trajectory[points, 1],
+                                     Trajectory[points, 0]]
+                                + dx[Trajectory[points-1, 1],
+                                     Trajectory[points-1, 0]]
+                                * dx[Trajectory[points, 1],
+                                     Trajectory[points, 0]])
 
             # increment trajectory length counter
             points += 1

--- a/histomicstk/segmentation/nuclear/min_model.py
+++ b/histomicstk/segmentation/nuclear/min_model.py
@@ -160,10 +160,10 @@ def seed_contours(I, Delta=0.3):
         Gradient = np.hstack((np.nan, I[i, 2:] - I[i, 0:-2], np.nan))
 
         # identify local maxima and minimia of row 'i' of 'I'
-        Maxima = ((I[i, 1:-1] >= I[i, 0:-2]) &
-                  (I[i, 1:-1] > I[i, 2:])).nonzero()[0] + 1
-        Minima = ((I[i, 1:-1] < I[i, 0:-2]) &
-                  (I[i, 1:-1] <= I[i, 2:])).nonzero()[0] + 1
+        Maxima = ((I[i, 1:-1] >= I[i, 0:-2])
+                  & (I[i, 1:-1] > I[i, 2:])).nonzero()[0] + 1
+        Minima = ((I[i, 1:-1] < I[i, 0:-2])
+                  & (I[i, 1:-1] <= I[i, 2:])).nonzero()[0] + 1
 
         # identify transitions - start of intervals of monotonic non-increase
         dI = np.sign(I[i, 1:] - I[i, 0:-1])
@@ -190,8 +190,8 @@ def seed_contours(I, Delta=0.3):
                     MinPos = Index[0]
 
                     # increment transition point to beyond current maxima
-                    while ((TranPos < Transitions.size) &
-                           (Transitions[TranPos] < Maxima[MaxPos])):
+                    while ((TranPos < Transitions.size)
+                           & (Transitions[TranPos] < Maxima[MaxPos])):
                         TranPos += 1
 
                     # add minima to current maxima until transition is reached
@@ -742,8 +742,8 @@ def angle_score(ax1, ay1, bx1, by1, ax2, ay2, bx2, by2, cx1, cy1, cx2, cy2):
     kCutAlpha = np.arctan2(cy1 - cy2, cx2 - cx1)
 
     # calculate angle score
-    Score = (np.abs(np.pi/2 - (jCutAlpha - jHullAlpha)) +
-             np.abs(np.pi/2 - (kCutAlpha - kHullAlpha))) / np.pi
+    Score = (np.abs(np.pi/2 - (jCutAlpha - jHullAlpha))
+             + np.abs(np.pi/2 - (kCutAlpha - kHullAlpha))) / np.pi
 
     return Score
 

--- a/histomicstk/segmentation/positive_pixel_count.py
+++ b/histomicstk/segmentation/positive_pixel_count.py
@@ -167,9 +167,9 @@ def count_image(image, params):
     mask_all_positive, mask_weak, mask_pos, mask_strong = masks
     label_image = np.full(image.shape[:-1], Labels.NEGATIVE, dtype=np.uint8)
     label_image[mask_all_positive] = (
-        mask_weak * Labels.WEAK +
-        mask_pos * Labels.PLAIN +
-        mask_strong * Labels.STRONG
+        mask_weak * Labels.WEAK
+        + mask_pos * Labels.PLAIN
+        + mask_strong * Labels.STRONG
     )
     return _totals_to_stats(total), label_image
 
@@ -182,11 +182,11 @@ def _count_image(image, params):
     p = params
     image_hsi = rgb_to_hsi(image / 255)
     mask_all_positive = (
-        (np.abs((image_hsi[..., 0] - p.hue_value + 0.5 % 1) - 0.5) <=
-         p.hue_width / 2) &
-        (image_hsi[..., 1] >= p.saturation_minimum) &
-        (image_hsi[..., 2] < p.intensity_upper_limit) &
-        (image_hsi[..., 2] >= p.intensity_lower_limit)
+        (np.abs((image_hsi[..., 0] - p.hue_value + 0.5 % 1) - 0.5)
+         <= p.hue_width / 2)
+        & (image_hsi[..., 1] >= p.saturation_minimum)
+        & (image_hsi[..., 2] < p.intensity_upper_limit)
+        & (image_hsi[..., 2] >= p.intensity_lower_limit)
     )
     all_positive_i = image_hsi[mask_all_positive, 2]
     mask_weak = all_positive_i >= p.intensity_weak_threshold
@@ -211,14 +211,14 @@ def _totals_to_stats(total):
     t = total
     all_positive = t.NumberWeakPositive + t.NumberPositive + t.NumberStrongPositive
     return Output(
-        IntensityAverage=((t.IntensitySumWeakPositive +
-                           t.IntensitySumPositive +
-                           t.IntensitySumStrongPositive) /
-                          all_positive),
+        IntensityAverage=((t.IntensitySumWeakPositive
+                           + t.IntensitySumPositive
+                           + t.IntensitySumStrongPositive)
+                          / all_positive),
         RatioStrongToTotal=t.NumberStrongPositive / all_positive,
         IntensityAverageWeakAndPositive=(
-            (t.IntensitySumWeakPositive + t.IntensitySumPositive) /
-            (t.NumberWeakPositive + t.NumberPositive)
+            (t.IntensitySumWeakPositive + t.IntensitySumPositive)
+            / (t.NumberWeakPositive + t.NumberPositive)
         ),
         **t._asdict()
     )

--- a/histomicstk/utils/eigen.py
+++ b/histomicstk/utils/eigen.py
@@ -33,8 +33,8 @@ def eigen(im_hess):
     v2 = np.zeros((sizeX, sizeY, 2))
 
     # compute eigenvalues of H
-    radical = np.sqrt((im_hess[:, :, 0] - im_hess[:, :, 3]) ** 2 +
-                      4 * im_hess[:, :, 1] ** 2)
+    radical = np.sqrt((im_hess[:, :, 0] - im_hess[:, :, 3]) ** 2
+                      + 4 * im_hess[:, :, 1] ** 2)
     lamda[:, :, 0] = (im_hess[:, :, 0] + im_hess[:, :, 3] + radical) / 2
     lamda[:, :, 1] = (im_hess[:, :, 0] + im_hess[:, :, 3] - radical) / 2
 

--- a/histomicstk/utils/gradient_diffusion.py
+++ b/histomicstk/utils/gradient_diffusion.py
@@ -67,12 +67,12 @@ def gradient_diffusion(im_dx, im_dy, im_fgnd_mask,
         DivY, DivX = np.gradient(Div)
 
         # calculate laplacians of current solution
-        im_vx += dt * (mu * spf.laplace(im_vx) +
-                       (lamda + mu) * DivX +
-                       im_fgnd_mask * (im_dx - im_vx))
-        im_vy += dt * (mu * spf.laplace(im_vy) +
-                       (lamda + mu) * DivY +
-                       im_fgnd_mask * (im_dy - im_vy))
+        im_vx += dt * (mu * spf.laplace(im_vx)
+                       + (lamda + mu) * DivX
+                       + im_fgnd_mask * (im_dx - im_vx))
+        im_vy += dt * (mu * spf.laplace(im_vy)
+                       + (lamda + mu) * DivY
+                       + im_fgnd_mask * (im_dy - im_vy))
 
     # return solution
     return im_vx, im_vy

--- a/histomicstk/utils/sample_pixels.py
+++ b/histomicstk/utils/sample_pixels.py
@@ -56,8 +56,8 @@ def sample_pixels(slide_path, sample_fraction=None, magnification=None,
     """
 
     if (sample_fraction is None) == (sample_approximate_total is None):
-        raise ValueError('Exactly one of sample_fraction and ' +
-                         'sample_approximate_total must have a value.')
+        raise ValueError('Exactly one of sample_fraction and '
+                         + 'sample_approximate_total must have a value.')
 
     ts = large_image.getTileSource(slide_path)
 

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -179,8 +179,8 @@ def _saveJob(event):
         from bson import json_util
 
         jobkwargs = json_util.loads(job['kwargs'])
-        if ('docker_run_args' not in jobkwargs['task'] and
-                'scheduler' in jobkwargs['inputs']):
+        if ('docker_run_args' not in jobkwargs['task']
+                and 'scheduler' in jobkwargs['inputs']):
             jobkwargs['task']['docker_run_args'] = {'ports': {'8787': None}}
             job['kwargs'] = json_util.dumps(jobkwargs)
     except Exception:

--- a/server/handlers.py
+++ b/server/handlers.py
@@ -14,8 +14,8 @@ def process_annotations(event):
     if reference is not None:
         try:
             reference = json.loads(reference)
-            if (isinstance(reference, dict) and
-                    isinstance(reference.get('identifier'), six.string_types)):
+            if (isinstance(reference, dict)
+                    and isinstance(reference.get('identifier'), six.string_types)):
                 identifier = reference['identifier']
         except (ValueError, TypeError):
             logger.warning('Failed to parse data.process reference: %r', reference)


### PR DESCRIPTION
PEP-8 has been updated to recommend breaking a line before a binary operator
instead of before as it had been recommended for years. This modification was
integrated in flake8 3.6 which is used to test HistomicsTK Python code style.

[1] https://www.python.org/dev/peps/pep-0008/#should-a-line-break-before-or-after-a-binary-operator