### PR TITLE
Fix a bug when changing the color or line width of all elements.

### DIFF
--- a/plugin_tests/histomicstk_test.py
+++ b/plugin_tests/histomicstk_test.py
@@ -216,7 +216,7 @@ class HistomicsTKCoreTest(base.TestCase):
         resp = self.request(
             path='/HistomicsTK/HistomicsTK/docker_image',
             user=self.admin, method='PUT',
-            params={'name': '"girder/slicer_cli_web:small"'})
+            params={'name': '"girder/slicer_cli_web:small-2.x"'})
         self.assertStatusOk(resp)
         endTime = time.time() + 180  # maxTimeout
         while time.time() < endTime:

--- a/web_client/dialogs/saveAnnotation.js
+++ b/web_client/dialogs/saveAnnotation.js
@@ -108,17 +108,20 @@ var SaveAnnotation = View.extend({
         // all valid
 
         if (setFillColor || setLineColor || setLineWidth) {
-            this.annotation.get('annotation').elements.forEach((element) => {
+            this.annotation.elements().each((element) => { /* eslint-disable backbone/no-silent */
                 if (setFillColor) {
-                    element.fillColor = fillColor;
+                    element.set('fillColor', fillColor, {silent: true});
                 }
                 if (setLineColor) {
-                    element.lineColor = lineColor;
+                    element.set('lineColor', lineColor, {silent: true});
                 }
                 if (setLineWidth) {
-                    element.lineWidth = lineWidth;
+                    element.set('lineWidth', lineWidth, {silent: true});
                 }
             });
+            const annotationData = _.extend({}, this.annotation.get('annotation'));
+            annotationData.elements = this.annotation.elements().toJSON();
+            this.annotation.set('annotation', annotationData);
         }
 
         _.extend(this.annotation.get('annotation'), {


### PR DESCRIPTION
When modifying the colors of all elements of an annotation, the changes weren't saved to properly work everywhere.

Fixes #755.