### PR TITLE
Fix building docs on CI.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -145,8 +145,8 @@ jobs:
     steps:
       - checkout
       - run:
-          name: Upgrade pip
-          command: pip install -U pip
+          name: Install dependencies
+          command: sudo apt-get update -yq && sudo apt install -yq pandoc
       - tox:
           env: docs,flake8
       - store_artifacts:

--- a/tox.ini
+++ b/tox.ini
@@ -8,11 +8,11 @@ toxworkdir = {toxinidir}/.tox
 
 [testenv]
 passenv = DOCKER_*
-install_command = pip install --upgrade --upgrade-strategy eager --find-links https://girder.github.io/large_image_wheels {opts} {packages}
 # This adds the tests directory to the python path so we can import the test
 # utilities as needed.
 setenv =
-  PYTHONPATH = {toxinidir}/tests
+  PYTHONPATH={toxinidir}/tests
+  PIP_FIND_LINKS=https://girder.github.io/large_image_wheels
 deps =
   coverage
   pooch
@@ -42,7 +42,7 @@ usedevelop = false
 deps =
   jupyter
   nbsphinx
-  py-pandoc
+  pypandoc
   sphinx
   sphinx-rtd-theme
 changedir = {toxinidir}/docs


### PR DESCRIPTION
Recent changes to pip break install pandoc via py-pandoc.  Install via apt-get and use pypandoc instead.