### PR TITLE
Test on Python 3.5 and 3.6.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: python
 python:
   - "2.7"
+  - "3.5"
+  - "3.6"
 
 cache:
   directories:
@@ -70,24 +72,30 @@ before_install:
 
     - CACHE="$HOME/.cache" OPENJPEG_VERSION=2.1.2 OPENJPEG_FILE=v2.1.2.tar.gz OPENJPEG_DIR=openjpeg-2.1.2 LIBTIFF_VERSION=4.0.8 OPENSLIDE_VERSION=3.4.1 source .install-openslide.sh
 
+    - if [ ${TRAVIS_PYTHON_VERSION:0:1} == "3" ]; then export PY3="true"; else export PY2="true"; fi
     - GIRDER_VERSION=2.x-maintenance
     - GIRDER_WORKER_VERSION=master
     - LARGE_IMAGE_VERSION=master
     - SLICER_CLI_WEB_VERSION=master
     - main_path=$PWD
-    - build_path=$PWD/build
+    - build_path=$HOME/build
     - mkdir -p $build_path
 
-    - girder_path=$build_path/girder
+    - girder_path=$HOME/girder
     - rm -fr $girder_path
     - git clone https://github.com/girder/girder.git $girder_path && git -C $girder_path checkout $GIRDER_VERSION
     - ln -sf $main_path $girder_path/plugins/
     - ls -l $girder_path/plugins
 
-    - girder_worker_path=$girder_path/plugins/girder_worker
+    - girder_worker_path=$HOME/girder_worker
     - git clone https://github.com/girder/girder_worker.git $girder_worker_path && git -C $girder_worker_path checkout $GIRDER_WORKER_VERSION
     - cp $PWD/plugin_tests/data/girder_worker.cfg $girder_worker_path/girder_worker/worker.local.cfg
-    - pip install --no-cache-dir -U --upgrade-strategy eager $girder_worker_path'[girder_io,docker]'
+    - if [ -n "${PY3}" ]; then
+      sudo pip2 install --no-cache-dir -U setuptools &&
+      sudo pip2 install --no-cache-dir -U $girder_worker_path'[girder_io,docker]' ;
+      else
+      pip install --no-cache-dir -U $girder_worker_path'[girder_io,docker]' ;
+      fi
 
     - large_image_path=$girder_path/plugins/large_image
     - git clone https://github.com/girder/large_image.git $large_image_path && git -C $large_image_path checkout $LARGE_IMAGE_VERSION
@@ -130,12 +138,18 @@ install:
     - pip freeze  # report what we have installed
 
 script:
-    - mkdir -p $build_path/girder_testing_build
-    - cd $build_path/girder_testing_build
-    - cmake -DPYTHON_COVERAGE:BOOL=${PY_COVG} -DPYTHON_VERSION:STRING=${TRAVIS_PYTHON_VERSION} -DCOVERAGE_MINIMUM_PASS=19 -DJS_COVERAGE_MINIMUM_PASS=19 -DRUN_CORE_TESTS:BOOL="OFF" -DTEST_PLUGINS:STRING="HistomicsTK" $girder_path
+    - cd $girder_worker_path
+    - python2 -m girder_worker >/tmp/worker.out 2>&1 &
+    - cd $build_path
+    - cmake -DPYTHON_COVERAGE:BOOL=${PY_COVG} -DPYTHON_EXECUTABLE:FILEPATH="`which python`" -DPYTHON_VERSION:STRING=${TRAVIS_PYTHON_VERSION} -DRUN_CORE_TESTS:BOOL="OFF" -DTEST_PLUGINS:STRING="HistomicsTK" $girder_path
     - make -j 5
     - JASMINE_TIMEOUT=15000 ctest -VV -j 3
     - travis-sphinx build --source=$main_path/docs
+
+after_failure:
+  # On failures, show the worker output and other information
+  - pip freeze
+  - cat /tmp/worker.out
 
 after_success:
     - bash <(curl -s https://codecov.io/bash) -R $main_path -s $girder_path

--- a/histomicstk/segmentation/rag_color.py
+++ b/histomicstk/segmentation/rag_color.py
@@ -1,5 +1,4 @@
 import numpy as np
-from sets import Set
 
 
 def rag_color(adj_mat):
@@ -51,8 +50,8 @@ def rag_color(adj_mat):
             if NeighborColors.size > 0:
 
                 # find lowest legal color of node 'i'
-                Reference = Set(range(1, ColorCount+1))
-                Diff = Reference.difference(Set(NeighborColors))
+                Reference = set(range(1, ColorCount+1))
+                Diff = Reference.difference(set(NeighborColors))
                 if len(Diff) == 0:
                     ColorCount += 1
                     Colors[i] = ColorCount

--- a/plugin_tests/cli_common_test.py
+++ b/plugin_tests/cli_common_test.py
@@ -130,7 +130,8 @@ class CliCommonTest(unittest.TestCase):
             'min_nucleus_area': 25,
             'local_max_search_radius': 8,
 
-            'scheduler': None,
+            # In Python 3 unittesting, the scheduler fails if it uses processes
+            'scheduler': 'multithreading',  # None,
             'num_workers': -1,
             'num_threads_per_worker': 1,
         }

