### PR TITLE
Reduce files in the HistomicsTK docker image.

### DIFF
--- a/ansible/Dockerfile-histomicstk
+++ b/ansible/Dockerfile-histomicstk
@@ -39,7 +39,8 @@ RUN ansible-playbook -i inventory/local docker_ansible.yml --extra-vars=docker=h
                 /home/ubuntu/.cache \
                 /home/ubuntu/.ansible* \
                 /home/ubuntu/.wget-hsts \
-                /root/.npm /opt/histomicstk/girder/node_modules \
+                /root/.npm \
+                /opt/histomicstk/girder/node_modules \
                 /opt/histomicstk/openjpeg-* \
                 /opt/histomicstk/openslide-* \
                 /opt/histomicstk/tiff-* \
@@ -54,8 +55,13 @@ EXPOSE 8080
 
 # Install npx and girder node_modules to aid testing
 RUN sudo npm install -g npx && \
-    sudo chown -R ubuntu:ubuntu /home/ubuntu/.npm
-RUN npm install
+    sudo rm -rf /home/ubuntu/.npm && \
+    sudo chown -R root:root /usr/lib/node_modules
+
+RUN npm install && \
+    sudo rm -rf /home/ubuntu/.npm \
+                /root/.npm \
+                /opt/histomicstk/girder/node_modules
 
 # If the environment variable
 #   HOST_MONGO=true

--- a/devops/build.sh
+++ b/devops/build.sh
@@ -2,6 +2,7 @@
 
 docker exec -it histomicstk_histomicstk bash -c "
      cd /opt/histomicstk/build && \
+     girder-install web --dev && \
      cmake -DRUN_CORE_TESTS:BOOL=OFF \
            -DGIRDER_EXTERNAL_DATA_STORE:PATH=/data \
            -DTEST_PLUGINS:STRING=HistomicsTK \


### PR DESCRIPTION
When we added some code to make it easier to run cmake tests in the HistomicsTK docker image, this also added ~40,000 files to the image.  Because of how docker works, we could possibly chown these files on initial startup, and this process can be slow on some systems.

This undoes those additions -- some files are chown to root; others are removed.

This means, to run the full tests, you will need to run `girder-install web --dev` at least once within the docker.  The `devops/build.sh` script has been updated to reflect this.