### PR TITLE
Optionally expose the rabbitmq port.

### DIFF
--- a/ansible/Dockerfile-girder-worker
+++ b/ansible/Dockerfile-girder-worker
@@ -42,6 +42,9 @@ RUN ansible-playbook -i inventory/local docker_ansible.yml --extra-vars="docker=
                 /opt/histomicstk/ImageMagick* \
                 /root/.cache/pip
 
+RUN echo 'task_reject_on_worker_lost = True' >> /opt/girder_worker/girder_worker/celeryconfig.py
+RUN echo 'task_acks_late = True' >> /opt/girder_worker/girder_worker/celeryconfig.py
+
 WORKDIR /opt/girder_worker
 
 # If the environment vairable
@@ -52,4 +55,4 @@ CMD sudo -E python /opt/girder_worker/set_environment.py ubuntu tmp_root && \
     sudo mkdir -p /tmp/girder_worker && \
     sudo chmod a+rwx /tmp/girder_worker && \
     sudo -E su ubuntu -c \
-    'python -m girder_worker --concurrency=2 >/opt/logs/worker.log 2>&1'
+    'python -m girder_worker --concurrency=2 -Ofair --prefetch-multiplier=1 >/opt/logs/worker.log 2>&1'

--- a/ansible/deploy_docker.py
+++ b/ansible/deploy_docker.py
@@ -103,6 +103,8 @@ def containers_provision(**kwargs):  # noqa
     if password:
         extra_vars['girder_admin_password'] = password
         extra_vars['girder_no_create_admin'] = True
+    if kwargs.get('worker_api_url'):
+        extra_vars['girder_api_url'] = kwargs['worker_api_url']
     if kwargs.get('cli'):
         extra_vars['cli_image'] = tag_with_version('cli', **kwargs)
         if kwargs['cli'] == 'test':
@@ -916,6 +918,10 @@ if __name__ == '__main__':   # noqa
         '--username', '--user', const='', default=None, nargs='?',
         help='Override the Girder admin username used in provisioning.  Set '
         'to an empty string to be prompted for username and password.')
+    parser.add_argument(
+        '--worker-api-url',
+        help='The alternate Girder API URL used by workers to reach Girder.  '
+        'This defaults to http://histomicstk:8080/api/v1')
     parser.add_argument(
         '--worker-tmp-root', '--tmp', default='/tmp/girder_worker',
         help='The path to use for the girder_worker tmp_root.  This must be '

--- a/ansible/roles/common/set_environment.py
+++ b/ansible/roles/common/set_environment.py
@@ -108,7 +108,7 @@ def adjust_ids(user_name):  # noqa
 def set_hosts():
     """
     Modify the /etc/hosts file to add a dockerhost entry and, if either the
-    HOST_MONGO and HOST_RMQ environment variables are equal to 'true', also
+    HOST_MONGO and HOST_RMQ environment variables are equal to 'true', also add
     the appropriate mongodb and rmq entries.
     """
     hostip = os.popen('netstat -nr').read().split('\n0.0.0.0')[1].strip().split()[0]
@@ -120,9 +120,15 @@ def set_hosts():
         if 'mongodb' not in [line.split()[-1] for line in hosts]:
             hosts.append('%s mongodb' % hostip)
             changed = True
-    if os.environ.get('HOST_RMQ') == 'true':
+    if os.environ.get('HOST_RMQ'):
+        rmqhost = os.environ.get('HOST_RMQ')
+        if rmqhost == 'true':
+            rmqhost = hostip
+        else:
+            import socket
+            rmqhost = socket.gethostbyname(rmqhost)
         if 'rmq' not in [line.split()[-1] for line in hosts]:
-            hosts.append('%s rmq' % hostip)
+            hosts.append('%s rmq' % rmqhost)
             changed = True
     hosts.append('%s dockerhost' % hostip)
     changed = True


### PR DESCRIPTION
Make it easier to start individual containers.

As an example, on one machine, start HistomicsTK and expose the RabbitMQ port: `./deploy_docker.py start --rmqport=5672 --latest --worker-api-url=http://<ip or hostname of this machine>:<port>/api/v1`.  This will start an instance of Girder Worker on that machine (to avoid doing so, pass `--only=histomicstk,rmq,mongodb`).  On a second machine, just start the worker: `./deploy_docker.py start --only=worker --rmq=<hostname or ip address of histomicstk machine> ---latest`.  Each of these start commands should have the appropriate `--mount` options.

Note that the worker machine resolves the hostname of the HistomicsTK machine, so if it has a non-fixed IP address, it will lose contact.

This provides a hostname to the worker docker that is `worker_<mac address>` to ensure workers have different names.  If there is some reason to have multiple girder_worker dockers with the same mac address, we'll need to add an addtional value to this to make it distinct.