--- a/plugin_tests/cli_results_test.py
+++ b/plugin_tests/cli_results_test.py
@@ -44,7 +44,7 @@ def tearDownModule():
 
 
 class CliResultsTest(unittest.TestCase):
-    def _runTest(self, cli_args=(), cli_kwargs={}, outputs={},
+    def _runTest(self, cli_args=(), cli_kwargs={}, outputs={},  # noqa
                  contains=[], excludes=[]):
         """
         Test a cli by calling runpy.  Ensure that output files match a
@@ -127,7 +127,7 @@ class CliResultsTest(unittest.TestCase):
                         sys.stderr.write('File hash mismatch: %s\n' % outpath)
                         raise
                 if 'contains' in options:
-                    data = open(outpath, 'rb').read(chunkSize)
+                    data = open(outpath, 'rt').read(chunkSize)
                     for entry in options['contains']:
                         self.assertIn(entry, data)
         except Exception:
@@ -203,7 +203,7 @@ class CliResultsTest(unittest.TestCase):
             cli_args=[
                 'ColorDeconvolution',
                 os.path.join(TEST_DATA_DIR, 'Easy1.png'),
-            ] + ['tmp_out_{}.png'.format(i) for i in 1, 2, 3],
+            ] + ['tmp_out_{}.png'.format(i) for i in (1, 2, 3)],
             outputs={
                 'tmp_out_1.png': dict(
                     hash='ea11f89a7e6752f1d831113472bf78e10d2eff50454ecd76474d7d5ba02e495c',

--- a/plugin_tests/color_normalization_test.py
+++ b/plugin_tests/color_normalization_test.py
@@ -73,7 +73,8 @@ class ReinhardNormalizationTest(unittest.TestCase):
 
         # create dask client
         args = {
-            'scheduler': None,
+            # In Python 3 unittesting, the scheduler fails if it uses processes
+            'scheduler': 'multithreading',  # None,
             'num_workers': -1,
             'num_threads_per_worker': 1,
         }
@@ -105,7 +106,8 @@ class BackgroundIntensityTest(unittest.TestCase):
 
         # create dask client
         args = {
-            'scheduler': None,
+            # In Python 3 unittesting, the scheduler fails if it uses processes
+            'scheduler': 'multithreading',  # None,
             'num_workers': -1,
             'num_threads_per_worker': 1,
         }

--- a/plugin_tests/histomicstk_test.py
+++ b/plugin_tests/histomicstk_test.py
@@ -218,7 +218,7 @@ class HistomicsTKCoreTest(base.TestCase):
         endTime = time.time() + 180  # maxTimeout
         while time.time() < endTime:
             resp = self.request(path='/HistomicsTK/HistomicsTK/docker_image', user=self.admin)
-            if resp.output_status.startswith('200') and len(resp.json) == 1:
+            if resp.output_status.startswith(b'200') and len(resp.json) == 1:
                 break
             time.sleep(1)
 

--- a/plugin_tests/web_client_test.py
+++ b/plugin_tests/web_client_test.py
@@ -134,7 +134,7 @@ class WebClientTestCase(web_client_test.WebClientTestCase):
             user, 'user', filters={'name': 'Public'}
         ).next()
 
-        with open(TEST_FILE) as f:
+        with open(TEST_FILE, 'rb') as f:
             file = self.uploadFile('image', f.read(), user, publicFolder)
 
         item = self.model('item').load(file['itemId'], force=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ tensorflow>=1.11
 #
 # dask packages
 #
-dask>=0.17.2
+dask>=1.1.0
 distributed>=1.21.6
 tornado
 

--- a/server/handlers.py
+++ b/server/handlers.py
@@ -47,7 +47,7 @@ def process_annotations(event):
             return
 
         try:
-            data = json.loads(''.join(File.download(file)()))
+            data = json.loads(b''.join(File.download(file)()).decode('utf8'))
         except Exception:
             logger.error('Could not parse annotation file')
             raise


### PR DESCRIPTION
This makes a number of changes to by Python 3 compatible.  It also updates to Dask 1.1.

Note that namedtuples, as of Python 3.5.1, no longer have a __dict__ attribute, so `vars(<namedtuple>)` no longer works.  Instead, the documented conversion to a dictionary is done via `<namedtuple>._asdict()`.