### PR TITLE
Enable the Girder settings cache.

### DIFF
--- a/ansible/roles/girder-histomicstk/templates/girder.local.cfg.j2
+++ b/ansible/roles/girder-histomicstk/templates/girder.local.cfg.j2
@@ -60,3 +60,6 @@ cache_python_memory_portion: 8
 cache_memcached_url: "{{ memcached_url }}"
 cache_memcached_username: None
 cache_memcached_password: None
+
+[cache]
+enabled = True


### PR DESCRIPTION
This reduces database queries when serving tiles to cross domains, saving around 10 ms per tile.