### PR TITLE
Handle the latest version of pip.

### DIFF
--- a/Dockerfile-wheels
+++ b/Dockerfile-wheels
@@ -43,6 +43,8 @@ RUN cd $htk_path && \
     strip --strip-unneeded /usr/local/lib{,64}/*.{so,a} || true && \
     for PYBIN in /opt/python/*/bin; do \
         ${PYBIN}/pip install --no-cache-dir . && \
+        # Remove any previous build artifacts && \
+        git clean -fxd && \
         ${PYBIN}/pip wheel . --no-deps -w /io/wheelhouse/; \
     done && \
     for WHL in /io/wheelhouse/histomicstk*.whl; do \


### PR DESCRIPTION
The latest release of pip (20.1) now builds wheels using the local directory rather than copying to a temp directory.  This prevents building multiple python versions without cleaning the Cython artifacts between builds.