### PR TITLE
Allow the zoom panel to go to round values.

### DIFF
--- a/web_client/templates/panels/zoomWidget.pug
+++ b/web_client/templates/panels/zoomWidget.pug
@@ -14,7 +14,7 @@ block content
         - var text = val;
       else
         - var text = 'Fit';
-        - val = Math.pow(2, min);
+        - val = minMag;
       .btn-group
         button.btn.btn-default.h-zoom-button(type="button", data-value=val, class={'btn-sm': val > maxNaturalMag}) #{text}
   .h-download-button-container


### PR DESCRIPTION
Because of how we were implementing the zoom slider, it would often show inexact values even after you clicked on an exact magnification (for instance, clinking on "20" might result in showing "19.9").  This fixes that by using aligned values.

Also, respond to the zoom slider dynamically.