### PR TITLE
Allow panning slightly beyond the image.

### DIFF
--- a/ansible/Dockerfile-histomicstk
+++ b/ansible/Dockerfile-histomicstk
@@ -53,7 +53,8 @@ WORKDIR /opt/histomicstk/girder
 EXPOSE 8080
 
 # Install npx and girder node_modules to aid testing
-RUN sudo npm install -g npx 
+RUN sudo npm install -g npx && \
+    sudo chown -R ubuntu:ubuntu /home/ubuntu/.npm
 RUN npm install
 
 # If the environment variable

--- a/web_client/views/body/ImageView.js
+++ b/web_client/views/body/ImageView.js
@@ -155,6 +155,17 @@ var ImageView = View.extend({
                 // store a reference to the underlying viewer
                 this.viewer = this.viewerWidget.viewer;
 
+                this.imageWidth = this.viewer.maxBounds().right;
+                this.imageHeight = this.viewer.maxBounds().bottom;
+                // allow panning off the image slightly
+                var extraPanWidth = 0.1, extraPanHeight = 0;
+                this.viewer.maxBounds({
+                    left: -this.imageWidth * extraPanWidth,
+                    right: this.imageWidth * (1 + extraPanWidth),
+                    top: -this.imageHeight * extraPanHeight,
+                    bottom: this.imageHeight * (1 + extraPanHeight)
+                });
+
                 // set the viewer bounds on first load
                 this.setImageBounds();
 


### PR DESCRIPTION
This makes it easier to pan to the edges of the image since we have panels that overlay the image.

The over-pan is currently set at 10% of the image width and 0% of the image height.  It can be changed easily in the code.

This resolves #581.
