### PR TITLE
Fix a bug with selecting an ROI.

### DIFF
--- a/web_client/panels/DrawWidget.js
+++ b/web_client/panels/DrawWidget.js
@@ -37,6 +37,7 @@ var DrawWidget = Panel.extend({
         this.annotation = settings.annotation;
         this.collection = this.annotation.elements();
         this.viewer = settings.viewer;
+        this.setViewer(settings.viewer);
         this._drawingType = settings.drawingType || null;
 
         this._highlighted = {};


### PR DESCRIPTION
If an annotation drawing mode was selected, picking the ROI selection tool didn't work correctly as the annotation drawing mode was still active.  This fixes binding the events to toggle off the drawing mode when ROI selection is turned on.