### PR TITLE
Speed up annotations.

### DIFF
--- a/plugin_tests/client/annotationSpec.js
+++ b/plugin_tests/client/annotationSpec.js
@@ -518,6 +518,9 @@ $(function () {
 
                 // make sure all groups are expanded
                 $('.h-annotation-selector .h-group-collapsed .h-annotation-group-name').click();
+                waitsFor(function () {
+                    return !$('.h-annotation-selector').hasClass('h-group-collapsed');
+                }, 'groups to expand');
             });
 
             it('collapse an annotation group', function () {
@@ -525,10 +528,15 @@ $(function () {
                 expect($el.length).toBe(1);
                 $el.find('.h-annotation-group-name').click();
 
-                $el = $('.h-annotation-selector .h-annotation-group[data-group-name="Other"]');
-                expect($el.hasClass('h-group-collapsed')).toBe(true);
-                expect($el.hasClass('h-group-expanded')).toBe(false);
-                expect($el.find('.h-annotation').length).toBe(0);
+                waitsFor(function () {
+                    $el = $('.h-annotation-selector .h-annotation-group[data-group-name="Other"]');
+                    return $el.hasClass('h-group-collapsed');
+                }, 'group to collapse');
+                runs(function () {
+                    expect($el.hasClass('h-group-collapsed')).toBe(true);
+                    expect($el.hasClass('h-group-expanded')).toBe(false);
+                    expect($el.find('.h-annotation').length).toBe(0);
+                });
             });
 
             it('expand an annotation group', function () {
@@ -536,10 +544,15 @@ $(function () {
                 expect($el.length).toBe(1);
                 $el.find('.h-annotation-group-name').click();
 
-                $el = $('.h-annotation-selector .h-annotation-group[data-group-name="Other"]');
-                expect($el.hasClass('h-group-collapsed')).toBe(false);
-                expect($el.hasClass('h-group-expanded')).toBe(true);
-                expect($el.find('.h-annotation').length).toBeGreaterThan(0);
+                waitsFor(function () {
+                    $el = $('.h-annotation-selector .h-annotation-group[data-group-name="Other"]');
+                    return $el.hasClass('h-group-expanded');
+                }, 'group to expand');
+                runs(function () {
+                    expect($el.hasClass('h-group-collapsed')).toBe(false);
+                    expect($el.hasClass('h-group-expanded')).toBe(true);
+                    expect($el.find('.h-annotation').length).toBeGreaterThan(0);
+                });
             });
 
             it('ensure user cannot remove the admin annotation', function () {
@@ -923,6 +936,10 @@ $(function () {
                     var $el = $('.h-annotation-selector');
                     return $el.find('.icon-spin3').length === 0;
                 }, 'loading spinners to disappear');
+                waitsFor(function () {
+                    var $el = $('.h-annotation-selector .h-annotation:contains("rectangle")');
+                    return $el.find('.icon-eye.h-toggle-annotation').length === 1;
+                }, 'annotation list to render');
                 runs(function () {
                     var $el = $('.h-annotation-selector .h-annotation:contains("rectangle")');
                     expect($el.find('.icon-eye.h-toggle-annotation').length).toBe(1);

--- a/web_client/templates/panels/annotationSelector.pug
+++ b/web_client/templates/panels/annotationSelector.pug
@@ -47,22 +47,22 @@ block content
               span.icon-spin3.animate-spin.h-float-left
             else if displayed
               span.icon-eye.h-toggle-annotation.h-float-left(
-                data-toggle='tooltip', title='Hide annotation')
+                title='Hide annotation')
             else
               span.icon-eye-off.h-toggle-annotation.h-float-left(
-                data-toggle='tooltip', title='Show annotation')
+                title='Show annotation')
             span.h-annotation-name(title=name) #{name}
 
             span.h-annotation-right
               if writeAccess(annotation)
                 span.icon-cancel.h-delete-annotation(
-                    data-toggle='tooltip', title='Remove annotation')
+                    title='Remove annotation')
                 span.icon-cog.h-edit-annotation-metadata(
-                    data-toggle='tooltip', title='Edit annotation')
+                    title='Edit annotation')
               a(href=annotation.downloadUrl().replace(/\/download$/, ''),
                   download=name + '.json')
                 span.icon-download.h-download-annotation(
-                    data-toggle='tooltip', title='Download annotation')
+                    title='Download annotation')
 
   .checkbox.h-annotation-toggle
     label(title='Show annotation labels when hovering with the mouse.')

--- a/web_client/views/body/ImageView.js
+++ b/web_client/views/body/ImageView.js
@@ -586,7 +586,9 @@ var ImageView = View.extend({
     },
 
     mouseResetAnnotation() {
-        this.popover.collection.reset();
+        if (this.popover.collection.length) {
+            this.popover.collection.reset();
+        }
     },
 
     mouseClickAnnotation(element, annotationId, evt) {
@@ -755,7 +757,9 @@ var ImageView = View.extend({
             left = Math.max(left, 0);
 
             menu.css({ left, top });
-            this.popover.collection.reset();
+            if (this.popover.collection.lenth) {
+                this.popover.collection.reset();
+            }
             this._contextMenuActive = true;
         }, 1);
     },
@@ -766,7 +770,9 @@ var ImageView = View.extend({
         }
         this.$('#h-annotation-context-menu').addClass('hidden');
         this._resetSelection();
-        this.popover.collection.reset();
+        if (this.popover.collection.lenth) {
+            this.popover.collection.reset();
+        }
         this._contextMenuActive = false;
     },
 
@@ -811,7 +817,9 @@ var ImageView = View.extend({
 
     _resetSelection() {
         this.viewerWidget.highlightAnnotation();
-        this.selectedElements.reset();
+        if (this.selectedElements.lenth) {
+            this.selectedElements.reset();
+        }
     },
 
     _saveSelection() {


### PR DESCRIPTION
Debounce rendering the annotation selector panel.  Use native tooltips.  Don't reset backbone collections that are empty.