### PR TITLE
Use our local changes to ctk_cli in all places.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -163,6 +163,7 @@ __pycache__/
 env/
 build/
 _build/
+_skbuild/
 develop-eggs/
 dist/
 downloads/

--- a/.travis.yml
+++ b/.travis.yml
@@ -116,19 +116,21 @@ before_install:
 install:
     - cd $girder_path
     - pip install -U --upgrade-strategy eager -r requirements-dev.txt
-    - pip install -U --upgrade-strategy eager -e .[worker]
+    - pip install -U -e .[worker]
     - cd $large_image_path
     - pip install --no-cache-dir 'numpy>=1.12.1'
     - pip install --upgrade --no-cache-dir --force-reinstall --ignore-installed openslide-python Pillow
 
-    - pip install -U --upgrade-strategy eager .[memcached,openslide]
+    - pip install -U .[memcached,openslide]
     - python setup.py install
     - cd $main_path
     - pip install -r requirements_dev.txt
     # needs to be installed in dev mode for it to place binaries of cython/c extensions in place
     - pip install -e .
     - cd $girder_path
-    - pip install -U --upgrade-strategy eager -r $slicer_cli_web_path/requirements.txt
+    - pip install -U -r $slicer_cli_web_path/requirements.txt
+    # Fix versions that were upgraded that shouldn't have been
+    - pip install botocore 'python-dateutil<2.7'
     - npm-install-retry
     - BABEL_ENV=cover NYC_CWD="$main_path" girder-install web --plugins=jobs,worker,large_image,slicer_cli_web,HistomicsTK --dev
     - pip install jupyter sphinx sphinx_rtd_theme nbsphinx travis-sphinx

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,12 +23,9 @@ WORKDIR $htk_path
 # is ignored.
 RUN pip install --no-cache-dir --upgrade --ignore-installed pip setuptools && \
     pip install --no-cache-dir 'bokeh>=0.12.14' && \
-    # Ensure we have the latest pylibtif
-    pip install --force-reinstall --ignore-installed --upgrade 'git+https://github.com/manthey/pylibtiff@0d89ae2edd37db6c84d0add7ba89ad4b87a0f4e9' && \
     # Install large_image
-    pip install --no-cache-dir 'git+https://github.com/girder/large_image#egg=large_image[openslide,memcached]' && \
-    # We could, instead, use large_image from pypi:
-    # pip install --no-cache-dir 'large-image[memcached,openslide,tiff,pil]' && \
+    pip install --no-cache-dir 'large-image[memcached,openslide,tiff,pil]' -f https://manthey.github.io/large_image_wheels && \
+    pip install --no-cache-dir scikit-build setuptools-scm Cython cmake && \
     # Install HistomicsTK
     pip install . && \
     # Create separate virtual environments with CPU and GPU versions of tensorflow

--- a/ansible/Dockerfile-girder-worker
+++ b/ansible/Dockerfile-girder-worker
@@ -16,7 +16,10 @@ RUN adduser --disabled-password --gecos '' ubuntu && \
 USER ubuntu
 ENV LANG en_US.UTF-8
 WORKDIR /home/ubuntu
-RUN git clone --depth=1 https://github.com/DigitalSlideArchive/HistomicsTK && rm -rf HistomicsTK/.git
+RUN git clone --depth=1 --no-checkout https://github.com/DigitalSlideArchive/HistomicsTK && \
+    cd HistomicsTK && \
+    git checkout master -- ansible/ && \
+    rm -rf .git
 WORKDIR /home/ubuntu/HistomicsTK
 ENV GIRDER_EXEC_USER ubuntu
 COPY . /home/ubuntu/HistomicsTK/ansible/.

--- a/ansible/Dockerfile-histomicstk
+++ b/ansible/Dockerfile-histomicstk
@@ -19,7 +19,10 @@ RUN adduser --disabled-password --gecos '' ubuntu && \
 USER ubuntu
 ENV LANG en_US.UTF-8
 WORKDIR /home/ubuntu
