### PR TITLE
Pin the version of digital_slide_archive.

### DIFF
--- a/ansible/group_vars/all
+++ b/ansible/group_vars/all
@@ -4,7 +4,7 @@ girder_version: 2.x-maintenance
 slicer_cli_web_version: 2.x-maintenance
 histomicstk_version: master
 large_image_version: 2.x-maintenance
-dsa_version: master
+dsa_version: 2.x-maintenance
 girder_worker_version: v0.5.1
 itk_version: master
 mongo_dbpath: /mongodata


### PR DESCRIPTION
DSA will be moving to Girder 3 shortly.  This allows this branch to continue to build for Girder 2.