### PR TITLE
Add a Quarantine option.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ build
 _build
 .coverage
 *.egg
+.eggs
 *.egg-info
 .cache
 .idea

--- a/.travis.yml
+++ b/.travis.yml
@@ -62,6 +62,8 @@ before_install:
     # https://github.com/travis-ci/travis-ci/issues/7940
     - sudo rm -f /etc/boto.cfg
 
+    - pip install -U pip
+
     - mkdir -p $HOME/.cache/node_modules || true
     - ln -sf $HOME/.cache/node_modules .
     - nvm install v8

--- a/ansible/Dockerfile-histomicstk
+++ b/ansible/Dockerfile-histomicstk
@@ -11,7 +11,8 @@ RUN apt-get update && \
     && \
     sudo rm -rf /var/lib/apt/lists/* /tmp/*
 RUN pip install -U pip
-RUN pip install -U --upgrade-strategy eager 'ansible<2.5'
+# RUN pip install -U --upgrade-strategy eager 'ansible<2.5'
+RUN pip install ansible
 RUN locale-gen en_US.UTF-8
 RUN adduser --disabled-password --gecos '' ubuntu && \
     adduser ubuntu sudo && \

--- a/ansible/README.rst
+++ b/ansible/README.rst
@@ -127,7 +127,7 @@ Prerequisites
     sudo apt-get update
     sudo apt-get install -y --force-yes libssl-dev git python2.7-dev python-pip
     sudo pip install -U pip
-    sudo pip install -U 'ansible<2.5'
+    sudo pip install -U ansible
     git clone https://github.com/DigitalSlideArchive/HistomicsTK
 
 Deploy

--- a/plugin_tests/client/histomicstkSpec.js
+++ b/plugin_tests/client/histomicstkSpec.js
@@ -76,6 +76,28 @@ describe('Test the HistomicsTK plugin', function () {
             $('#g-histomicstk-banner-default-color').click();
             expect($('#g-histomicstk-banner-color').val() === '#f8f8f8');
         });
+        /* test the quarantine folder */
+        runs(function () {
+            $('.g-open-browser').click();
+        });
+        girderTest.waitForDialog();
+        runs(function () {
+            $('#g-root-selector').val($('#g-root-selector')[0].options[1].value).trigger('change');
+        });
+        waitsFor(function () {
+            return $('.g-folder-list-link').length >= 2;
+        });
+        runs(function () {
+            $('.g-folder-list-link').click();
+        });
+        waitsFor(function () {
+            return $('#g-selected-model').val() !== '';
+        });
+        runs(function () {
+            $('.g-submit-button').click();
+        });
+        girderTest.waitForLoad();
+        /* Cancel the changes */
         runs(function () {
             $('.g-histomicstk-buttons #g-histomicstk-cancel').click();
         });

--- a/plugin_tests/histomicstk_test.py
+++ b/plugin_tests/histomicstk_test.py
@@ -8,7 +8,9 @@ import time
 
 from girder import config
 from girder.constants import AccessType
+from girder.models.folder import Folder
 from girder.models.group import Group
+from girder.models.item import Item
 from girder.models.model_base import ValidationException
 from girder.models.setting import Setting
 from girder.models.user import User
@@ -258,7 +260,7 @@ class HistomicsTKCoreTest(base.TestCase):
             self.assertEqual(len(resp.json), count)
 
     def testRestrictDownloads(self):