-RUN git clone --depth=1 https://github.com/DigitalSlideArchive/HistomicsTK && rm -rf HistomicsTK/.git
+RUN git clone --depth=1 --no-checkout https://github.com/DigitalSlideArchive/HistomicsTK && \
+    cd HistomicsTK && \
+    git checkout master -- ansible/ && \
+    rm -rf .git
 WORKDIR /home/ubuntu/HistomicsTK
 ENV GIRDER_EXEC_USER ubuntu
 COPY . /home/ubuntu/HistomicsTK/ansible/.
@@ -40,6 +43,7 @@ RUN ansible-playbook -i inventory/local docker_ansible.yml --extra-vars=docker=h
                 /home/ubuntu/.ansible* \
                 /home/ubuntu/.wget-hsts \
                 /root/.npm \
+                /opt/histomicstk/logs/*.log \
                 /opt/histomicstk/girder/node_modules \
                 /opt/histomicstk/openjpeg-* \
                 /opt/histomicstk/openslide-* \
@@ -48,6 +52,7 @@ RUN ansible-playbook -i inventory/local docker_ansible.yml --extra-vars=docker=h
                 /opt/histomicstk/ImageMagick* \
                 /opt/histomicstk/HistomicsTK/_skbuild \
                 /opt/histomicstk/large_image/build \
+                /opt/histomicstk/HistomicsTK/.eggs \
                 /root/.cache/pip
 
 WORKDIR /opt/histomicstk/girder
@@ -61,7 +66,8 @@ RUN sudo npm install -g npx && \
 RUN npm install && \
     sudo rm -rf /home/ubuntu/.npm \
                 /root/.npm \
-                /opt/histomicstk/girder/node_modules
+                /opt/histomicstk/girder/node_modules \
+                /tmp/*
 
 # If the environment variable
 #   HOST_MONGO=true

--- a/histomicstk/cli/ctk_cli_adjustment.py
+++ b/histomicstk/cli/ctk_cli_adjustment.py
@@ -1,0 +1,96 @@
+import ctk_cli
+
+
+# This is copied from ctk_cli/module.py with a few changes
+@classmethod  # noqa
+def ctkCliParse(cls, elementTree):  # noqa
+    assert ctk_cli.module._tag(elementTree) in cls.TYPES, "%s not in CLIParameter.TYPES" % ctk_cli.module._tag(elementTree)  # noqa
+
+    self = cls()
+    self.typ = ctk_cli.module._tag(elementTree)
+
+    if self.typ in ('point', 'region'):
+        self._pythonType = float
+    else:
+        elementType = self.typ
+        if elementType.endswith('-vector'):
+            elementType = elementType[:-7]
+        elif elementType.endswith('-enumeration'):
+            elementType = elementType[:-12]
+        self._pythonType = self.PYTHON_TYPE_MAPPING.get(elementType, str)
+
+    self.hidden = ctk_cli.module._parseBool(elementTree.get('hidden', 'false'))
+
+    self.constraints = None
+    self.multiple = None
+    self.elements = None
+    self.coordinateSystem = None
+    self.fileExtensions = None
+    self.reference = None
+    self.subtype = None
+
+    for key, value in elementTree.items():
+        if key == 'multiple':
+            self.multiple = ctk_cli.module._parseBool(value)
+        elif key == 'coordinateSystem' and self.typ in ('point', 'pointfile', 'region'):
+            self.coordinateSystem = value
+        elif key == 'fileExtensions':
+            self.fileExtensions = [ext.strip() for ext in value.split(",")]
+        elif key == 'reference' and self.typ in ('image', 'file', 'transform', 'geometry', 'table'):  # noqa
+            self.reference = value
+            ctk_cli.module.logger.warning("'reference' attribute of %r is not part of the spec yet (CTK issue #623)" % (ctk_cli.module._tag(elementTree), ))  # noqa
+        elif key == 'type':
+            self.subtype = value
+        elif key != 'hidden':
+            ctk_cli.module.logger.warning('attribute of %r ignored: %s=%r' % (ctk_cli.module._tag(elementTree), key, value))  # noqa
+
+    elements = []
+
+    childNodes = ctk_cli.module._parseElements(self, elementTree)
+    for n in childNodes:
+        if ctk_cli.module._tag(n) == 'constraints':
+            self.constraints = ctk_cli.module.CLIConstraints.parse(n)
+        elif ctk_cli.module._tag(n) == 'element':
+            if not n.text:
+                ctk_cli.module.logger.warning("Ignoring empty <element> within <%s>" % (ctk_cli.module._tag(elementTree), ))  # noqa
+            else:
+                elements.append(n.text)
+        else:
+            ctk_cli.module.logger.warning("Element %r within %r not parsed" % (ctk_cli.module._tag(n), ctk_cli.module._tag(elementTree)))  # noqa
+
+    if not self.flag and not self.longflag and self.index is None:
+        ctk_cli.module.logger.warning("Parameter %s cannot be passed (missing one of flag, longflag, or index)!" % (  # noqa
+            self.identifier(), ))
+
+    if self.flag and not self.flag.startswith('-'):
+        self.flag = '-' + self.flag
+    if self.longflag and not self.longflag.startswith('-'):
+        self.longflag = '--' + self.longflag
+
+    if self.index is not None:
+        self.index = int(self.index)
+
+    if self.default:
+        try:
+            self.default = self.parseValue(self.default)
+        except ValueError as e:
+            ctk_cli.module.logger.warning('Could not parse default value of <%s> (%s): %s' % (
+                ctk_cli.module._tag(elementTree), self.name, e))
+
+    if self.typ.endswith('-enumeration'):
+        try:
+            self.elements = list(map(self.parseValue, elements))
+        except ValueError as e:
+            ctk_cli.module.logger.warning('Problem parsing enumeration element values of <%s> (%s): %s' % (  # noqa
+                ctk_cli.module._tag(elementTree), self.name, e))
+        if not elements:
+            ctk_cli.module.logger.warning("No <element>s found within <%s>" % (ctk_cli.module._tag(elementTree), ))  # noqa
+    else:
+        self.elements = None
+        if elements:
+            ctk_cli.module.logger.warning("Ignoring <element>s within <%s>" % (ctk_cli.module._tag(elementTree), ))  # noqa
+
+    return self
+
+
+ctk_cli.module.CLIParameter.parse = ctkCliParse

--- a/histomicstk/cli/utils.py
+++ b/histomicstk/cli/utils.py
@@ -1,6 +1,6 @@
 from argparse import Namespace
 from datetime import timedelta
-import ctk_cli
+from ctk_cli import CLIArgumentParser
 import psutil
 import numpy as np
 import skimage.measure
@@ -9,6 +9,7 @@ import skimage.morphology
 import histomicstk.preprocessing.color_deconvolution as htk_cdeconv
 import histomicstk.segmentation as htk_seg
 import histomicstk.utils as htk_utils
+from histomicstk.cli import ctk_cli_adjustment  # noqa - imported for side effects
 
 import large_image
 
@@ -330,98 +331,6 @@ def sample_pixels(args):
         if args[k] == -1:
             del args[k]
     return htk_utils.sample_pixels(**args)
-
-
-# This is copied from ctk_cli/module.py with a few changes
-class CLIArgumentParser(ctk_cli.CLIArgumentParser):
-    def parse(cls, elementTree):  # noqa
-        assert ctk_cli._tag(elementTree) in cls.TYPES, "%s not in CLIParameter.TYPES" % ctk_cli._tag(elementTree)  # noqa
-
-        self = cls()
-        self.typ = ctk_cli._tag(elementTree)
-
-        if self.typ in ('point', 'region'):
-            self._pythonType = float
-        else:
-            elementType = self.typ
-            if elementType.endswith('-vector'):
-                elementType = elementType[:-7]
-            elif elementType.endswith('-enumeration'):
-                elementType = elementType[:-12]
-            self._pythonType = self.PYTHON_TYPE_MAPPING.get(elementType, str)
-
-        self.hidden = ctk_cli._parseBool(elementTree.get('hidden', 'false'))
-
-        self.constraints = None
-        self.multiple = None
-        self.elements = None
-        self.coordinateSystem = None
-        self.fileExtensions = None
-        self.reference = None
-        self.subtype = None
-
-        for key, value in elementTree.items():
-            if key == 'multiple':
-                self.multiple = ctk_cli._parseBool(value)
-            elif key == 'coordinateSystem' and self.typ in ('point', 'pointfile', 'region'):
-                self.coordinateSystem = value
-            elif key == 'fileExtensions':
-                self.fileExtensions = [ext.strip() for ext in value.split(",")]
-            elif key == 'reference' and self.typ in ('image', 'file', 'transform', 'geometry', 'table'):  # noqa
-                self.reference = value
-                ctk_cli.logger.warning("'reference' attribute of %r is not part of the spec yet (CTK issue #623)" % (ctk_cli._tag(elementTree), ))  # noqa
-            elif key == 'type':
-                self.subtype = value
-            elif key != 'hidden':
-                ctk_cli.logger.warning('attribute of %r ignored: %s=%r' % (ctk_cli._tag(elementTree), key, value))  # noqa
-
-        elements = []
-
-        childNodes = ctk_cli._parseElements(self, elementTree)
-        for n in childNodes:
-            if ctk_cli._tag(n) == 'constraints':
-                self.constraints = ctk_cli.CLIConstraints.parse(n)
-            elif ctk_cli._tag(n) == 'element':
-                if not n.text:
-                    ctk_cli.logger.warning("Ignoring empty <element> within <%s>" % (ctk_cli._tag(elementTree), ))  # noqa
-                else:
-                    elements.append(n.text)
-            else:
-                ctk_cli.logger.warning("Element %r within %r not parsed" % (ctk_cli._tag(n), ctk_cli._tag(elementTree)))  # noqa
-
-        if not self.flag and not self.longflag and self.index is None:
-            ctk_cli.logger.warning("Parameter %s cannot be passed (missing one of flag, longflag, or index)!" % (  # noqa
-                self.identifier(), ))
-
-        if self.flag and not self.flag.startswith('-'):
-            self.flag = '-' + self.flag
-        if self.longflag and not self.longflag.startswith('-'):
-            self.longflag = '--' + self.longflag
-
-        if self.index is not None:
-            self.index = int(self.index)
-
-        if self.default:
-            try:
-                self.default = self.parseValue(self.default)
-            except ValueError as e:
-                ctk_cli.logger.warning('Could not parse default value of <%s> (%s): %s' % (
-                    ctk_cli._tag(elementTree), self.name, e))
-
-        if self.typ.endswith('-enumeration'):
-            try:
-                self.elements = list(map(self.parseValue, elements))
-            except ValueError as e:
-                ctk_cli.logger.warning('Problem parsing enumeration element values of <%s> (%s): %s' % (  # noqa
-                    ctk_cli._tag(elementTree), self.name, e))
-            if not elements:
-                ctk_cli.logger.warning("No <element>s found within <%s>" % (ctk_cli._tag(elementTree), ))  # noqa
-        else:
-            self.elements = None
-            if elements:
-                ctk_cli.logger.warning("Ignoring <element>s within <%s>" % (ctk_cli._tag(elementTree), ))  # noqa
-
-        return self
 
 
 __all__ = (

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -22,6 +22,7 @@ from girder.plugins.slicer_cli_web.docker_resource import DockerResource
 from .handlers import process_annotations
 from .constants import PluginSettings
 from .image_browse_resource import ImageBrowseResource
+from . import ctk_cli_adjustment  # noqa - for side effects
 
 from girder.models.model_base import ModelImporter
 _template = os.path.join(

--- a/server/ctk_cli_adjustment.py
+++ b/server/ctk_cli_adjustment.py
@@ -1,0 +1,96 @@
+import ctk_cli
+
+
+# This is copied from ctk_cli/module.py with a few changes
+@classmethod  # noqa
+def ctkCliParse(cls, elementTree):  # noqa
+    assert ctk_cli.module._tag(elementTree) in cls.TYPES, "%s not in CLIParameter.TYPES" % ctk_cli.module._tag(elementTree)  # noqa
+
+    self = cls()
+    self.typ = ctk_cli.module._tag(elementTree)
+
+    if self.typ in ('point', 'region'):
+        self._pythonType = float
+    else:
+        elementType = self.typ
+        if elementType.endswith('-vector'):
+            elementType = elementType[:-7]
+        elif elementType.endswith('-enumeration'):
+            elementType = elementType[:-12]
+        self._pythonType = self.PYTHON_TYPE_MAPPING.get(elementType, str)
+
+    self.hidden = ctk_cli.module._parseBool(elementTree.get('hidden', 'false'))
+
+    self.constraints = None
+    self.multiple = None
+    self.elements = None
+    self.coordinateSystem = None
+    self.fileExtensions = None
+    self.reference = None
+    self.subtype = None
+
+    for key, value in elementTree.items():
+        if key == 'multiple':
+            self.multiple = ctk_cli.module._parseBool(value)
+        elif key == 'coordinateSystem' and self.typ in ('point', 'pointfile', 'region'):
+            self.coordinateSystem = value
+        elif key == 'fileExtensions':
+            self.fileExtensions = [ext.strip() for ext in value.split(",")]
+        elif key == 'reference' and self.typ in ('image', 'file', 'transform', 'geometry', 'table'):  # noqa
+            self.reference = value
+            ctk_cli.module.logger.warning("'reference' attribute of %r is not part of the spec yet (CTK issue #623)" % (ctk_cli.module._tag(elementTree), ))  # noqa
+        elif key == 'type':
+            self.subtype = value
+        elif key != 'hidden':
+            ctk_cli.module.logger.warning('attribute of %r ignored: %s=%r' % (ctk_cli.module._tag(elementTree), key, value))  # noqa
+
+    elements = []
+
+    childNodes = ctk_cli.module._parseElements(self, elementTree)
+    for n in childNodes:
+        if ctk_cli.module._tag(n) == 'constraints':
+            self.constraints = ctk_cli.module.CLIConstraints.parse(n)
+        elif ctk_cli.module._tag(n) == 'element':
+            if not n.text:
+                ctk_cli.module.logger.warning("Ignoring empty <element> within <%s>" % (ctk_cli.module._tag(elementTree), ))  # noqa
+            else:
+                elements.append(n.text)
+        else:
+            ctk_cli.module.logger.warning("Element %r within %r not parsed" % (ctk_cli.module._tag(n), ctk_cli.module._tag(elementTree)))  # noqa
+
+    if not self.flag and not self.longflag and self.index is None:
+        ctk_cli.module.logger.warning("Parameter %s cannot be passed (missing one of flag, longflag, or index)!" % (  # noqa
+            self.identifier(), ))
+
+    if self.flag and not self.flag.startswith('-'):
+        self.flag = '-' + self.flag
+    if self.longflag and not self.longflag.startswith('-'):
+        self.longflag = '--' + self.longflag
+
+    if self.index is not None:
+        self.index = int(self.index)
+
+    if self.default:
+        try:
+            self.default = self.parseValue(self.default)
+        except ValueError as e:
+            ctk_cli.module.logger.warning('Could not parse default value of <%s> (%s): %s' % (
+                ctk_cli.module._tag(elementTree), self.name, e))
+
+    if self.typ.endswith('-enumeration'):
+        try:
+            self.elements = list(map(self.parseValue, elements))
+        except ValueError as e:
+            ctk_cli.module.logger.warning('Problem parsing enumeration element values of <%s> (%s): %s' % (  # noqa
+                ctk_cli.module._tag(elementTree), self.name, e))
+        if not elements:
+            ctk_cli.module.logger.warning("No <element>s found within <%s>" % (ctk_cli.module._tag(elementTree), ))  # noqa
+    else:
+        self.elements = None
+        if elements:
+            ctk_cli.module.logger.warning("Ignoring <element>s within <%s>" % (ctk_cli.module._tag(elementTree), ))  # noqa
+
+    return self
+
+
+ctk_cli.module.CLIParameter.parse = ctkCliParse

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,6 @@ setup(
     include_package_data=True,
     setup_requires=[
         'setuptools-scm',
-        'pygit2',
         'Cython>=0.25.2',
         'scikit-build>=0.8.1',
         'cmake>=0.6.0',


### PR DESCRIPTION
This PR has some seemingly disparate improvements, all of which help build dockers.
- Reduce the number of files that might need to be chowned in the docker images.
- Fix some issues with building the CLI docker image that were introduced by using setuptools-scm.
- Use our local changes to ctk_cli in all places.  This is done in duplicating a file, which is necessary until we refactor how we use ctk_cli in a more generic manner.
- Pull large image dependencies from the wheels to make use we are using recent versions.