### PR TITLE
Make sure annotations are saved.

### DIFF
--- a/plugin_tests/client/annotationSpec.js
+++ b/plugin_tests/client/annotationSpec.js
@@ -1086,6 +1086,7 @@ $(function () {
                     $('#h-annotation-context-menu .h-remove-elements').click();
                     expect($('#h-annotation-context-menu').hasClass('hidden')).toBe(true);
                 });
+                girderTest.waitForLoad();
             });
 
             it('open a different image', function () {

--- a/web_client/panels/AnnotationSelector.js
+++ b/web_client/panels/AnnotationSelector.js
@@ -176,7 +176,11 @@ var AnnotationSelector = Panel.extend({
                     model.unset('displayed');
                     model.unset('highlight');
                     this.collection.remove(model);
-                    model.destroy();
+                    if (model._saving) {
+                        model._saveAgain = 'delete';
+                    } else {
+                        model.destroy();
+                    }
                 }
             });
         }
@@ -206,6 +210,15 @@ var AnnotationSelector = Panel.extend({
 
     _refreshAnnotations() {
         if (!this.parentItem || !this.parentItem.id) {
+            return;
+        }
+        // if any annotations are saving, defer this
+        if (!this.viewer._saving) {
+            this.viewer._saving = {};
+        }
+        delete this.viewer._saving.refresh;
+        if (Object.keys(this.viewer._saving).length) {
+            this.viewer._saving.refresh = true;
             return;
         }
         var models = this.collection.indexBy(_.property('id'));
@@ -346,12 +359,60 @@ var AnnotationSelector = Panel.extend({
     },
 
     _saveAnnotation(annotation) {
+        if (!this.viewer._saving) {
+            this.viewer._saving = {};
+        }
         if (!annotation._saving && !annotation._inFetch && !annotation.get('loading')) {
+            this.viewer._saving[annotation.id] = true;
+            this.$el.addClass('saving');
+            let lastSaveAgain = annotation._saveAgain;
             annotation._saving = true;
+            annotation._saveAgain = false;
             this.trigger('h:redraw', annotation);
-            annotation.save().always(() => {
+            annotation.save().fail(() => {
+                /* If we fail to save (possible because the server didn't
+                 * respond), try again, gradually backing off the frequency
+                 * of retries. */
+                annotation._saveAgain = Math.min(lastSaveAgain ? lastSaveAgain * 2 : 5, 300);
+            }).always(() => {
+                delete this.viewer._saving[annotation.id];
                 annotation._saving = false;
+                if (annotation._saveAgain !== undefined && annotation._saveAgain !== false) {
+                    if (annotation._saveAgain === 'delete') {
+                        annotation.destroy();
+                    } else if (!annotation._saveAgain) {
+                        this._saveAnnotation(annotation);
+                    } else {
+                        this.viewer._saving[annotation.id] = true;
+                        window.setTimeout(() => {
+                            if (annotation._saveAgain !== undefined && annotation._saveAgain !== false) {
+                                this._saveAnnotation(annotation);
+                            }
+                        }, annotation._saveAgain * 1000);
+                    }
+                }
+                if (Object.keys(this.viewer._saving).length === 1 && this.viewer._saving.refresh) {
+                    this._refreshAnnotations();
+                }
+                if (!Object.keys(this.viewer._saving).length || (Object.keys(this.viewer._saving).length === 1 && this.viewer._saving.refresh)) {
+                    this.$el.removeClass('saving');
+                }
             });
+        } else if (!annotation._inFetch && !annotation.get('loading')) {
+            /* if we are saving, flag that we need to save again after we
+             * finish as there are newer changes. */
+            if (annotation._saveAgain !== 'delete') {
+                annotation._saveAgain = 0;
+            }
+        } else {
+            annotation._saveAgain = false;
+            delete this.viewer._saving[annotation.id];
+            if (Object.keys(this.viewer._saving).length === 1 && this.viewer._saving.refresh) {
+                this._refreshAnnotations();
+            }
+            if (!Object.keys(this.viewer._saving).length || (Object.keys(this.viewer._saving).length === 1 && this.viewer._saving.refresh)) {
+                this.$el.removeClass('saving');
+            }
         }
     },
 

--- a/web_client/stylesheets/panels/annotationSelector.styl
+++ b/web_client/stylesheets/panels/annotationSelector.styl
@@ -81,3 +81,14 @@
 
 .h-annotation:hover
   background-color #eee
+
+.h-annotation-selector
+  .s-panel-title
+    .save-mark
+      display none
+.h-annotation-selector.saving
+  .s-panel-title
+    .icon-tags
+      display none
+    .save-mark
+      display inherit

--- a/web_client/templates/panels/annotationSelector.pug
+++ b/web_client/templates/panels/annotationSelector.pug
@@ -1,7 +1,7 @@
 extends ./panel.pug
 
 block title
-  | #[span.icon-tags] #{title}
+  | #[span.icon-tags] #[span.icon-spin1.animate-spin.save-mark(title="Saving Annotations")] #{title}
 
 block content
   .btn-group.h-hide-show-buttons(role='group')


### PR DESCRIPTION
We have a bug when saving annotations to a slow database or an intermittently connected server.  Specifically, when we are saving an annotation and another change occurs, we were not saving again (to prevent race conditions).  However, this means the second save might never happen.  Similarly, if the save failed, we would not retry it.

This fixes the issue by marking that we need to call save again after the first save request completes (success or fail).  In the event of failure, retry the save after a delay.