### PR TITLE
select by region

### DIFF
--- a/plugin_tests/client/annotationSpec.js
+++ b/plugin_tests/client/annotationSpec.js
@@ -716,10 +716,8 @@ $(function () {
                 girderTest.waitForDialog();
                 runs(function () {
                     expect($('#h-annotation-name').val()).toBe('drawn 2');
-                    expect($('#h-annotation-line-width').length).toBe(1);
                     expect($('#h-annotation-line-color').length).toBe(1);
                     expect($('#h-annotation-fill-color').length).toBe(1);
-                    $('#h-annotation-line-width').val(2);
                     $('#h-annotation-line-color').val('black');
                     $('#h-annotation-fill-color').val('white');
                     $('.h-submit').click();
@@ -730,7 +728,6 @@ $(function () {
                     var annotation = app.bodyView.annotations.filter(function (annotation) {
                         return annotation.get('annotation').name === 'drawn 2';
                     })[0];
-                    expect(annotation.get('annotation').elements[0].lineWidth).toBe(2);
                     expect(annotation.get('annotation').elements[0].lineColor).toBe('rgb(0, 0, 0)');
                     expect(annotation.get('annotation').elements[0].fillColor).toBe('rgb(255, 255, 255)');
                 });

--- a/plugin_tests/client/annotationSpec.js
+++ b/plugin_tests/client/annotationSpec.js
@@ -633,7 +633,7 @@ $(function () {
                 }, 'annotation to toggle on');
             });
 
-            it('select annotations by rect - hits', function () {
+            it('select annotations by rect - no hits', function () {
                 var interactor = histomicsTest.geojsMap().interactor();
                 expect($('.h-annotation-select-by-region').length).toBe(1);
                 $('.h-annotation-select-by-region').click();
@@ -662,8 +662,22 @@ $(function () {
                     width: viewer.$el.width(),
                     height: viewer.$el.height()
                 };
-                var elements = app.bodyView.getElementsInBox(boundingBox);
-                expect(elements.length).toBe(10);
+
+                $('.h-show-all-annotations').click();
+                girderTest.waitForLoad();
+
+                waitsFor(function () {
+                    var $el = $('.h-annotation-selector');
+                    return $el.find('.icon-spin3').length === 0;
+                }, 'load all annotations');
+
+                runs(function () {
+                    var elements = app.bodyView.getElementsInBox(boundingBox);
+                    var countExistingElements = app.bodyView.annotations.reduce(function (acc, annotation) {
+                        return acc + annotation.elements.length;
+                    }, 0);
+                    expect(elements.length).toBe(countExistingElements);
+                });
             });
 
             it('edit annotation metadata', function () {

--- a/plugin_tests/client/annotationSpec.js
+++ b/plugin_tests/client/annotationSpec.js
@@ -633,6 +633,39 @@ $(function () {
                 }, 'annotation to toggle on');
             });
 
+            it('select annotations by rect - hits', function () {
+                var interactor = histomicsTest.geojsMap().interactor();
+                expect($('.h-annotation-select-by-region').length).toBe(1);
+                $('.h-annotation-select-by-region').click();
+
+                interactor.simulateEvent('mousedown', {
+                    map: { x: 100, y: 100 },
+                    button: 'left'
+                });
+                interactor.simulateEvent('mousemove', {
+                    map: { x: 200, y: 200 },
+                    button: 'left'
+                });
+                interactor.simulateEvent('mouseup', {
+                    map: { x: 200, y: 200 },
+                    button: 'left'
+                });
+
+                expect($('#h-annotation-context-menu').is(':hidden')).toBe(true);
+            });
+
+            it('getElementsInBox', function () {
+                var viewer = app.bodyView.viewerWidget;
+                var boundingBox = {
+                    left: 0,
+                    top: 0,
+                    width: viewer.$el.width(),
+                    height: viewer.$el.height()
+                };
+                var elements = app.bodyView.getElementsInBox(boundingBox);
+                expect(elements.length).toBe(10);
+            });
+
             it('edit annotation metadata', function () {
                 runs(function () {
                     $('.h-annotation-selector .h-annotation:contains("drawn 1") .h-edit-annotation-metadata').click();
@@ -669,8 +702,10 @@ $(function () {
                 girderTest.waitForDialog();
                 runs(function () {
                     expect($('#h-annotation-name').val()).toBe('drawn 2');
+                    expect($('#h-annotation-line-width').length).toBe(1);
                     expect($('#h-annotation-line-color').length).toBe(1);
                     expect($('#h-annotation-fill-color').length).toBe(1);
+                    $('#h-annotation-line-width').val(2);
                     $('#h-annotation-line-color').val('black');
                     $('#h-annotation-fill-color').val('white');
                     $('.h-submit').click();
@@ -681,6 +716,7 @@ $(function () {
                     var annotation = app.bodyView.annotations.filter(function (annotation) {
                         return annotation.get('annotation').name === 'drawn 2';
                     })[0];
+                    expect(annotation.get('annotation').elements[0].lineWidth).toBe(2);
                     expect(annotation.get('annotation').elements[0].lineColor).toBe('rgb(0, 0, 0)');
                     expect(annotation.get('annotation').elements[0].fillColor).toBe('rgb(255, 255, 255)');
                 });

--- a/web_client/panels/AnnotationSelector.js
+++ b/web_client/panels/AnnotationSelector.js
@@ -37,6 +37,7 @@ var AnnotationSelector = Panel.extend({
         'change #h-toggle-interactive': 'toggleInteractiveMode',
         'input #h-annotation-opacity': '_changeGlobalOpacity',
         'input #h-annotation-fill-opacity': '_changeGlobalFillOpacity',
+        'click .h-annotation-select-by-region': 'selectAnnotationByRegion',
         'click .h-annotation-group-name': '_toggleExpandGroup'
     }),
 
@@ -370,6 +371,10 @@ var AnnotationSelector = Panel.extend({
         this.collection.each((model) => {
             model.set('displayed', false);
         });
+    },
+
+    selectAnnotationByRegion() {
+        this.parentView.trigger('h:selectElementsByRegion');
     },
 
     _highlightAnnotation(evt) {

--- a/web_client/panels/AnnotationSelector.js
+++ b/web_client/panels/AnnotationSelector.js
@@ -374,7 +374,28 @@ var AnnotationSelector = Panel.extend({
     },
 
     selectAnnotationByRegion() {
-        this.parentView.trigger('h:selectElementsByRegion');
+        const btn = this.$('.h-annotation-select-by-region');
+        // listen to escape key
+        $(document).on('keydown.h-annotation-select-by-region', (evt) => {
+            if (evt.keyCode === 27) {
+                btn.removeClass('active');
+                $(document).off('keydown.h-annotation-select-by-region');
+                this.parentView.trigger('h:selectElementsByRegionCancel');
+            }
+        });
+        this.listenToOnce(this.parentView, 'h:selectedElementsByRegion', () => {
+            btn.removeClass('active');
+            $(document).off('keydown.h-annotation-select-by-region');
+        });
+
+        if (!btn.hasClass('active')) {
+            btn.addClass('active');
+            this.parentView.trigger('h:selectElementsByRegion');
+        } else {
+            btn.removeClass('active');
+            $(document).off('keydown.h-annotation-select-by-region');
+            this.parentView.trigger('h:selectElementsByRegionCancel');
+        }
     },
 
     _highlightAnnotation(evt) {

--- a/web_client/stylesheets/panels/annotationSelector.styl
+++ b/web_client/stylesheets/panels/annotationSelector.styl
@@ -2,17 +2,18 @@
   border-bottom 1px solid #ececec
   padding-bottom 8px
   margin-bottom 5px
+  display flex
 
   button.btn
     padding 2px 5px
     margin 0
     background none
 
-  input[type="range"]
-    width 93px
-    float right
-    margin-left 10px
-    margin-top 2px
+  .h-annotation-opacity-container,
+  .h-annotation-fill-opacity-container
+    flex 1 1 0
+    position relative
+    margin 2px 5px
 
 .h-annotation
   padding 2px

--- a/web_client/templates/panels/annotationSelector.pug
+++ b/web_client/templates/panels/annotationSelector.pug
@@ -17,6 +17,9 @@ block content
     span.h-annotation-fill-opacity-container(title=`Annotation fill opacity ${(fillOpacity * 100).toFixed()}%`)
       input#h-annotation-fill-opacity(
           type="range", min="0", max="1", step="0.01", value=fillOpacity)
+    .btn-group.btn-group-sm(role='group')
+      button.btn.btn-default.h-annotation-select-by-region(type='button', title='Select annotations by region.  Keyboard shortcut: a')
+        | #[span.icon-marquee]
 
   - var groups = _.keys(annotationGroups);
   - groups.sort();

--- a/web_client/templates/panels/annotationSelector.pug
+++ b/web_client/templates/panels/annotationSelector.pug
@@ -18,7 +18,7 @@ block content
       input#h-annotation-fill-opacity(
           type="range", min="0", max="1", step="0.01", value=fillOpacity)
     .btn-group.btn-group-sm(role='group')
-      button.btn.btn-default.h-annotation-select-by-region(type='button', title='Select annotations by region.  Keyboard shortcut: a')
+      button.btn.btn-default.h-annotation-select-by-region(type='button', title='Select annotations by region.  Keyboard shortcut: s')
         | #[span.icon-marquee]
 
   - var groups = _.keys(annotationGroups);

--- a/web_client/views/body/ImageView.js
+++ b/web_client/views/body/ImageView.js
@@ -29,14 +29,16 @@ var ImageView = View.extend({
     events: {
         'keydown .h-image-body': '_onKeyDown',
         'keydown .geojs-map': '_handleKeyDown',
-        'click .h-control-panel-container .s-close-panel-group': '_closeAnalysis'
+        'click .h-control-panel-container .s-close-panel-group': '_closeAnalysis',
+        'mousemove .geojs-map': '_trackMousePosition',
     },
     initialize(settings) {
         this.viewerWidget = null;
         this._mouseClickQueue = [];
         this._openId = null;
         this._displayedRegion = null;
-        this.selectedAnnotation = new AnnotationModel({_id: 'selected'});
+        this._currentMousePosition = null;
+        this.selectedAnnotation = new AnnotationModel({ _id: 'selected' });
         this.selectedElements = this.selectedAnnotation.elements();
 
         // Allow zooming this many powers of 2 more than native pixel resolution
@@ -82,7 +84,7 @@ var ImageView = View.extend({
         });
         this.listenTo(events, 'h:submit', (data) => {
             this.$('.s-jobs-panel .s-panel-controls .icon-down-open').click();
-            events.trigger('g:alert', {type: 'success', text: 'Analysis job submitted.'});
+            events.trigger('g:alert', { type: 'success', text: 'Analysis job submitted.' });
         });
         this.listenTo(events, 'h:select-region', this.showRegion);
         this.listenTo(this.annotationSelector.collection, 'add update change:displayed', this.toggleAnnotation);
@@ -94,6 +96,7 @@ var ImageView = View.extend({
         this.listenTo(this.annotationSelector, 'h:annotationFillOpacity', this._setAnnotationFillOpacity);
         this.listenTo(this.annotationSelector, 'h:redraw', this._redrawAnnotation);
         this.listenTo(this, 'h:highlightAnnotation', this._highlightAnnotationForInteractiveMode);
+        this.listenTo(this, 'h:selectElementsByRegion', this._selectElementsByRegion);
         this.listenTo(this.contextMenu, 'h:edit', this._editElement);
         this.listenTo(this.contextMenu, 'h:redraw', this._redrawAnnotation);
         this.listenTo(this.contextMenu, 'h:close', this._closeContextMenu);
@@ -145,7 +148,7 @@ var ImageView = View.extend({
                 // it is very confusing if this value is smaller than the
                 // AnnotationSelector MAX_ELEMENTS_LIST_LENGTH
                 highlightFeatureSizeLimit: 5000,
-                scale: {position: {bottom: 20, right: 10}}
+                scale: { position: { bottom: 20, right: 10 } }
             });
             this.trigger('h:viewerWidgetCreated', this.viewerWidget);
 
@@ -180,7 +183,7 @@ var ImageView = View.extend({
                 this.setBoundsQuery();
 
                 if (this.viewer) {
-                    this.viewer.zoomRange({max: this.viewer.zoomRange().max + this._increaseZoom2x});
+                    this.viewer.zoomRange({ max: this.viewer.zoomRange().max + this._increaseZoom2x });
 
                     // update the query string on pan events
                     this.viewer.geoOn(geo.event.pan, () => {
@@ -242,12 +245,12 @@ var ImageView = View.extend({
     },
     openImage(id) {
         if (id) {
-            this.model.set({_id: id}).fetch().then(() => {
+            this.model.set({ _id: id }).fetch().then(() => {
                 this._setImageInput();
                 return null;
             });
         } else {
-            this.model.set({_id: null});
+            this.model.set({ _id: null });
             this.render();
             this._openId = null;
             events.trigger('h:imageOpened', null);
@@ -323,7 +326,7 @@ var ImageView = View.extend({
         return promise.then((file) => {
             _.each(this.controlPanel.models(), (model) => {
                 if (model.get('type') === 'image') {
-                    model.set('value', file, {trigger: true});
+                    model.set('value', file, { trigger: true });
                 }
             });
             return null;
@@ -376,7 +379,7 @@ var ImageView = View.extend({
 
     _closeAnalysis(evt) {
         evt.preventDefault();
-        router.setQuery('analysis', null, {trigger: false});
+        router.setQuery('analysis', null, { trigger: false });
         this.controlPanel.$el.addClass('hidden');
     },
 
@@ -395,7 +398,7 @@ var ImageView = View.extend({
             bottom = bounds.bottom.toFixed();
             router.setQuery('bounds', [
                 left, top, right, bottom, rotation
-            ].join(','), {replace: true});
+            ].join(','), { replace: true });
         }
     },
 
@@ -500,7 +503,7 @@ var ImageView = View.extend({
         }
 
         this.viewerWidget.removeAnnotation(
-            new AnnotationModel({_id: 'region-selection'})
+            new AnnotationModel({ _id: 'region-selection' })
         );
         if (!region) {
             return;
@@ -533,7 +536,7 @@ var ImageView = View.extend({
                 }]
             }
         });
-        this.viewerWidget.drawAnnotation(annotation, {fetch: false});
+        this.viewerWidget.drawAnnotation(annotation, { fetch: false });
     },
 
     showCoordinates(evt) {
@@ -713,7 +716,22 @@ var ImageView = View.extend({
     _onKeyDown(evt) {
         if (evt.key === 'a') {
             this._showOrHideAnnotations();
+        } else if (evt.key === 's') {
+            this.annotationSelector.selectAnnotationByRegion();
         }
+    },
+
+    _trackMousePosition(evt) {
+        this._currentMousePosition = {
+            page: {
+                x: evt.pageX,
+                y: evt.pageY
+            },
+            client: {
+                x: evt.clientX,
+                y: evt.clientY,
+            }
+        };
     },
 
     _showOrHideAnnotations() {
@@ -722,6 +740,50 @@ var ImageView = View.extend({
         } else {
             this.annotationSelector.showAllAnnotations();
         }
+    },
+
+    _selectElementsByRegion() {
+        this.viewerWidget.drawRegion().then((coord) => {
+            const boundingBox = {
+                left: coord[0],
+                top: coord[1],
+                width: coord[2],
+                height: coord[3]
+            };
+            this._resetSelection();
+            const found = this._getElementsInBox(boundingBox);
+            found.forEach(({ element }) => this._selectElement(element));
+            if (this.selectedElements.length > 0 && this._currentMousePosition) {
+                // fake an open context menu
+                const { element, annotationId } = found[0];
+                this._openContextMenu(element, annotationId, {
+                    mouse: this._currentMousePosition
+                });
+            }
+            return this;
+        });
+    },
+
+    _getElementsInBox(boundingBox) {
+        const lowerLeft = { x: boundingBox.left, y: boundingBox.top + boundingBox.height };
+        const upperRight = { x: boundingBox.left + boundingBox.width, y: boundingBox.top };
+
+        const results = [];
+        this.viewerWidget.featureLayer.features().forEach((feature) => {
+            const r = feature.boxSearch(lowerLeft, upperRight, { partial: false });
+            r.found.forEach((feature) => {
+                const annotationId = feature.properties ? feature.properties.annotation : null;
+                const element = feature.properties ? feature.properties.element : null;
+                if (element && element.id && annotationId) {
+                    const annotation = this.annotations.get(annotationId);
+                    results.push({
+                        element: annotation.elements().get(element.id),
+                        annotationId
+                    });
+                }
+            });
+        });
+        return results;
     },
 
     _openContextMenu(element, annotationId, evt) {

--- a/web_client/views/body/ImageView.js
+++ b/web_client/views/body/ImageView.js
@@ -30,7 +30,7 @@ var ImageView = View.extend({
         'keydown .h-image-body': '_onKeyDown',
         'keydown .geojs-map': '_handleKeyDown',
         'click .h-control-panel-container .s-close-panel-group': '_closeAnalysis',
-        'mousemove .geojs-map': '_trackMousePosition',
+        'mousemove .geojs-map': '_trackMousePosition'
     },
     initialize(settings) {
         this.viewerWidget = null;
@@ -729,7 +729,7 @@ var ImageView = View.extend({
             },
             client: {
                 x: evt.clientX,
-                y: evt.clientY,
+                y: evt.clientY
             }
         };
     },

--- a/web_client/views/body/ImageView.js
+++ b/web_client/views/body/ImageView.js
@@ -751,7 +751,7 @@ var ImageView = View.extend({
                 height: coord[3]
             };
             this._resetSelection();
-            const found = this._getElementsInBox(boundingBox);
+            const found = this.getElementsInBox(boundingBox);
             found.forEach(({ element }) => this._selectElement(element));
             if (this.selectedElements.length > 0 && this._currentMousePosition) {
                 // fake an open context menu
@@ -764,7 +764,7 @@ var ImageView = View.extend({
         });
     },
 
-    _getElementsInBox(boundingBox) {
+    getElementsInBox(boundingBox) {
         const lowerLeft = { x: boundingBox.left, y: boundingBox.top + boundingBox.height };
         const upperRight = { x: boundingBox.left + boundingBox.width, y: boundingBox.top };
 


### PR DESCRIPTION
closes #620 

![image](https://user-images.githubusercontent.com/4129778/66411675-1ebada00-e9c2-11e9-8ca5-868b805086bb.png)

allow the user to draw a rectangle (see button in the annotation panel or using the keyboard shortcut s) and open a context menu for all the elements within this rect. 

notes: some changes are just auto applied linter fixes