### PR TITLE
Explicitly install Cython.

### DIFF
--- a/ansible/roles/girder-histomicstk/tasks/main.yml
+++ b/ansible/roles/girder-histomicstk/tasks/main.yml
@@ -96,6 +96,13 @@
     state: present
   become: true
 
+- name: Install Cython (must be installed before HistomicsTK plugin)
+  pip:
+    name: Cython
+    extra_args: "-U --upgrade-strategy eager"
+    state: present
+  become: true
+
 - name: Install numpy (must be installed before large_image plugin)
   pip:
     name: numpy


### PR DESCRIPTION
Some package previous installed Cython as a side effect.  Now we need to explicitly install it.

Fixes #652.