### PR TITLE
Fix license in setup.py.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -15,8 +15,8 @@ HistomicsTK |build-status| |codecov-io| |code-health| |gitter|
    :alt: Code Health
 
 .. |gitter| image:: https://badges.gitter.im/DigitalSlideArchive/HistomicsTK.svg
-   :alt: Join the chat at https://gitter.im/DigitalSlideArchive/HistomicsTK
    :target: https://gitter.im/DigitalSlideArchive/HistomicsTK?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge
+   :alt: Join the chat at https://gitter.im/DigitalSlideArchive/HistomicsTK
 
 HistomicsTK is a Python and REST API for the analysis of Histopathology images
 in association with clinical and genomic data.
@@ -50,22 +50,22 @@ HistomicsTK can be used in two ways:
   and `examples <https://digitalslidearchive.github.io/HistomicsTK/examples.html>`__
   for more information.
 
-  This can be installed on Linux via `pip install histomicstk`.
+  This can be installed on Linux via ``pip install histomicstk``.
 
   HistomicsTK uses the `large_image`_ library to read and various microscopy
   image formats.  Depending on your exact system, installing the necessary 
   libraries to support these formats can be complex.  There are some
   non-official prebuilt libraries available for Linux that can be included as
   part of the installation by specifying 
-  `pip install histomicstk --find-links https://manthey.github.io/large_image_wheels`.
+  ``pip install histomicstk --find-links https://manthey.github.io/large_image_wheels``.
   Note that if you previously installed HistomicsTK or large_image without
-  these, you may need to add `--force-reinstall --no-cache-dir` to the `pip
-  install` command to force it to use the find-links option.
+  these, you may need to add ``--force-reinstall --no-cache-dir`` to the
+  ``pip install`` command to force it to use the find-links option.
 
-  The system version of various libraries are used if the `--find-links` option
-  is not specified.  You will need to use your package manager to install 
-  appropriate libraries (on Ubuntu, for instance, you'll need 
-  `libopenslide-dev` and `libtiff-dev`).
+  The system version of various libraries are used if the ``--find-links``
+  option is not specified.  You will need to use your package manager to
+  install appropriate libraries (on Ubuntu, for instance, you'll need 
+  ``libopenslide-dev`` and ``libtiff-dev``).
 
 - **As a server-side Girder plugin for web-based analysis**: This is intended
   to allow pathologists/biologists to apply analysis modules/pipelines

--- a/setup.py
+++ b/setup.py
@@ -18,11 +18,8 @@ except ImportError:
     sys.exit(1)
 
 
-with open('README.rst') as readme_file:
+with open('README.rst', 'rt') as readme_file:
     readme = readme_file.read()
-
-with open('LICENSE') as f:
-    license_str = f.read()
 
 
 def prerelease_local_scheme(version):
@@ -47,6 +44,7 @@ setup(
     use_scm_version={'local_scheme': prerelease_local_scheme},
     description='A Python toolkit for Histopathology Image Analysis',
     long_description=readme,
+    long_description_content_type='text/x-rst',
     author='Kitware, Inc.',
     author_email='developers@digitalslidearchive.net',
     url='https://github.com/DigitalSlideArchive/HistomicsTK',
@@ -84,7 +82,7 @@ setup(
         'large-image-source-openslide',
         'large-image-source-pil',
     ],
-    license=license_str,
+    license='Apache Software License 2.0',
     keywords='histomicstk',
     classifiers=[
         'Development Status :: 4 - Beta',
@@ -94,7 +92,7 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7'
+        'Programming Language :: Python :: 3.7',
         'Topic :: Scientific/Engineering :: Artificial Intelligence',
         'Topic :: Software Development :: Libraries :: Python Modules',
     ],


### PR DESCRIPTION
The license field in setup is supposed to be a short string, not the full license text.

This also fixes a missing comma.

Monospaced information in RST needs double backticks.