### PR TITLE
Better handle long annotation group and label names.

### DIFF
--- a/web_client/stylesheets/panels/annotationSelector.styl
+++ b/web_client/stylesheets/panels/annotationSelector.styl
@@ -44,6 +44,8 @@
   padding 2px
   border-style none
   border-width 0
+  white-space nowrap
+  overflow hidden
 
   i
     margin-right 2px

--- a/web_client/stylesheets/panels/drawWidget.styl
+++ b/web_client/stylesheets/panels/drawWidget.styl
@@ -12,6 +12,12 @@
 
         .h-element-label
             margin-left 5px
+            white-space nowrap
+            overflow hidden
+            display inline-block
+            vertical-align top
+            max-width calc(100% - 50px)
+            text-overflow ellipsis
 
         .h-delete-element
             float right

--- a/web_client/templates/panels/annotationSelector.pug
+++ b/web_client/templates/panels/annotationSelector.pug
@@ -26,11 +26,11 @@ block content
     - var expandedClass = expanded ? 'h-group-expanded' : 'h-group-collapsed';
     .h-annotation-group(class=[expandedClass], data-group-name=groupName)
       .h-annotation-group-name.clearfix
-        = groupName
         if expanded
           i.icon-folder-open
         else
           i.icon-folder
+        = groupName
       if expanded
         - var admin = user && user.get && user.get('admin');
         each annotation in annotations


### PR DESCRIPTION
Long annotation group or label names would take multiple lines and move control icons to odd spots.