### PR TITLE
Fix IndexError in simple_mask() if no peaks are found

### DIFF
--- a/histomicstk/utils/simple_mask.py
+++ b/histomicstk/utils/simple_mask.py
@@ -79,7 +79,7 @@ def simple_mask(im_rgb, bandwidth=2, bgnd_std=2.5, tissue_std=30,
     if len(Peaks) > 1:
         TissuePeak = Peaks[yHist[Peaks[1:]].argmax() + 1]
     else:  # no peak found - take initial guess at 2/3 distance from origin
-        TissuePeak = np.asscalar(xHist[np.round(0.66*xHist.size)])
+        TissuePeak = xHist[int(np.round(0.66*xHist.size))].item()
 
     # analyze background peak to estimate variance parameter via FWHM
     BGScale = estimate_variance(xHist, yHist, BGPeak)


### PR DESCRIPTION
If no peaks are found in the image histogram, the fallback definition of
TissuePeak throws an IndexError in Python 3. This commit addresses it by
converting the index to an integer.