### PR TITLE
Fix transparency slider issue #618.

### DIFF
--- a/web_client/views/body/ImageView.js
+++ b/web_client/views/body/ImageView.js
@@ -137,7 +137,9 @@ var ImageView = View.extend({
                 el: this.$('.h-image-view-container'),
                 itemId: this.model.id,
                 hoverEvents: true,
-                highlightFeatureSizeLimit: 1000,
+                // it is very confusing if this value is smaller than the
+                // AnnotationSelector MAX_ELEMENTS_LIST_LENGTH
+                highlightFeatureSizeLimit: 5000,
                 scale: {position: {bottom: 20, right: 10}}
             });
             this.trigger('h:viewerWidgetCreated', this.viewerWidget);


### PR DESCRIPTION
This issue was caused by only allowing changes to opacity for annotation sets with less than 1000 elements, but allowing editing with annotations with up to 5000 elements.

We should test changing opacity on very large sets, as it probably is still performant and the limit could be raised further or removed entirely.

For now, the limit has been raised to be the same as the editable limit.

This resolves #618.