### PR TITLE
Speed up updating annotation elements.

### DIFF
--- a/ansible/roles/girder-histomicstk/templates/girder.local.cfg.j2
+++ b/ansible/roles/girder-histomicstk/templates/girder.local.cfg.j2
@@ -12,7 +12,7 @@ hash_alg: "bcrypt"
 bcrypt_rounds: 12
 
 [database]
-uri: "mongodb://{{ mongo_private_ip }}:27017/{{ mongo_girder_database }}"
+uri: "mongodb://{{ mongo_private_ip }}:27017/{{ mongo_girder_database }}?socketTimeoutMS=3600000"
 replica_set: None
 
 [server]

--- a/plugin_tests/client/annotationSpec.js
+++ b/plugin_tests/client/annotationSpec.js
@@ -1086,6 +1086,7 @@ $(function () {
                     $('#h-annotation-context-menu .h-remove-elements').click();
                     expect($('#h-annotation-context-menu').hasClass('hidden')).toBe(true);
                 });
+                girderTest.waitForLoad();
             });
 
             it('open a different image', function () {

--- a/web_client/dialogs/editElement.js
+++ b/web_client/dialogs/editElement.js
@@ -65,6 +65,7 @@ var EditElement = View.extend({
             return;
         }
 
+        this.trigger('h:editElement', {element: this.annotationElement, data: data});
         this.annotationElement.set(data);
         this.$el.modal('hide');
     },

--- a/web_client/panels/AnnotationSelector.js
+++ b/web_client/panels/AnnotationSelector.js
@@ -176,7 +176,11 @@ var AnnotationSelector = Panel.extend({
                     model.unset('displayed');
                     model.unset('highlight');
                     this.collection.remove(model);
-                    model.destroy();
+                    if (model._saving) {
+                        model._saveAgain = 'delete';
+                    } else {
+                        model.destroy();
+                    }
                 }
             });
         }
