### PR TITLE
Add import and export of groups.

### DIFF
--- a/web_client/panels/DrawWidget.js
+++ b/web_client/panels/DrawWidget.js
@@ -223,7 +223,10 @@ var DrawWidget = Panel.extend({
     },
 
     _styleGroupEditor() {
-        editStyleGroups(this._style, this._groups);
+        var dlg = editStyleGroups(this._style, this._groups);
+        dlg.$el.on('hidden.bs.modal', () => {
+            this.render();
+        });
     },
 
     _highlightElement(evt) {

--- a/web_client/stylesheets/dialogs/editStyleGroups.styl
+++ b/web_client/stylesheets/dialogs/editStyleGroups.styl
@@ -2,3 +2,10 @@ select.h-group-name
   appearance none
 .h-btn-left
   float left
+#h-export-link
+  visibility hidden
+#h-import-groups
+  display none
+#h-import-replace
+  margin 0 0 0 5px
+  vertical-align middle

--- a/web_client/templates/dialogs/confirmDialog.pug
+++ b/web_client/templates/dialogs/confirmDialog.pug
@@ -9,6 +9,6 @@
       p
         = message
     .modal-footer
-      button.btn.btn-small.btn-default(type='button', data-dismiss='modal') Cancel
-      button.btn.btn-small.btn-danger.h-submit(type='submit')
+      button.btn.btn-default(type='button', data-dismiss='modal') Cancel
+      button.btn.btn-danger.h-submit(type='submit')
         = submitButton

--- a/web_client/templates/dialogs/editElement.pug
+++ b/web_client/templates/dialogs/editElement.pug
@@ -35,5 +35,5 @@
               i
         .g-validation-failed-message.hidden
       .modal-footer
-        button.btn.btn-small.btn-default(type='button', data-dismiss='modal') Cancel
-        button.btn.btn-small.btn-primary.h-submit(type='submit') Save
+        button.btn.btn-default(type='button', data-dismiss='modal') Cancel
+        button.btn.btn-primary.h-submit(type='submit') Save

--- a/web_client/templates/dialogs/editRegionOfInterest.pug
+++ b/web_client/templates/dialogs/editRegionOfInterest.pug
@@ -34,7 +34,7 @@
       .modal-footer
         span#h-msgDisable.g-validation-failed-message
           | Size > 1GB : Please select a smaller area.
-        a#h-download-area-link.h-download-link.btn.btn-small.btn-primary
+        a#h-download-area-link.h-download-link.btn.btn-primary
           i.icon-download
           |  Download
-        button.btn.btn-small.btn-default(data-dismiss='modal') Cancel
+        button.btn.btn-default(data-dismiss='modal') Cancel

--- a/web_client/templates/dialogs/editStyleGroups.pug
+++ b/web_client/templates/dialogs/editStyleGroups.pug
@@ -52,8 +52,13 @@
               i
         .g-validation-failed-message.hidden
       .modal-footer
-        button#h-reset-defaults.btn.btn-small.btn-default.h-btn-left(type='button') Reset to Defaults
+        button#h-reset-defaults.btn.btn-sm.btn-default.h-btn-left(type='button') Reset to Defaults
         if user.get && user.get('admin')
-          button#h-set-defaults.btn.btn-small.btn-default.h-btn-left(type='button') Save as Defaults
-        button.btn.btn-small.btn-default.h-cancel(type='button', data-dismiss='modal') Cancel
-        button.btn.btn-small.btn-primary.h-submit(type='submit') Save
+          button#h-set-defaults.btn.btn-sm.btn-default.h-btn-left(type='button') Save as Defaults
+        button#h-export.btn.btn-sm.btn-default.h-btn-left(type='button') Export
+          a#h-export-link(download='histomicstk_groups.json')
+        button#h-import.btn.btn-sm.btn-default.h-btn-left(type='button', title='Completely replace all styles if checked; add to and modify existsing styles if unchecked') Import
+          input#h-import-replace(type='checkbox')
+        input#h-import-groups(type='file', name='import-groups')
+        button.btn.btn-default.h-cancel(type='button', data-dismiss='modal') Cancel
+        button.btn.btn-primary.h-submit(type='submit') Save

--- a/web_client/templates/dialogs/saveAnnotation.pug
+++ b/web_client/templates/dialogs/saveAnnotation.pug
@@ -35,6 +35,6 @@
         .g-validation-failed-message.hidden
       .modal-footer
         if hasAdmin
-          button.btn.btn-small.btn-warning.h-access(type='button') Permissions
-        button.btn.btn-small.btn-default.h-cancel(type='button', data-dismiss='modal') Cancel
-        button.btn.btn-small.btn-primary.h-submit(type='submit') Save
+          button.btn.btn-warning.h-access(type='button') Permissions
+        button.btn.btn-default.h-cancel(type='button', data-dismiss='modal') Cancel
+        button.btn.btn-primary.h-submit(type='submit') Save

--- a/web_client/templates/panels/zoomWidget.pug
+++ b/web_client/templates/panels/zoomWidget.pug
@@ -19,8 +19,8 @@ block content
         button.btn.btn-default.h-zoom-button(type="button", data-value=val, class={'btn-sm': val > maxNaturalMag}) #{text}
   .h-download-button-container
     a#download-view-link.h-download-link
-      button.btn-default.h-download-button.h-download-button-view(type="button", data-toggle="tooltip", title="Download current view")
+      button.btn-default.btn-sm.h-download-button.h-download-button-view(type="button", data-toggle="tooltip", title="Download current view")
         | #{title_download_view}
 
-    button.btn-default.h-download-button.h-download-button-area(type="button", data-toggle="tooltip", title="Draw the region of interest")
+    button.btn-default.btn-sm.h-download-button.h-download-button-area(type="button", data-toggle="tooltip", title="Draw the region of interest")
       | #{title_download_area}


### PR DESCRIPTION
Make button styles more consistent.

Note that this also fixes a small bug where if you canceled the Edit Style Groups dialog, the draw widget panel could show the wrong groups until it was next refreshed.

This resolves #621.