### PR TITLE
Update the base docker we use for building wheels.

### DIFF
--- a/Dockerfile-wheels
+++ b/Dockerfile-wheels
@@ -1,4 +1,4 @@
-FROM dockcross/manylinux-x64
+FROM dockcross/manylinux2010-x64
 
 # Don't build python 3.4 wheels.
 RUN rm -r /opt/python/cp27-cp27m

--- a/setup.py
+++ b/setup.py
@@ -77,6 +77,7 @@ setup(
         'dask>=1.1.0',
         'distributed>=1.21.6',
         'tornado',
+        'fsspec>=0.3.3;python_version>="3"',
         # large image sources
         'large-image-source-tiff',
         'large-image-source-openslide',


### PR DESCRIPTION
This is now based on manylinux2010 rather than manylinux1.