### PR TITLE
Only show innermost polygon in annotation popover

### DIFF
--- a/plugin_tests/client/annotationSpec.js
+++ b/plugin_tests/client/annotationSpec.js
@@ -979,7 +979,14 @@ $(function () {
                     interactor.simulateEvent('mousemove', {
                         map: {x: 45, y: 45}
                     });
+                });
 
+                waitsFor(function () {
+                    var $el = $('#h-annotation-popover-container');
+                    return $el.find('.h-annotation-name').text() !== '';
+                }, 'popup window to update');
+
+                runs(function () {
                     var $el = $('#h-annotation-popover-container');
                     expect($el.hasClass('hidden')).toBe(false);
                     expect($el.find('.h-annotation-name').text()).toBe('rectangle');


### PR DESCRIPTION
This uses the same heuristic as the context menu to determine the
innermost element--the element contain a vertex closest to the mouse
position.  The update is throttled to 100ms/call to prevent blocking too
much on mouse move.  Having many polygons in a single spot will likely
cause performance issues, but hopefully that is unlikely to occur in
real world scenarios.

Fixes #632