### PR TITLE
Simplify the Dockerfile.

### DIFF
--- a/Dockerfile-wheels
+++ b/Dockerfile-wheels
@@ -1,8 +1,9 @@
 FROM dockcross/manylinux2010-x64
 
-# Don't build python 3.4 or 2.7m wheels.
+# Don't build python 2.7m, 3.4, or 3.9 wheels.
 RUN rm -rf /opt/python/cp27-cp27m
 RUN rm -rf /opt/python/cp34*
+RUN rm -rf /opt/python/cp39*
 
 RUN for PYBIN in /opt/python/*/bin; do \
         ${PYBIN}/pip install --no-cache-dir --upgrade pip; \


### PR DESCRIPTION
Before, this was based on the dsarchive/base_docker_image, which greatly sped up building the docker image when we built all dependencies in the docker.  Since all of the complex dependencies are now available as wheels, this no longer has much advantage.

We can install fewer system packages, which shrinks the size of the docker a small amount.

We can more easily be explicit about the version of Python we want to use.  Here it has been changed to 3.8.

As a starting point, if you need a newer version of cuda, that can more easily be changed, too.

Additionally, dockcross now supports Python 3.9, but we can't build with it yet.