### PR TITLE
Update to work with scipy 1.3.0.

### DIFF
--- a/histomicstk/utils/sample_pixels.py
+++ b/histomicstk/utils/sample_pixels.py
@@ -1,8 +1,8 @@
 import dask
 import dask.distributed
 import large_image
+import PIL.Image
 import numpy as np
-import scipy
 
 from .simple_mask import simple_mask
 
@@ -152,11 +152,10 @@ def _sample_pixels_tile(slide_path, iter_args, positions, sample_fraction,
         im_tile = tile['tile'][:, :, :3]
 
         # get tile foreground mask at resolution of current tile
-        tile_fgnd_mask = scipy.misc.imresize(
-            tile_fgnd_mask_lres,
-            im_tile.shape,
-            interp='nearest'
-        )
+        tile_fgnd_mask = np.array(PIL.Image.fromarray(tile_fgnd_mask_lres).resize(
+            im_tile.shape[:2],
+            resample=PIL.Image.NEAREST
+        ))
 
         # generate linear indices of sample pixels in fgnd mask
         nz_ind = np.nonzero(tile_fgnd_mask.flatten())[0]

--- a/setup.py
+++ b/setup.py
@@ -67,6 +67,7 @@ setup(
         'nimfa>=1.3.2',
         'numpy>=1.12.1',
         'scipy>=0.19.0',
+        'Pillow>=3.2.0',
         'pandas>=0.19.2',
         'scikit-image>=0.14.2',
         'scikit-learn>=0.18.1' + ('' if sys.version_info >= (3, ) else ',<0.21'),


### PR DESCRIPTION
scipy deprecated imresize.  Use PIL instead.