-        publicFolder = self.model('folder').childFolders(
+        publicFolder = Folder().childFolders(
             self.user, 'user', filters={'name': 'Public'}
         ).next()
         test_file = os.path.join(
@@ -277,3 +279,88 @@ class HistomicsTKCoreTest(base.TestCase):
         resp = self.request(
             path='/item/%s/tiles/images/noimage' % file['itemId'], user=None)
         self.assertStatus(resp, 401)
+
+    def testQuarantine(self):
+        from girder.plugins.HistomicsTK.constants import PluginSettings
+
+        publicFolder = Folder().childFolders(
+            self.user, 'user', filters={'name': 'Public'}
+        ).next()
+        adminFolder = Folder().childFolders(
+            self.admin, 'user', filters={'name': 'Public'}
+        ).next()
+        privateFolder = Folder().childFolders(
+            self.admin, 'user', filters={'name': 'Private'}, user=self.admin
+        ).next()
+        items = [Item().createItem(name, creator, folder) for name, creator, folder in [
+            ('userPublic1', self.user, publicFolder),
+            ('userPublic2', self.user, publicFolder),
+            ('adminPublic1', self.admin, adminFolder),
+            ('adminPublic2', self.admin, adminFolder),
+            ('adminPrivate1', self.admin, privateFolder),
+            ('adminPrivate2', self.admin, privateFolder),
+        ]]
+        resp = self.request(
+            method='PUT',
+            path='/HistomicsTK/quarantine/%s' % str(items[0]['_id']))
+        self.assertStatus(resp, 401)
+        self.assertIn('Write access denied', resp.json['message'])
+        resp = self.request(
+            method='PUT', user=self.user,
+            path='/HistomicsTK/quarantine/%s' % str(items[0]['_id']))
+        self.assertStatus(resp, 400)
+        self.assertIn('The quarantine folder is not configure', resp.json['message'])
+        key = PluginSettings.HISTOMICSTK_QUARANTINE_FOLDER
+        Setting().set(key, str(privateFolder['_id']))
+        resp = self.request(
+            method='PUT', user=self.user,
+            path='/HistomicsTK/quarantine/%s' % str(items[0]['_id']))
+        self.assertStatusOk(resp)
+        resp = self.request(
+            method='PUT', user=self.user,
+            path='/HistomicsTK/quarantine/%s' % str(items[0]['_id']))
+        self.assertStatus(resp, 403)
+        self.assertIn('Write access denied', resp.json['message'])
+        resp = self.request(
+            method='PUT', user=self.user,
+            path='/HistomicsTK/quarantine/%s' % str(items[2]['_id']))
+        self.assertStatus(resp, 403)
+        self.assertIn('Write access denied', resp.json['message'])
+        resp = self.request(
+            method='PUT', user=self.admin,
+            path='/HistomicsTK/quarantine/%s' % str(items[2]['_id']))
+        self.assertStatusOk(resp)
+        resp = self.request(
+            method='PUT', user=self.admin,
+            path='/HistomicsTK/quarantine/%s' % str(items[4]['_id']))
+        self.assertStatus(resp, 400)
+        self.assertIn('already in the quarantine', resp.json['message'])
+        # Restore
+        resp = self.request(
+            method='PUT', user=self.admin,
+            path='/HistomicsTK/quarantine/%s/restore' % str(items[1]['_id']))
+        self.assertStatus(resp, 400)
+        self.assertIn('no quarantine record', resp.json['message'])
+        resp = self.request(
+            method='PUT',
+            path='/HistomicsTK/quarantine/%s/restore' % str(items[0]['_id']))
+        self.assertStatus(resp, 401)
+        self.assertIn('Write access denied', resp.json['message'])
+        resp = self.request(
+            method='PUT', user=self.user,
+            path='/HistomicsTK/quarantine/%s/restore' % str(items[0]['_id']))
+        self.assertStatus(resp, 403)
+        self.assertIn('Write access denied', resp.json['message'])
+        resp = self.request(
+            method='PUT', user=self.admin,
+            path='/HistomicsTK/quarantine/%s/restore' % str(items[0]['_id']))
+        self.assertStatusOk(resp)
+        resp = self.request(
+            method='PUT', user=self.admin,
+            path='/HistomicsTK/quarantine/%s/restore' % str(items[0]['_id']))
+        self.assertStatus(resp, 400)
+        self.assertIn('no quarantine record', resp.json['message'])
+        resp = self.request(
+            method='PUT', user=self.user,
+            path='/HistomicsTK/quarantine/%s' % str(items[0]['_id']))
+        self.assertStatusOk(resp)

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -1,13 +1,17 @@
+import datetime
 import json
 import os
 import re
 
 from girder import events
 from girder.api import access
-from girder.api.describe import Description, describeRoute
-from girder.constants import AccessType, SettingDefault
-from girder.exceptions import ValidationException
+from girder.api.describe import Description, describeRoute, autoDescribeRoute
+from girder.api.rest import filtermodel
+from girder.constants import AccessType, SettingDefault, TokenScope
+from girder.exceptions import RestException, ValidationException
+from girder.models.folder import Folder
 from girder.models.group import Group
+from girder.models.item import Item
 from girder.models.setting import Setting
 from girder.models.user import User
 from girder.utility.webroot import Webroot
@@ -25,6 +29,8 @@ from .image_browse_resource import ImageBrowseResource
 from . import ctk_cli_adjustment  # noqa - for side effects
 
 from girder.models.model_base import ModelImporter
+
+
 _template = os.path.join(
     os.path.dirname(__file__),
     'webroot.mako'
@@ -93,6 +99,14 @@ def validateHistomicsTKAnalysisAccess(doc):
     value['public'] = bool(value.get('public'))
 
 
+@setting_utilities.validator(PluginSettings.HISTOMICSTK_QUARANTINE_FOLDER)
+def validateHistomicsTKQuarantineFolder(doc):
+    if not doc.get('value', None):
+        doc['value'] = None
+    else:
+        Folder().load(doc['value'], force=True, exc=True)
+
+
 # Defaults that have fixed values are added to the system defaults dictionary.
 SettingDefault.defaults.update({
     PluginSettings.HISTOMICSTK_WEBROOT_PATH: 'histomicstk',
@@ -107,6 +121,8 @@ class HistomicsTKResource(DockerResource):
     def __init__(self, name, *args, **kwargs):
         super(HistomicsTKResource, self).__init__(name, *args, **kwargs)
         self.route('GET', ('settings',), self.getPublicSettings)
+        self.route('PUT', ('quarantine', ':id'), self.putQuarantine)
+        self.route('PUT', ('quarantine', ':id', 'restore'), self.restoreQuarantine)
         self.route('GET', ('analysis', 'access'), self.getAnalysisAccess)
 
     def _accessList(self):
@@ -159,8 +175,12 @@ class HistomicsTKResource(DockerResource):
     def getPublicSettings(self, params):
         keys = [
             PluginSettings.HISTOMICSTK_DEFAULT_DRAW_STYLES,
+            PluginSettings.HISTOMICSTK_QUARANTINE_FOLDER,
         ]
-        return {k: self.model('setting').get(k) for k in keys}
+        result = {k: self.model('setting').get(k) for k in keys}
+        result[PluginSettings.HISTOMICSTK_QUARANTINE_FOLDER] = bool(
+            result[PluginSettings.HISTOMICSTK_QUARANTINE_FOLDER])
+        return result
 
     @describeRoute(
         Description('Get the access list for analyses.')
@@ -168,6 +188,58 @@ class HistomicsTKResource(DockerResource):
     @access.admin
     def getAnalysisAccess(self, params):
         return self._accessList()
+
+    @autoDescribeRoute(
+        Description('Move an item to the quarantine folder.')
+        .responseClass('Item')
+        .modelParam('id', model=Item, level=AccessType.WRITE)
+        .errorResponse('ID was invalid.')
+        .errorResponse('Write access was denied for the item', 403)
+    )
+    @access.user(scope=TokenScope.DATA_WRITE)
+    @filtermodel(model=Item)
+    def putQuarantine(self, item):
+        folder = Setting().get(PluginSettings.HISTOMICSTK_QUARANTINE_FOLDER)
+        if not folder:
+            raise RestException('The quarantine folder is not configured.')
+        folder = Folder().load(folder, force=True, exc=True)
+        if not folder:
+            raise RestException('The quarantine folder does not exist.')
+        if str(folder['_id']) == str(item['folderId']):
+            raise RestException('The item is already in the quarantine folder.')
+        quarantineInfo = {
+            'originalFolderId': item['folderId'],
+            'originalBaseParentType': item['baseParentType'],
+            'originalBaseParentId': item['baseParentId'],
+            'originalUpdated': item['updated'],
+            'quarantineUserId': self.getCurrentUser()['_id'],
+            'quarantineTime': datetime.datetime.utcnow()
+        }
+        item = Item().move(item, folder)
+        item.setdefault('meta', {})['quarantine'] = quarantineInfo
+        item = Item().updateItem(item)
+        return item
+
+    @autoDescribeRoute(
+        Description('Restore a quarantined item to its original folder.')
+        .responseClass('Item')
+        .modelParam('id', model=Item, level=AccessType.WRITE)
+        .errorResponse('ID was invalid.')
+        .errorResponse('Write access was denied for the item', 403)
+    )
+    @access.admin
+    @filtermodel(model=Item)
+    def restoreQuarantine(self, item):
+        if not item.get('meta', {}).get('quarantine'):
+            raise RestException('The item has no quarantine record.')
+        folder = Folder().load(item['meta']['quarantine']['originalFolderId'], force=True)
+        if not folder:
+            raise RestException('The original folder is not accesible.')
+        item = Item().move(item, folder)
+        item['updated'] = item['meta']['quarantine']['originalUpdated']
+        del item['meta']['quarantine']
+        item = Item().updateItem(item)
+        return item
 
 
 def _saveJob(event):

--- a/server/constants.py
+++ b/server/constants.py
@@ -10,3 +10,4 @@ class PluginSettings(object):
     HISTOMICSTK_BRAND_COLOR = 'histomicstk.brand_color'
     HISTOMICSTK_BANNER_COLOR = 'histomicstk.banner_color'
     HISTOMICSTK_ANALYSIS_ACCESS = 'histomicstk.analysis_access'
+    HISTOMICSTK_QUARANTINE_FOLDER = 'histomicstk.quarantine_folder'

--- a/web_client/main.js
+++ b/web_client/main.js
@@ -9,6 +9,7 @@ import * as histomicstk from 'girder_plugins/HistomicsTK';
 
 // import modules for side effects
 import './views/itemList';
+import './views/itemPage';
 
 import ConfigView from './views/body/ConfigView';
 

--- a/web_client/main.js
+++ b/web_client/main.js
@@ -7,6 +7,9 @@ import { exposePluginConfig } from 'girder/utilities/PluginUtils';
 // expose symbols under girder.plugins
 import * as histomicstk from 'girder_plugins/HistomicsTK';
 
+// import modules for side effects
+import './views/itemList';
+
 import ConfigView from './views/body/ConfigView';
 
 const pluginName = 'HistomicsTK';

--- a/web_client/stylesheets/views/itemList.styl
+++ b/web_client/stylesheets/views/itemList.styl
@@ -1,0 +1,8 @@
+.g-histomicstk-quarantine span
+  font-weight bold
+  display inline-block
+  width 1em
+  margin-left 0.2em
+  margin-right 0.2em
+  text-align center
+  line-height 1em

--- a/web_client/stylesheets/views/itemList.styl
+++ b/web_client/stylesheets/views/itemList.styl
@@ -1,4 +1,4 @@
-.g-histomicstk-quarantine span
+.g-histomicstk-quarantine span, .g-histomicstk-quarantine-item span
   font-weight bold
   display inline-block
   width 1em

--- a/web_client/templates/body/configView.pug
+++ b/web_client/templates/body/configView.pug
@@ -3,7 +3,7 @@ p.g-histomicstk-description
   | Provides a toolkit for analyzing histology images.
 form#g-histomicstk-form(role="form")
   .form-group
-    label(for="g-histomicstk-brand-name") Root Path
+    label(for="g-histomicstk-webroot-path") Root Path
     input#g-histomicstk-webroot-path.form-control.input-sm(
         type="text", value=settings['histomicstk.webroot_path'] || '',
         placeholder=`Default: ${defaults['histomicstk.webroot_path'] || 'histomicstk'}`,
@@ -40,6 +40,17 @@ form#g-histomicstk-form(role="form")
   .form-group
     label#g-histomicstk-analysis-access-label(for="g-histomicstk-analysis-access") Analysis Access
     #g-histomicstk-analysis-access
+  .form-group
+    label(for="g-histomicstk-quarantine-folder") Quarantine Folder
+    p.g-histomicstk-description
+      | If a quarantine folder is specified, users with write access will see a Quarantine button next to items.  When clicked, this moves that item to the quarantine folder and adds metadata to record where it was originally.  The quarantine folder should have restricted visibility.
+    .input-group.input-group-sm
+      input#g-histomicstk-quarantine-folder.form-control.input-sm(
+          type="text", value=settings['histomicstk.quarantine_folder'] || '',
+          title="A folder to store quarantined items.")
+      .input-group-btn
+        button.g-open-browser.btn.btn-default(type="button")
+          i.icon-folder-open
   p#g-histomicstk-error-message.g-validation-failed-message
 .g-histomicstk-buttons
   button#g-histomicstk-save.btn.btn-sm.btn-primary Save

--- a/web_client/views/itemList.js
+++ b/web_client/views/itemList.js
@@ -1,6 +1,7 @@
 import { wrap } from 'girder/utilities/PluginUtils';
 import { AccessType } from 'girder/constants';
 import { restRequest } from 'girder/rest';
+import events from 'girder/events';
 import ItemListWidget from 'girder/views/widgets/ItemListWidget';
 
 import '../stylesheets/views/itemList.styl';
@@ -16,6 +17,7 @@ wrap(ItemListWidget, 'render', function (render) {
         }
         root.$el.find('.g-item-list-entry').each(function () {
             var parent = $(this);
+            parent.remove('.g-histomicstk-quarantine');
             parent.append($('<a class="g-histomicstk-quarantine"><span>Q</span></a>').attr({
                 'g-item-cid': $('[g-item-cid]', parent).attr('g-item-cid'),
                 title: 'Move this item to the quarantine folder'
@@ -29,14 +31,28 @@ wrap(ItemListWidget, 'render', function (render) {
         const item = root.collection.get(cid);
         restRequest({
             type: 'PUT',
-            url: 'HistomicsTK/quarantine/' + item.id
+            url: 'HistomicsTK/quarantine/' + item.id,
+            error: null
         }).done((resp) => {
+            events.trigger('g:alert', {
+                icon: 'ok',
+                text: 'Item quarantined.',
+                type: 'success',
+                timeout: 4000
+            });
             root.trigger('g:changed');
             if (root.parentView && root.parentView.setCurrentModel && root.parentView.parentModel) {
                 root.parentView.setCurrentModel(root.parentView.parentModel, {setRoute: false});
             } else {
                 target.closest('.g-item-list-entry').remove();
             }
+        }).fail((resp) => {
+            events.trigger('g:alert', {
+                icon: 'cancel',
+                text: 'Failed to quarantine item.',
+                type: 'danger',
+                timeout: 4000
+            });
         });
     }
 

--- a/web_client/views/itemList.js
+++ b/web_client/views/itemList.js
@@ -1,0 +1,58 @@
+import { wrap } from 'girder/utilities/PluginUtils';
+import { AccessType } from 'girder/constants';
+import { restRequest } from 'girder/rest';
+import ItemListWidget from 'girder/views/widgets/ItemListWidget';
+
+import '../stylesheets/views/itemList.styl';
+
+wrap(ItemListWidget, 'render', function (render) {
+    const root = this;
+
+    render.call(this);
+
+    function adjustView(settings) {
+        if (!settings || !settings['histomicstk.quarantine_folder']) {
+            return;
+        }
+        root.$el.find('.g-item-list-entry').each(function () {
+            var parent = $(this);
+            parent.append($('<a class="g-histomicstk-quarantine"><span>Q</span></a>').attr({
+                'g-item-cid': $('[g-item-cid]', parent).attr('g-item-cid'),
+                title: 'Move this item to the quarantine folder'
+            }));
+        });
+    }
+
+    function quarantine(event) {
+        const target = $(event.currentTarget);
+        const cid = target.attr('g-item-cid');
+        const item = root.collection.get(cid);
+        restRequest({
+            type: 'PUT',
+            url: 'HistomicsTK/quarantine/' + item.id
+        }).done((resp) => {
+            root.trigger('g:changed');
+            if (root.parentView && root.parentView.setCurrentModel && root.parentView.parentModel) {
+                root.parentView.setCurrentModel(root.parentView.parentModel, {setRoute: false});
+            } else {
+                target.closest('.g-item-list-entry').remove();
+            }
+        });
+    }
+
+    if (this.accessLevel >= AccessType.WRITE) {
+        if (!this._htk_settings) {
+            restRequest({
+                type: 'GET',
+                url: 'HistomicsTK/settings'
+            }).done((resp) => {
+                this._htk_settings = resp;
+                adjustView(this._htk_settings);
+            });
+        } else {
+            adjustView(this._htk_settings);
+        }
+        this.events['click .g-histomicstk-quarantine'] = quarantine;
+        this.delegateEvents();
+    }
+});

--- a/web_client/views/itemPage.js
+++ b/web_client/views/itemPage.js
@@ -1,0 +1,43 @@
+import { wrap } from 'girder/utilities/PluginUtils';
+import { restRequest } from 'girder/rest';
+import events from 'girder/events';
+import ItemView from 'girder/views/body/ItemView';
+
+import '../stylesheets/views/itemList.styl';
+
+wrap(ItemView, 'render', function (render) {
+    function quarantine(event) {
+        const item = this.model;
+        restRequest({
+            type: 'PUT',
+            url: 'HistomicsTK/quarantine/' + item.id,
+            error: null
+        }).done((resp) => {
+            events.trigger('g:alert', {
+                icon: 'ok',
+                text: 'Item quarantined.',
+                type: 'success',
+                timeout: 4000
+            });
+            this.render();
+        }).fail((resp) => {
+            events.trigger('g:alert', {
+                icon: 'cancel',
+                text: 'Failed to quarantine item.',
+                type: 'danger',
+                timeout: 4000
+            });
+        });
+    }
+
+    this.once('g:rendered', function () {
+        if (this.$el.find('.g-edit-item[role="menuitem"]').length && !this.$el.find('.g-histomicstk-quarantine-item[role="menuitem"]').length) {
+            this.$el.find('.g-edit-item[role="menuitem"]').parent('li').after(
+                '<li role="presentation"><a class="g-histomicstk-quarantine-item" role="menuitem"><span>Q</span>Quarantine item</a></li>'
+            );
+        }
+        this.events['click .g-histomicstk-quarantine-item'] = quarantine;
+        this.delegateEvents();
+    });
+    render.call(this);
+});


### PR DESCRIPTION
The a folder is specified in the plugin settings, a Quarantine button will appear next to each item that a user has write access to.  When clicked, the item will be moved to the quarantine folder.

Two endpoints have been added, HistomicsTK/quarantine/:itemId and HistomicsTK/quarantime/:itemId/restore to move an item to the quarantine folder or to put it back.

Currently, only the itemList widget shows the quarantine action.  We probably should also show it on the individual item page.

