### PR TITLE
Explicitly install setup_requires in the wheel docker build.

### DIFF
--- a/Dockerfile-wheels
+++ b/Dockerfile-wheels
@@ -14,7 +14,7 @@ RUN for PYBIN in /opt/python/*/bin; do \
     done
 
 RUN for PYBIN in /opt/python/*/bin; do \
-        ${PYBIN}/pip install Cython setuptools-scm; \
+        ${PYBIN}/pip install setuptools-scm 'Cython>=0.25.2' 'scikit-build>=0.8.1' 'cmake>=0.6.0' 'numpy>=1.12.1'; \
     done
 
 ENV htk_path=/HistomicsTK


### PR DESCRIPTION
@kheffah This change is needed to automatically build wheels and publish them to pypi.