### PR TITLE
Change the default girder_worker log level to info.

### DIFF
--- a/ansible/roles/worker/templates/worker.local.cfg.j2
+++ b/ansible/roles/worker/templates/worker.local.cfg.j2
@@ -27,3 +27,7 @@ diskcache_large_value_threshold=1024
 
 [docker]
 exclude_images=
+
+[logging]
+level = INFO
+format = [%%(asctime)s] %%(levelname)s: %%(message)s


### PR DESCRIPTION
It was at warning.  Info level will make it easier to debug some issues.