@@ -206,6 +210,15 @@ var AnnotationSelector = Panel.extend({
 
     _refreshAnnotations() {
         if (!this.parentItem || !this.parentItem.id) {
+            return;
+        }
+        // if any annotations are saving, defer this
+        if (!this.viewer._saving) {
+            this.viewer._saving = {};
+        }
+        delete this.viewer._saving.refresh;
+        if (Object.keys(this.viewer._saving).length) {
+            this.viewer._saving.refresh = true;
             return;
         }
         var models = this.collection.indexBy(_.property('id'));
@@ -346,12 +359,60 @@ var AnnotationSelector = Panel.extend({
     },
 
     _saveAnnotation(annotation) {
+        if (!this.viewer._saving) {
+            this.viewer._saving = {};
+        }
         if (!annotation._saving && !annotation._inFetch && !annotation.get('loading')) {
+            this.viewer._saving[annotation.id] = true;
+            this.$el.addClass('saving');
+            let lastSaveAgain = annotation._saveAgain;
             annotation._saving = true;
+            annotation._saveAgain = false;
             this.trigger('h:redraw', annotation);
-            annotation.save().always(() => {
+            annotation.save().fail(() => {
+                /* If we fail to save (possible because the server didn't
+                 * respond), try again, gradually backing off the frequency
+                 * of retries. */
+                annotation._saveAgain = Math.min(lastSaveAgain ? lastSaveAgain * 2 : 5, 300);
+            }).always(() => {
+                delete this.viewer._saving[annotation.id];
                 annotation._saving = false;
+                if (annotation._saveAgain !== undefined && annotation._saveAgain !== false) {
+                    if (annotation._saveAgain === 'delete') {
+                        annotation.destroy();
+                    } else if (!annotation._saveAgain) {
+                        this._saveAnnotation(annotation);
+                    } else {
+                        this.viewer._saving[annotation.id] = true;
+                        window.setTimeout(() => {
+                            if (annotation._saveAgain !== undefined && annotation._saveAgain !== false) {
+                                this._saveAnnotation(annotation);
+                            }
+                        }, annotation._saveAgain * 1000);
+                    }
+                }
+                if (Object.keys(this.viewer._saving).length === 1 && this.viewer._saving.refresh) {
+                    this._refreshAnnotations();
+                }
+                if (!Object.keys(this.viewer._saving).length || (Object.keys(this.viewer._saving).length === 1 && this.viewer._saving.refresh)) {
+                    this.$el.removeClass('saving');
+                }
             });
+        } else if (!annotation._inFetch && !annotation.get('loading')) {
+            /* if we are saving, flag that we need to save again after we
+             * finish as there are newer changes. */
+            if (annotation._saveAgain !== 'delete') {
+                annotation._saveAgain = 0;
+            }
+        } else {
+            annotation._saveAgain = false;
+            delete this.viewer._saving[annotation.id];
+            if (Object.keys(this.viewer._saving).length === 1 && this.viewer._saving.refresh) {
+                this._refreshAnnotations();
+            }
+            if (!Object.keys(this.viewer._saving).length || (Object.keys(this.viewer._saving).length === 1 && this.viewer._saving.refresh)) {
+                this.$el.removeClass('saving');
+            }
         }
     },
 

--- a/web_client/panels/DrawWidget.js
+++ b/web_client/panels/DrawWidget.js
@@ -73,18 +73,23 @@ var DrawWidget = Panel.extend({
         this.$('[data-toggle="tooltip"]').tooltip('destroy');
         if (!this.viewer) {
             this.$el.empty();
+            delete this._skipRenderHTML;
             return;
         }
         const name = (this.annotation.get('annotation') || {}).name || 'Untitled';
         this.trigger('h:redraw', this.annotation);
-        this.$el.html(drawWidget({
-            title: 'Draw',
-            elements: this.collection.models,
-            groups: this._groups,
-            style: this._style.id,
-            highlighted: this._highlighted,
-            name
-        }));
+        if (this._skipRenderHTML) {
+            delete this._skipRenderHTML;
+        } else {
+            this.$el.html(drawWidget({
+                title: 'Draw',
+                elements: this.collection.models,
+                groups: this._groups,
+                style: this._style.id,
+                highlighted: this._highlighted,
+                name
+            }));
+        }
         if (this._drawingType) {
             this.$('button.h-draw[data-type="' + this._drawingType + '"]').addClass('active');
             this.drawElement(undefined, this._drawingType);
@@ -143,7 +148,16 @@ var DrawWidget = Panel.extend({
      * the EditAnnotation modal dialog.
      */
     editElement(evt) {
-        editElement(this.collection.get(this._getId(evt)));
+        var dialog = editElement(this.collection.get(this._getId(evt)));
+        this.listenTo(dialog, 'h:editElement', (obj) => {
+            // update the html immediately instead of rerendering it
+            let id = obj.element.id,
+                label = (obj.data.label || {}).value,
+                elemType = obj.element.get('type');
+            label = label || (elemType === 'polyline' ? (obj.element.get('closed') ? 'polygon' : 'line') : elemType);
+            this.$(`.h-element[data-id="${id}"] .h-element-label`).text(label).attr('title', label);
+            this._skipRenderHTML = true;
+        });
     },
 
     /**
@@ -151,7 +165,10 @@ var DrawWidget = Panel.extend({
      * the element from the element collection.
      */
     deleteElement(evt) {
-        this.collection.remove(this._getId(evt));
+        let id = this._getId(evt);
+        this.$(`.h-element[data-id="${id}"]`).remove();
+        this._skipRenderHTML = true;
+        this.collection.remove(id);
     },
 
     /**

--- a/web_client/stylesheets/panels/annotationSelector.styl
+++ b/web_client/stylesheets/panels/annotationSelector.styl
@@ -81,3 +81,14 @@
 
 .h-annotation:hover
   background-color #eee
+
+.h-annotation-selector
+  .s-panel-title
+    .save-mark
+      display none
+.h-annotation-selector.saving
+  .s-panel-title
+    .icon-tags
+      display none
+    .save-mark
+      display inherit

--- a/web_client/templates/panels/annotationSelector.pug
+++ b/web_client/templates/panels/annotationSelector.pug
@@ -1,7 +1,7 @@
 extends ./panel.pug
 
 block title
-  | #[span.icon-tags] #{title}
+  | #[span.icon-tags] #[span.icon-spin1.animate-spin.save-mark(title="Saving Annotations")] #{title}
 
 block content
   .btn-group.h-hide-show-buttons(role='group')


### PR DESCRIPTION
When an annotation element is edited or deleted, the entire list was rerendered.  Now, the appropriate element is modified or removed.  This still rerenders the entire list on additions (and probably on group edits, too).

On long lists this is a substantial speedup (500 ms for a list that is ~2000 elements long).

