### PR TITLE
Shapely 1.8 causes some tests to fail.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ setup(
         'scikit-image>=0.14.2',
         'scikit-learn>=0.18.1',
         'imageio>=2.3.0',
-        'shapely[vectorized]',
+        'shapely[vectorized]<1.8',
         'opencv-python-headless',
         'sqlalchemy',
         'matplotlib',


### PR DESCRIPTION
Pin to shapely<1.8 until we can determine what changed.