### PR TITLE
Fix an issue with get_contours_from_mask.

### DIFF
--- a/histomicstk/annotations_and_masks/masks_to_annotations_handler.py
+++ b/histomicstk/annotations_and_masks/masks_to_annotations_handler.py
@@ -145,12 +145,20 @@ def _get_contours_df(
 
     # pad with zeros to be able to detect edge contours later
     pad_margin = 50
-    MASK = np.pad(MASK, pad_margin, 'constant')
+    pad_value = 0
+    while (GTCodes_df.GT_code == pad_value).any():
+        pad_value += 1
+    MASK = np.pad(MASK, pad_margin, 'constant', constant_values=pad_value)
 
     # Go through unique groups one by one -- each group (i.e. GTCode)
     # is extracted separately by binarizing the multi-class mask
     if groups_to_get is None:
         groups_to_get = list(GTCodes_df.index)
+    else:
+        groups_to_get = [
+            GTCodes_df[GTCodes_df.group == group].head(1).index[0]
+            if (GTCodes_df.group == group).any() else group
+            for group in groups_to_get]
     contours_df = DataFrame()
 
     for nestgroup in groups_to_get:
@@ -291,7 +299,7 @@ def get_contours_from_mask(
             rgb format. eg. rgb(255,0,0).
     groups_to_get : None
         if None (default) then all groups (ground truth labels) will be
-        extracted. Otherwise pass a list fo strings like ['mostly_tumor',].
+        extracted. Otherwise pass a list of strings like ['mostly_tumor',].
     MIN_SIZE : int
         minimum bounding box size of contour
     MAX_SIZE : None

--- a/histomicstk/annotations_and_masks/tests/test_masks_to_annotations_handler.py
+++ b/histomicstk/annotations_and_masks/tests/test_masks_to_annotations_handler.py
@@ -62,6 +62,52 @@ class TestMasksToAnnotations(object):
         assert set(contours_df.columns) == set(self.CONTOURS_DF.columns)
         assert all(contours_df.iloc[:10, :] == self.CONTOURS_DF.iloc[:10, :])
 
+    def test_get_contours_from_mask_with_groups(self):
+        """Test get_contours_from_mask()."""
+        self._setup()
+        # get contours from mask
+        groups_to_get = [
+            'mostly_tumor', 'mostly_stroma']
+        contours_df = get_contours_from_mask(
+            MASK=self.MASK, GTCodes_df=self.GTCodes_df,
+            groups_to_get=groups_to_get,
+            get_roi_contour=True, roi_group='roi',
+            discard_nonenclosed_background=True,
+            background_group='mostly_stroma',
+            MIN_SIZE=30, MAX_SIZE=None, verbose=False,
+            monitorPrefix=self.MASKNAME[:12] + ": getting contours")
+
+        # make sure it is what we expect
+        assert set(contours_df.columns) == set(self.CONTOURS_DF.columns)
+        assert all(contours_df.iloc[:10, :] == self.CONTOURS_DF.iloc[:10, :])
+        assert len(contours_df) == 26
+
+    def test_get_contours_from_mask_with_zeroes(self):
+        """Test get_contours_from_mask()."""
+        self._setup()
+        groups_to_get = None
+        gtcodes = self.GTCodes_df.append({
+            'group': 'zeroes',
+            'overlay_order': 4,
+            'GT_code': 0,
+            'is_roi': 0,
+            'is_background_class': 0,
+            'color': 'rgb(0,128,0)',
+            'comments': 'zeroes'}, ignore_index=True)
+        gtcodes.index = gtcodes.loc[:, 'group']
+        contours_df = get_contours_from_mask(
+            MASK=self.MASK, GTCodes_df=gtcodes,
+            groups_to_get=groups_to_get,
+            get_roi_contour=True, roi_group='roi',
+            discard_nonenclosed_background=True,
+            background_group='mostly_stroma',
+            MIN_SIZE=30, MAX_SIZE=None)
+
+        # make sure it is what we expect
+        assert set(contours_df.columns) == set(self.CONTOURS_DF.columns)
+        assert all(contours_df.iloc[:10, :] == self.CONTOURS_DF.iloc[:10, :])
+        assert len(contours_df) == 49
+
     @pytest.mark.usefixtures('girderClient')  # noqa
     def test_get_annotation_documents_from_contours(self, girderClient):  # noqa
         """Test get_contours_from_bin_mask()."""


### PR DESCRIPTION
If a groundtruth group had a GT_code of 0, the use of padding to detect edges caused incorrect results.  Now, the padding value is guaranteed not be be a present GT_code.

This also fixes a bug when passing groups_to_get.