### PR TITLE
Don't set the current assetstore when deploying.

### DIFF
--- a/ansible/roles/provision/tasks/main.yml
+++ b/ansible/roles/provision/tasks/main.yml
@@ -176,7 +176,7 @@
       name: default
       type: filesystem
       root: "{{ root_dir }}/assetstore"
-      current: true
+      # current: true
     state: present
 
 - name: Get assetstore list


### PR DESCRIPTION
The auto-generated filesystem assetstore was always being set as the current assetstore.  This will happen on the first installation anyway, so it isn't needed.  On subsequent deployments, if the current has been changed, this was changing it back, which is confusing and undesired.