### PR TITLE
Linspace int check

### DIFF
--- a/histomicstk/filters/edge/gaussian_grad.py
+++ b/histomicstk/filters/edge/gaussian_grad.py
@@ -30,10 +30,10 @@ def gaussian_grad(im_input, sigma):
     """
 
     # generate separable gaussian derivative kernels
-    x = np.linspace(0, 2 * 3 * sigma, 2 * 3 * sigma + 1)
-    y = np.linspace(0, 2 * 3 * sigma, 2 * 3 * sigma + 1)
-    x -= 2 * 3 * sigma / 2  # center independent variables at zero
-    y -= 2 * 3 * sigma / 2
+    x = np.linspace(0, np.ceil(2 * 3 * sigma), int(np.ceil(2 * 3 * sigma) + 1))
+    y = np.linspace(0, np.ceil(2 * 3 * sigma), int(np.ceil(2 * 3 * sigma) + 1))
+    x -= np.ceil(2 * 3 * sigma) / 2  # center independent variables at zero
+    y -= np.ceil(2 * 3 * sigma) / 2
     x = np.reshape(x, (1, x.size))  # reshape to 2D row and column vectors
     y = np.reshape(y, (y.size, 1))
     xGx = 2 * x / (sigma ** 2) * np.exp(-x ** 2 / (2 * sigma ** 2)) \

--- a/histomicstk/filters/shape/clog.py
+++ b/histomicstk/filters/shape/clog.py
@@ -70,7 +70,7 @@ def clog(im_input, im_mask, sigma_min, sigma_max):
     sigma_end = np.ceil(sigma_max)
 
     sigma_list = np.linspace(sigma_start, sigma_end,
-                             sigma_end - sigma_start + 1)
+                             int(sigma_end - sigma_start + 1))
 
     for sigma in sigma_list:
 

--- a/histomicstk/filters/shape/glog.py
+++ b/histomicstk/filters/shape/glog.py
@@ -79,7 +79,7 @@ def glog(im_input, alpha=1, range=None, theta=np.pi/4, tau=0.6, eps=0.6):
     SigmaX = np.exp(range[XRange])
 
     # define rotation angles
-    Thetas = np.linspace(0, np.pi - theta, np.round(np.pi / theta))
+    Thetas = np.linspace(0, np.pi - theta, int(np.round(np.pi / theta)))
 
     # loop over SigmaX, SigmaY and then angle, summing up filter responses
     Rsum = np.zeros(im_input.shape)
@@ -108,8 +108,8 @@ def glog(im_input, alpha=1, range=None, theta=np.pi/4, tau=0.6, eps=0.6):
 def glogkernel(sigma_x, sigma_y, theta):
 
     N = np.ceil(2 * 3 * sigma_x)
-    X, Y = np.meshgrid(np.linspace(0, N, N + 1) - N / 2,
-                       np.linspace(0, N, N + 1) - N / 2)
+    X, Y = np.meshgrid(np.linspace(0, N, int(N + 1)) - N / 2,
+                       np.linspace(0, N, int(N + 1)) - N / 2)
     a = np.cos(theta) ** 2 / (2 * sigma_x ** 2) + \
         np.sin(theta) ** 2 / (2 * sigma_y ** 2)
     b = -np.sin(2 * theta) / (4 * sigma_x ** 2) + \

--- a/histomicstk/segmentation/nuclear/gaussian_voting.py
+++ b/histomicstk/segmentation/nuclear/gaussian_voting.py
@@ -89,10 +89,10 @@ def gaussian_voting(I, rmax=35, rmin=10, sSigma=5, Tau=5, bw=15, Psi=0.3):
             dMag[Voting[0][i]][Voting[1][i]]
 
     # create voting kernel
-    x = np.linspace(0, 2*3*vSigma, 2*3*vSigma + 1)  # independent variables
-    y = np.linspace(0, 2*3*vSigma, 2*3*vSigma + 1)
-    x -= 2*3*vSigma/2  # center at zero
-    y -= 2*3*vSigma/2
+    x = np.linspace(0, np.ceil(2*3*vSigma), int(np.ceil(2*3*vSigma) + 1))
+    y = np.linspace(0, np.ceil(2*3*vSigma), int(np.ceil(2*3*vSigma) + 1))
+    x -= np.ceil(2*3*vSigma)/2  # center at zero
+    y -= np.ceil(2*3*vSigma)/2
     x = np.reshape(x, (1, x.size))  # reshape to 2D row and column vectors
     y = np.reshape(y, (y.size, 1))
     xK = np.exp(-x**2 / (2 * vSigma**2)) / (sSigma * (2 * np.pi) ** 0.5)


### PR DESCRIPTION
This branch fixes required int type of 'num' argument for numpy linspace. Several of our filtering functions were floats and not even integer valued.