### PR TITLE
Fix the xml spec for ComputeNucleiFeatures and NucleiClassification.

### DIFF
--- a/server/ComputeNucleiFeatures/ComputeNucleiFeatures.xml
+++ b/server/ComputeNucleiFeatures/ComputeNucleiFeatures.xml
@@ -25,7 +25,7 @@
       <longflag>analysis_roi</longflag>
       <default>-1,-1,-1,-1</default>
     </region>
-    <file fileExtensions=".csv,.h5">
+    <file fileExtensions=".csv|.h5">
       <name>outputNucleiFeatureFile</name>
       <label>Output Nuclei Feature file</label>
       <channel>output</channel>
@@ -210,6 +210,7 @@
       <name>ignore_border_nuclei</name>
       <label>Ignore Border Nuclei</label>
       <description>Ignore/drop nuclei touching the image/tile border</description>
+      <longflag>ignore_border_nuclei</longflag>
       <default>false</default>
     </boolean>
     <string-enumeration>

--- a/server/NucleiClassification/NucleiClassification.xml
+++ b/server/NucleiClassification/NucleiClassification.xml
@@ -25,7 +25,7 @@
       <index>1</index>
       <description>Pickled file (*.pkl) of the scikit-learn model for classifying nuclei</description>
     </file>
-    <file fileExtensions=".csv,.h5">
+    <file fileExtensions=".csv|.h5">
       <name>inputNucleiFeatureFile</name>
       <label>Input Nuclei Feature File</label>
       <channel>input</channel>


### PR DESCRIPTION
For multiple possible file extensions, extensions should be separated by `|` not `,`.

For ComputeNucleiFeatures, ignore_border_nuclei was missing the `longflag`.