### PR TITLE
Use a specific version of numpy in our wheels.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -141,6 +141,9 @@ jobs:
       - image: circleci/python:3.7
     steps:
       - checkout
+      - run:
+          name: Upgrade pip
+          command: pip install -U pip
       - tox:
           env: docs,flake8
       - store_artifacts:
@@ -181,6 +184,9 @@ jobs:
           command: |
             if [ ! -d env ]; then python -m virtualenv env || python -m venv env; fi
             echo ". $CIRCLE_WORKING_DIRECTORY/env/bin/activate" >> $BASH_ENV
+      - run:
+          name: Upgrade pip
+          command: pip install -U pip
       - run:
           name: Install python packages
           command: pip install setuptools_scm twine

--- a/Dockerfile
+++ b/Dockerfile
@@ -59,6 +59,9 @@ WORKDIR $htk_path
 RUN pip install --no-cache-dir --upgrade pip setuptools && \
     # Install bokeh to help debug dask \
     pip install --no-cache-dir 'bokeh>=0.12.14' && \
+    # Install a specific version of numpy.  This needs to be compatible with
+    # tensorflow and our wheels \
+    pip install --no-cache-dir 'numpy==1.17.5' && \
     # Install large_image memcached extras \
     pip install --no-cache-dir --pre 'large-image[memcached]' --find-links https://girder.github.io/large_image_wheels && \
     # Install girder-client \

--- a/Dockerfile-wheels
+++ b/Dockerfile-wheels
@@ -10,10 +10,6 @@ RUN for PYBIN in /opt/python/*/bin; do \
     done
 
 RUN for PYBIN in /opt/python/*/bin; do \
-        ${PYBIN}/pip install --no-cache-dir -f https://girder.github.io/large_image_wheels 'large_image[sources]' pyvips; \
-    done
-
-RUN for PYBIN in /opt/python/*/bin; do \
       if [[ "${PYBIN}" =~ "39" ]]; then \
         export VERSIONS="numpy==1.19.*"; \
       elif [[ "${PYBIN}" =~ "38" ]]; then \
@@ -25,6 +21,10 @@ RUN for PYBIN in /opt/python/*/bin; do \
         export VERSIONS="numpy==1.12.*"; \
       fi && \
       ${PYBIN}/pip install setuptools-scm 'Cython>=0.25.2' 'scikit-build>=0.8.1' 'cmake>=0.6.0' "${VERSIONS}"; \
+    done
+
+RUN for PYBIN in /opt/python/*/bin; do \
+        ${PYBIN}/pip install --no-cache-dir -f https://girder.github.io/large_image_wheels 'large_image[sources]' pyvips; \
     done
 
 ENV htk_path=/HistomicsTK


### PR DESCRIPTION
The version of tensorflow in the gpu environment is not compatible with latest numpy, but since we copy the packages the pip resolver doesn't correct this.