### PR TITLE
fix object mask to be restricted to unique products

### DIFF
--- a/histomicstk/annotations_and_masks/annotations_to_object_mask_handler.py
+++ b/histomicstk/annotations_and_masks/annotations_to_object_mask_handler.py
@@ -292,6 +292,14 @@ def annotations_to_contours_no_mask(
 # %%===========================================================================
 
 
+def combs_with_unique_products(low, high, k):
+    combs = {
+        np.prod(comb): comb
+        for comb in combinations(range(low, high), k)
+    }
+    return iter(combs.values())
+
+
 def contours_to_labeled_object_mask(
         contours, gtcodes, mode='object', verbose=False, monitorprefix=''):
     """Process contours to get and object segmentation labeled mask.
@@ -375,14 +383,14 @@ def contours_to_labeled_object_mask(
 
     # unique combinations of number to be multiplied (second & third channel)
     # to be able to reconstruct the object ID when image is re-read
-    object_code_comb = combinations(range(1, 256), 2)
+    object_code_comb = combs_with_unique_products(1, 256, 2)
 
     # Add annotations in overlay order
     overlay_orders = sorted(set(gtcodes.loc[:, 'overlay_order']))
     N_elements = contours.shape[0]
 
     # Make sure we don't run out of object encoding values.
-    if N_elements > 32358:
+    if N_elements > 17437:  # max unique products
         raise Exception("Too many objects!!")
 
     # Add roiinfo & init roi

--- a/histomicstk/annotations_and_masks/annotations_to_object_mask_handler.py
+++ b/histomicstk/annotations_and_masks/annotations_to_object_mask_handler.py
@@ -345,7 +345,7 @@ def contours_to_labeled_object_mask(
     Returns
     -------
     np.array
-        If mode is "object", this returns an (m, n, 3) np array
+        If mode is "object", this returns an (m, n, 3) np array of dtype uint8
         that can be saved as a png
         First channel: encodes label (can be used for semantic segmentation)
         Second & third channels: multiplication of second and third channel
@@ -358,6 +358,9 @@ def contours_to_labeled_object_mask(
         compatibility with data loaders that expect an image or mask.
         If mode is "semantic" only the labels (corresponding to first
         channel of the object mode) is output.
+        ** IMPORTANT NOTE ** When you read this mask and decide to reconstruct
+        the object codes, convert it to float32 so that the product doesn't
+        saturate at 255.
 
     """
     def _process_gtcodes(gtcodesdf):

--- a/histomicstk/annotations_and_masks/annotations_to_object_mask_handler.py
+++ b/histomicstk/annotations_and_masks/annotations_to_object_mask_handler.py
@@ -293,11 +293,12 @@ def annotations_to_contours_no_mask(
 
 
 def combs_with_unique_products(low, high, k):
-    combs = {
-        np.prod(comb): comb
-        for comb in combinations(range(low, high), k)
-    }
-    return iter(combs.values())
+    prods = set()
+    for comb in combinations(range(low, high), k):
+        prod = np.prod(comb)
+        if prod not in prods:
+            yield comb
+            prods.add(prod)
 
 
 def contours_to_labeled_object_mask(

--- a/histomicstk/annotations_and_masks/tests/test_annotations_to_object_mask_handler.py
+++ b/histomicstk/annotations_and_masks/tests/test_annotations_to_object_mask_handler.py
@@ -184,7 +184,7 @@ class TestGetSlideRegionNoMask:
         mask = imread(os.path.join(cfg.SAVEPATHS['mask'], imname + '.png'))
         assert mask.shape == (82, 92, 3)
         assert set(np.unique(mask[..., 0])) == {0, 1, 2, 7}
-        assert set(np.unique(mask[..., 1])) == {0, 1}
+        assert set(np.unique(mask[..., 1])) == {0, 1, 2, 3}
         assert set(np.unique(mask[..., 2])) == {
             0, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12}
 

--- a/histomicstk/annotations_and_masks/tests/test_annotations_to_object_mask_handler.py
+++ b/histomicstk/annotations_and_masks/tests/test_annotations_to_object_mask_handler.py
@@ -185,8 +185,7 @@ class TestGetSlideRegionNoMask:
         assert mask.shape == (82, 92, 3)
         assert set(np.unique(mask[..., 0])) == {0, 1, 2, 7}
         assert set(np.unique(mask[..., 1])) == {0, 1, 2, 3}
-        assert set(np.unique(mask[..., 2])) == {
-            0, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12}
+        assert set(np.unique(mask[..., 2])) == {0, 2, 3, 4, 5, 7, 9, 11}
 
         # Second, we test the semantic segmentation mode
         cfg.get_all_rois_kwargs['mode'] = 'semantic'

--- a/histomicstk/annotations_and_masks/tests/test_annotations_to_object_mask_handler.py
+++ b/histomicstk/annotations_and_masks/tests/test_annotations_to_object_mask_handler.py
@@ -184,8 +184,9 @@ class TestGetSlideRegionNoMask:
         mask = imread(os.path.join(cfg.SAVEPATHS['mask'], imname + '.png'))
         assert mask.shape == (82, 92, 3)
         assert set(np.unique(mask[..., 0])) == {0, 1, 2, 7}
-        assert set(np.unique(mask[..., 1])) == {0, 1, 2, 3}
-        assert set(np.unique(mask[..., 2])) == {0, 2, 3, 4, 5, 7, 9, 11}
+        assert set(np.unique(mask[..., 1])) == {0, 1}
+        assert set(np.unique(mask[..., 2])) == {
+            0, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12}
 
         # Second, we test the semantic segmentation mode
         cfg.get_all_rois_kwargs['mode'] = 'semantic'


### PR DESCRIPTION
When parsing object masks, the current codebase ensures that the **combination** of 2nd and 3rd mask channel is unique, but does not actually guarantee that the **product** of 2nd and 3rd channel is unique (which is the desired behavior). This was not discovered earlier because it only becomes relevant for fields with > 256 objects.