### PR TITLE
Fix an issue with the externaldata directory permissions

### DIFF
--- a/tests/htk_test_utilities.py
+++ b/tests/htk_test_utilities.py
@@ -109,6 +109,9 @@ def girderClient():
 
     cwd = os.getcwd()
     thisDir = os.path.dirname(os.path.realpath(__file__))
+    externdatadir = os.path.join(thisDir, '..', '.tox', 'externaldata')
+    if not os.path.exists(externdatadir):
+        os.makedirs(externdatadir)
     os.chdir(thisDir)
     outfilePath = os.path.join(tempfile.gettempdir(), 'histomicstk_test_girder_log.txt')
     with open(outfilePath, 'w') as outfile:


### PR DESCRIPTION
When a test is run that using a girder server in a docker container, the externaldata folder could be created as the root user.  To avoid this, precreate this directory.