### PR TITLE
Minor cleanup.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -67,7 +67,7 @@ before_install:
     - mkdir -p $HOME/.cache/node_modules || true
     - ln -sf $HOME/.cache/node_modules .
     - nvm install v8
-    - npm install -g npm
+    - npm install -g npm@6.10.3
     - npm install -g npm-install-retry
     - npm --version
     - npm prune

--- a/plugin_tests/annotation_handler_test.py
+++ b/plugin_tests/annotation_handler_test.py
@@ -17,9 +17,6 @@
 #  limitations under the License.
 #############################################################################
 
-# This is to serve as an example for how to create a server-side test in a
-# girder plugin, it is not meant to be useful.
-
 import json
 
 from girder import events
@@ -39,7 +36,7 @@ def tearDownModule():
 
 class AnnotationHandlerTest(base.TestCase):
 
-    def testHandleAnntation(self):
+    def testHandleAnnotation(self):
         admin = self.model('user').findOne({'login': 'admin'})
         item = self.model('item').findOne({'name': 'Item 1'})
         file1 = self.model('file').findOne({'name': 'File 1'})

--- a/setup.py
+++ b/setup.py
@@ -81,6 +81,7 @@ setup(
         # large image sources
         'large-image-source-tiff',
         'large-image-source-openslide',
+        'large-image-source-ometiff',
         'large-image-source-pil',
     ],
     license='Apache Software License 2.0',


### PR DESCRIPTION
Fix a typo in a test file.

Include the ometiff tile source by default in the toolkit deployment.

This also pins an npm version to work around a CI issue.