### PR TITLE
Don't show annotations that are too slow to load.

### DIFF
--- a/web_client/views/body/ImageView.js
+++ b/web_client/views/body/ImageView.js
@@ -419,6 +419,11 @@ var ImageView = View.extend({
             }
             annotation.set('loading', true);
             annotation.fetch().then(() => {
+                // abandon this if the annotation should not longer be shown
+                // or we are now showing a different image.
+                if (!annotation.get('displayed') || annotation.get('itemId') !== this.model.id) {
+                    return null;
+                }
                 this.viewerWidget.drawAnnotation(annotation);
                 return null;
             }).always(() => {


### PR DESCRIPTION
If you ask to show an annotation on a slide that is slow to load, then switch to another slide, the annotation would appear on the now wrong slide.  Similarly, if you show an annotation that is slow to load, then hide all annotations, that annotation could still appear once it was loaded.

This checks to make sure it is still appropriate to show an annotation when it finishes loading.