### PR TITLE
Handle a recent change in the python cmake module.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,6 +62,8 @@ before_install:
     # https://github.com/travis-ci/travis-ci/issues/7940
     - sudo rm -f /etc/boto.cfg
 
+    - pip install -U pip
+
     - mkdir -p $HOME/.cache/node_modules || true
     - ln -sf $HOME/.cache/node_modules .
     - nvm install v8

--- a/ansible/roles/girder-histomicstk/tasks/main.yml
+++ b/ansible/roles/girder-histomicstk/tasks/main.yml
@@ -140,6 +140,14 @@
     extra_args: "{{ root_dir }}/large_image[memcached,openslide]"
     state: present
 
+- name: Install python cmake modules
+  # as of 2019-05-27, this needs to be installed before the HistomicsTK plugin,
+  # though it isn't clear why.
+  pip:
+    name: cmake
+    state: present
+  become: true
+
 - name: Install our external girder plugins - HistomicsTK
   command: girder-install plugin -s {{ root_dir }}/HistomicsTK
   become: true


### PR DESCRIPTION
Some recent change, probably in cmake's python module, has caused the build to fail.  Explicitly install cmake as part of the ansible script.   Update pip in travis.
