### PR TITLE
Test in Python 3.9.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -142,14 +142,30 @@ jobs:
     steps:
       - checkout
       - upgradepython:
-          version: 3.8.3
+          version: 3.8.6
       - run:
           name: Use pyenv to set python version
           command: |
             pyenv versions
-            pyenv global 3.8.3
+            pyenv global 3.8.6
       - tox:
           env: py38
+      - coverage
+  py39:
+    working_directory: ~/project
+    machine:
+      image: circleci/classic:201808-01
+    steps:
+      - checkout
+      - upgradepython:
+          version: 3.9.1
+      - run:
+          name: Use pyenv to set python version
+          command: |
+            pyenv versions
+            pyenv global 3.9.1
+      - tox:
+          env: py39
       - coverage
   lint_and_docs:
     working_directory: ~/project
@@ -303,6 +319,13 @@ workflows:
             branches:
               ignore:
                 - gh-pages
+      - py39:
+          filters:
+            tags:
+              only: /^v.*/
+            branches:
+              ignore:
+                - gh-pages
       - lint_and_docs:
           filters:
             tags:
@@ -331,6 +354,7 @@ workflows:
             - py36
             - py37
             - py38
+            - py39
             - lint_and_docs
             - wheels
             - docker
@@ -346,6 +370,7 @@ workflows:
             - py36
             - py37
             - py38
+            - py39
             - lint_and_docs
             - wheels
             - docker

--- a/Dockerfile-wheels
+++ b/Dockerfile-wheels
@@ -1,9 +1,8 @@
-FROM dockcross/manylinux2010-x64
+FROM dockcross/manylinux2014-x64
 
-# Don't build python 2.7m, 3.4, or 3.9 wheels.
+# Don't build python 2.7m, or 3.4 wheels.
 RUN rm -rf /opt/python/cp27-cp27m
 RUN rm -rf /opt/python/cp34*
-RUN rm -rf /opt/python/cp39*
 
 RUN for PYBIN in /opt/python/*/bin; do \
         ${PYBIN}/pip install --no-cache-dir --upgrade pip; \
@@ -14,7 +13,9 @@ RUN for PYBIN in /opt/python/*/bin; do \
     done
 
 RUN for PYBIN in /opt/python/*/bin; do \
-      if [[ "${PYBIN}" =~ "38" ]]; then \
+      if [[ "${PYBIN}" =~ "39" ]]; then \
+        export VERSIONS="numpy==1.19.*"; \
+      elif [[ "${PYBIN}" =~ "38" ]]; then \
         export VERSIONS="numpy==1.17.*"; \
       elif [[ "${PYBIN}" =~ "37" ]]; then \
         export VERSIONS="numpy==1.14.*"; \
@@ -54,4 +55,4 @@ RUN cd $htk_path && \
     done && \
     ls -l /io/wheelhouse && \
     mkdir /io/wheels && \
-    cp /io/wheelhouse/histomicstk*many*2010* /io/wheels/.
+    cp /io/wheelhouse/histomicstk*many*2014* /io/wheels/.

--- a/setup.py
+++ b/setup.py
@@ -94,8 +94,11 @@ setup(
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
         'Topic :: Scientific/Engineering :: Artificial Intelligence',
         'Topic :: Software Development :: Libraries :: Python Modules',
     ],
     zip_safe=False,
+    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*',
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-  py{27,35,36,37,38}
+  py{27,35,36,37,38,39}
   docs
   flake8
 skip_missing_interpreters = true
@@ -13,6 +13,7 @@ python =
   3.6: py36
   3.7: py37, docs, flake8
   3.8: py38
+  3.9: py39
 
 [testenv]
 passenv = DOCKER_*
@@ -36,7 +37,6 @@ skipsdist = true
 skip_install = true
 deps =
   flake8
-  flake8-blind-except
   flake8-bugbear; python_version >= '3.5'
   flake8-docstrings
   flake8-quotes
@@ -95,7 +95,6 @@ ignore =
   W504
   # We may wish to gradually change or reconsider these
   B007
-  B902
   D201
   D202
   D204


### PR DESCRIPTION
This had to wait for several packages to have a 3.9 wheel (opencv-python-headless and shapely).

This moves the wheels to use manylinux2014.
