### PR TITLE
Speed up draw widget rendering by using native tooltips.

### DIFF
--- a/web_client/templates/panels/drawWidget.pug
+++ b/web_client/templates/panels/drawWidget.pug
@@ -37,6 +37,6 @@ block content
         - element = element.toJSON();
         - var label = (element.label || {}).value || (element.type === 'polyline' ? (element.closed ? 'polygon' : 'line') : element.type);
         .h-element(data-id=element.id, class=classes)
-          span.icon-cog.h-edit-element(data-toggle='tooltip', title='Change style')
-          span.h-element-label #{label}
-          span.icon-cancel.h-delete-element(data-toggle='tooltip', title='Remove')
+          span.icon-cog.h-edit-element(title='Change style')
+          span.h-element-label(title=label) #{label}
+          span.icon-cancel.h-delete-element(title='Remove')


### PR DESCRIPTION
When we render the draw widget with the list of annotation elements, about 3/4 of the render time is spent setting up Bootstrap tooltips.  While these look nicer than native tooltips, it isn't worth multiple seconds of delay.

We could have a threshold where if there are a few elements, we use fancy tooltips, and don't for many elements.  Here, I've just de-bootstrapped the tooltips.