### PR TITLE
Restrict some endpoints to require a logged in user.

### DIFF
--- a/ansible/roles/girder-histomicstk/templates/girder.local.cfg.j2
+++ b/ansible/roles/girder-histomicstk/templates/girder.local.cfg.j2
@@ -63,3 +63,8 @@ cache_memcached_password: None
 
 [cache]
 enabled = True
+
+[histomicstk]
+# If restrict_downloads is True, only logged-in users can access download and
+# tiles/images endpoints.
+restrict_downloads = True

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -55,6 +55,13 @@ HistomicsTK can be used in two ways:
     to image analysis pipelines developed as `slicer execution model`_
     CLIs and containerized using Docker.
 
+  HistomicsTK uses Girder's configuration files for some settings under the 
+  `histomicstk` section:
+
+  - `restrict_downloads`: if True, Girder's standard download endpoints and 
+    large_image's `item/{id}/tiles/images/{image}` endpoint are only 
+    available to logged-in users.
+
 For questions, comments, or to get in touch with the maintainers, head to our
 `Discourse forum`_, or use our `Gitter Chatroom`_.
 


### PR DESCRIPTION
This adds a girder configuration value to control if the restriction is added.  When turned on via the grider config value `[histomicstk]` `restrict_downloads: True`, all standard girder download endpoints and the large_image `item/{id}/tiles/images/{image}` endpoint are restricted to logged-in-users.  This is in addition to ordinary ACL restrictions.

The restriction is turned on for our standard deployment.

This resolves #176.