### PR TITLE
allow backup callbacks

### DIFF
--- a/histomicstk/utils/girder_convenience_utils.py
+++ b/histomicstk/utils/girder_convenience_utils.py
@@ -22,22 +22,35 @@ def connect_to_api(apiurl, apikey=None, interactive=True):
     return gc
 
 
-def backup_annotation_jsons(gc, folderid, local):
+def backup_annotation_jsons(
+        gc, folderid, local, save_json=True,
+        callback=None, callback_kwargs=dict()):
     """Dump annotations of folder and subfolders locally recursively.
 
-    This reproduces this tiered structure locally and dumps annotations there.
-    Adapted from Lee A.D. Cooper
+    This reproduces this tiered structure locally and (possibly) dumps
+    annotations there. Adapted from Lee A.D. Cooper
 
     Parameters
     -----------
-    gc : object
-        girder client object
+    gc : girder_client.GirderClient
+        authenticated girder client instance
 
     folderid : str
         girder id of source (base) folder
 
     local : str
         local path to dump annotations
+
+    save_json : bool
+        whether to dump annotations as json file
+
+    callback : function
+        function to call that takes in AT LEAST the following params
+        - annotations: loaded annotations
+        - local: local directory
+
+    callback_kwargs : dict
+        kwargs to pass along to callback
 
     """
     print("\n== Dumping results to:", local, " ==\n")
@@ -53,12 +66,22 @@ def backup_annotation_jsons(gc, folderid, local):
             print("%s: load annotations" % monitorStr)
             annotations = gc.get('/annotation/item/' + item['_id'])
 
-            # dump to JSON in local folder
-            if annotations:
-                print("%s: save json" % monitorStr)
-                savepath = os.path.join(local, item['name'] + '.json')
-                with open(savepath, 'w') as fout:
-                    json.dump(annotations, fout)
+            if annotations is not None:
+
+                # dump to JSON in local folder
+                if save_json:
+                    print("%s: save json" % monitorStr)
+                    savepath = os.path.join(local, item['name'] + '.json')
+                    with open(savepath, 'w') as fout:
+                        json.dump(annotations, fout)
+
+                # run callback
+                if callback is not None:
+                    print("%s: run callback" % monitorStr)
+                    callback(
+                        annotations=annotations, local=local,
+                        **callback_kwargs)
+
         except Exception as e:
             print(str(e))
 

--- a/histomicstk/utils/girder_convenience_utils.py
+++ b/histomicstk/utils/girder_convenience_utils.py
@@ -93,4 +93,6 @@ def backup_annotation_jsons(
         os.mkdir(new_folder)
 
         # call self
-        backup_annotation_jsons(gc, folder['_id'], new_folder)
+        backup_annotation_jsons(
+            gc, folder['_id'], new_folder,
+            callback=callback, callback_kwargs=callback_kwargs)

--- a/histomicstk/utils/tests/girder_convenience_utils_test.py
+++ b/histomicstk/utils/tests/girder_convenience_utils_test.py
@@ -32,7 +32,13 @@ class GirderConvenienceTest(unittest.TestCase):
         gc = connect_to_api(APIURL, apikey=APIKEY)
 
         savepath = tempfile.mkdtemp()
-        backup_annotation_jsons(gc, folderid=SAMPLE_FOLDER_ID, local=savepath)
+
+        def dummy(annotations, local, printme=''):
+            print(printme)
+
+        backup_annotation_jsons(
+            gc, folderid=SAMPLE_FOLDER_ID, local=savepath,
+            callback=dummy, callback_kwargs={'printme': "callback works!"})
 
         self.assertGreater(len(os.listdir(savepath)), 0)
 


### PR DESCRIPTION
Allow running function callbacks when backing up annotation jsons. For example, one may decide to create segmentation masks from annotations and to dump them locally. Any callback is allowed, and is specified by the user. 