### PR TITLE
Update the context menu after styles are edited.

### DIFF
--- a/web_client/panels/DrawWidget.js
+++ b/web_client/panels/DrawWidget.js
@@ -226,6 +226,7 @@ var DrawWidget = Panel.extend({
         var dlg = editStyleGroups(this._style, this._groups);
         dlg.$el.on('hidden.bs.modal', () => {
             this.render();
+            this.parentView.trigger('h:styleGroupsEdited', this._groups);
         });
     },
 

--- a/web_client/views/body/ImageView.js
+++ b/web_client/views/body/ImageView.js
@@ -73,6 +73,9 @@ var ImageView = View.extend({
             parentView: this,
             collection: this.selectedElements
         });
+        this.listenTo(this, 'h:styleGroupsEdited', () => {
+            this.contextMenu.refetchStyles();
+        });
 
         this.listenTo(this.annotationSelector, 'h:groupCount', (obj) => {
             this.contextMenu.setGroupCount(obj);

--- a/web_client/views/popover/AnnotationContextMenu.js
+++ b/web_client/views/popover/AnnotationContextMenu.js
@@ -24,6 +24,9 @@ const AnnotationContextMenu = View.extend({
         }));
         return this;
     },
+    refetchStyles() {
+        this.styles.fetch().done(() => this.render());
+    },
     setGroupCount(groupCount) {
         this._cachedGroupCount = groupCount;
     },


### PR DESCRIPTION
Before, if you added or removed styles, the context menu could show stale style names.