### PR TITLE
Fix joblib reference in scikit-learn.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -172,6 +172,18 @@ jobs:
       - run:
           name: Build HistomicsTK docker
           command: docker build --force-rm -t dsarchive/histomicstk .
+      - run:
+          name: Get xml for each cli
+          command: |
+            docker run --rm dsarchive/histomicstk:latest --list_cli
+            docker run --rm dsarchive/histomicstk:latest BackgroundIntensity --xml
+            docker run --rm dsarchive/histomicstk:latest ColorDeconvolution --xml
+            docker run --rm dsarchive/histomicstk:latest ComputeNucleiFeatures --xml
+            docker run --rm dsarchive/histomicstk:latest NucleiClassification --xml
+            docker run --rm dsarchive/histomicstk:latest NucleiDetection --xml
+            docker run --rm dsarchive/histomicstk:latest PositivePixelCount --xml
+            docker run --rm dsarchive/histomicstk:latest SeparateStainsMacenkoPCA --xml
+            docker run --rm dsarchive/histomicstk:latest SeparateStainsXuSnmf --xml
   wheels:
     working_directory: ~/project
     docker:

--- a/histomicstk/cli/NucleiClassification/NucleiClassification.py
+++ b/histomicstk/cli/NucleiClassification/NucleiClassification.py
@@ -4,7 +4,11 @@ import colorsys
 
 import numpy as np
 import pandas as pd
-from sklearn.externals import joblib
+try:
+    import joblib
+except ImportError:
+    # Versions of scikit-learn before 0.21 had joblib internally
+    from sklearn.externals import joblib
 import dask.dataframe as dd
 
 from histomicstk.cli.utils import CLIArgumentParser


### PR DESCRIPTION
scikit-learn "devendored" joblib, so now it has to be imported differently.

This adds tests for all CLIs to report their options, which would have caught this issue.

Resolves #869.