### PR TITLE
Switch large_image_wheels reference to girder organization.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ WORKDIR $htk_path
 RUN pip install --no-cache-dir --upgrade --ignore-installed pip setuptools && \
     pip install --no-cache-dir 'bokeh>=0.12.14' && \
     # Install large_image
-    pip install --no-cache-dir 'large-image[memcached,openslide,tiff,pil]' -f https://manthey.github.io/large_image_wheels && \
+    pip install --no-cache-dir 'large-image[memcached,openslide,tiff,pil]' -f https://girder.github.io/large_image_wheels && \
     pip install --no-cache-dir scikit-build setuptools-scm Cython cmake && \
     # Install HistomicsTK
     pip install . && \

--- a/Dockerfile-wheels
+++ b/Dockerfile-wheels
@@ -10,7 +10,7 @@ RUN for PYBIN in /opt/python/*/bin; do \
     done
 
 RUN for PYBIN in /opt/python/*/bin; do \
-        ${PYBIN}/pip install libtiff openslide_python pyvips -f https://manthey.github.io/large_image_wheels large_image_source_tiff large_image_source_openslide large_image_source_pil; \
+        ${PYBIN}/pip install libtiff openslide_python pyvips -f https://girder.github.io/large_image_wheels large_image_source_tiff large_image_source_openslide large_image_source_pil; \
     done
 
 RUN for PYBIN in /opt/python/*/bin; do \

--- a/README.rst
+++ b/README.rst
@@ -68,7 +68,7 @@ HistomicsTK can be used in two ways:
   libraries to support these formats can be complex.  There are some
   non-official prebuilt libraries available for Linux that can be included as
   part of the installation by specifying 
-  ``pip install histomicstk --find-links https://manthey.github.io/large_image_wheels``.
+  ``pip install histomicstk --find-links https://girder.github.io/large_image_wheels``.
   Note that if you previously installed HistomicsTK or large_image without
   these, you may need to add ``--force-reinstall --no-cache-dir`` to the
   ``pip install`` command to force it to use the find-links option.

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -16,7 +16,7 @@ On Linux, HistomicsTK can be installed via pip.  You can specify the
 `--find-links` option to get prebuilt libraries for reading some common image
 formats.  The installation command is::
 
-    $ pip install histomicstk --find-links https://manthey.github.io/large_image_wheels
+    $ pip install histomicstk --find-links https://girder.github.io/large_image_wheels
 
 For non-Linux systems, or to use system libraries for reading image formats,
 please see the Github repo of large_image to find out how to install it as a

--- a/test_wheels.py
+++ b/test_wheels.py
@@ -7,7 +7,7 @@ script = """
 python --version && \\
 pip install --upgrade pip && \\
 pip install 'large_image[tiff,openslide,pil]' \\
-  -f https://manthey.github.io/large_image_wheels && \\
+  -f https://girder.github.io/large_image_wheels && \\
 pip install histomicstk -f /wheels && \\
 echo 'Test basic import of histomicstk' && \\
 python -c 'import histomicstk' && \\


### PR DESCRIPTION
They are more official now.