### PR TITLE
Specify girder worker concurrency in deploy_docker.py.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ WORKDIR $htk_path
 # Install HistomicsTK and its dependencies
 #   Upgrade setuptools, as the version in Conda won't upgrade cleanly unless it
 # is ignored.
-RUN pip install --no-cache-dir --upgrade --ignore-installed pip setuptools && \
+RUN pip install --no-cache-dir --upgrade --ignore-installed pip 'setuptools<40.8.0' && \
     pip install --no-cache-dir --upgrade 'git+https://github.com/cdeepakroy/ctk-cli' && \
     # Install requirements.txt via pip; installing via conda causes
     # version issues with our home-built libtiff.
@@ -40,7 +40,7 @@ RUN pip install --no-cache-dir --upgrade --ignore-installed pip setuptools && \
     # Install HistomicsTK
     python setup.py install && \
     # Create separate virtual environments with CPU and GPU versions of tensorflow
-    pip install --no-cache-dir virtualenv && \
+    pip install --no-cache-dir 'virtualenv<16.4.0' && \
     virtualenv --system-site-packages /venv-gpu && \
     chmod +x /venv-gpu/bin/activate && \
     /venv-gpu/bin/pip install --no-cache-dir tensorflow-gpu>=1.3.0 && \

--- a/ansible/Dockerfile-girder-worker
+++ b/ansible/Dockerfile-girder-worker
@@ -55,4 +55,4 @@ CMD sudo -E python /opt/girder_worker/set_environment.py ubuntu tmp_root && \
     sudo mkdir -p /tmp/girder_worker && \
     sudo chmod a+rwx /tmp/girder_worker && \
     sudo -E su ubuntu -c \
-    'python -m girder_worker --concurrency=2 -Ofair --prefetch-multiplier=1 >/opt/logs/worker.log 2>&1'
+    'python -m girder_worker --concurrency="${GIRDER_WORKER_CONCURRENCY:-2}" -Ofair --prefetch-multiplier=1 >/opt/logs/worker.log 2>&1'

--- a/ansible/deploy_docker.py
+++ b/ansible/deploy_docker.py
@@ -384,6 +384,8 @@ def container_start_worker(client, env, key='worker', rmq='docker', **kwargs):
         else:
             env['HOST_RMQ'] = 'true' if rmq == 'host' else rmq
         env['GIRDER_WORKER_TMP_ROOT'] = worker_tmp_root
+        if 'concurrency' in kwargs:
+            env['GIRDER_WORKER_CONCURRENCY'] = kwargs['concurrency']
         params = {
             'image': image,
             'detach': True,
@@ -843,6 +845,9 @@ if __name__ == '__main__':   # noqa
     parser.add_argument(
         '--no-cli', dest='cli', action='store_false',
         help='Do not pull or install the HistomicsTK cli docker image.')
+    parser.add_argument(
+        '--concurrency', '-j', type=int,
+        help='Girder worker concurrency.')
     parser.add_argument(
         '--conf', '--cfg', '--girder-cfg',
         help='Merge a Girder configuration file with the default '


### PR DESCRIPTION
This is a command line option to start girder_worker with a specified concurrency.  It still defaults to 2.