### PR TITLE
Allow using large_image from master or from pypi.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,8 @@ RUN pip install --no-cache-dir --upgrade --ignore-installed pip setuptools && \
     pip install --force-reinstall --ignore-installed --upgrade 'git+https://github.com/manthey/pylibtiff@0d89ae2edd37db6c84d0add7ba89ad4b87a0f4e9' && \
     # Install large_image
     pip install --no-cache-dir 'git+https://github.com/girder/large_image#egg=large_image[openslide,memcached]' && \
+    # We could, instead, use large_image from pypi:
+    # pip install --no-cache-dir 'large-image[memcached,openslide,tiff,pil]' && \
     # Install HistomicsTK
     python setup.py install && \
     # Create separate virtual environments with CPU and GPU versions of tensorflow

--- a/server/cli_common/utils.py
+++ b/server/cli_common/utils.py
@@ -14,10 +14,10 @@ import large_image
 
 # These defaults are only used if girder is not present
 # Use memcached by default.
-large_image.cache_util.cachefactory.defaultConfig['cache_backend'] = 'memcached'
+large_image.config.setConfig('cache_backend', 'memcached')
 # If memcached is unavilable, specify the fraction of memory that python
 # caching is allowed to use.  This is deliberately small.
-large_image.cache_util.cachefactory.defaultConfig['cache_python_memory_portion'] = 32
+large_image.config.setConfig('cache_python_memory_portion', 32)
 
 
 def get_stain_vector(args, index):


### PR DESCRIPTION
This changes how we set config values to a branch-generic manner.