### PR TITLE
Update trace_object_boundaries.py

### DIFF
--- a/histomicstk/segmentation/label/trace_object_boundaries.py
+++ b/histomicstk/segmentation/label/trace_object_boundaries.py
@@ -157,7 +157,7 @@ def _remove_thin_colinear_spurs(px, py, eps_colinear_area=0):
 
         # get coords of next triplet of points to test
         if testpos == len(px) - 1:
-            if not len(keep):
+            if not keep:
                 break
             nextpos = keep[0]
         else:


### PR DESCRIPTION
#PERFORMANCE
Using the len function to check if a sequence is empty is not idiomatic and can be less performant than checking the truthiness of the object.
len doesn't know the context in which it is called, so if computing the length means traversing the entire sequence, it must; it doesn't know that the result is just being compared to 0. Computing the boolean value can stop after it sees the first element, regardless of how long the sequence actually is.