### PR TITLE
Explicitly install requests[security].

### DIFF
--- a/ansible/roles/girder-histomicstk/tasks/main.yml
+++ b/ansible/roles/girder-histomicstk/tasks/main.yml
@@ -89,7 +89,7 @@
   become: true
 
 - name: Install requests (needed to resolve conflict with docker-py)
-  pip: name=requests version=2.10.0
+  pip: name=requests[security]
   become: true
 
 - name: Install ctk-cli using pip


### PR DESCRIPTION
I'm not sure why this has become required in the last few days, but as of at least yesterday, the docker build was failing without this.