### PR TITLE
Add analysis to create superpixel pixelmaps and annotations

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -171,6 +171,7 @@ jobs:
             docker run --rm dsarchive/histomicstk:latest PositivePixelCount --xml
             docker run --rm dsarchive/histomicstk:latest SeparateStainsMacenkoPCA --xml
             docker run --rm dsarchive/histomicstk:latest SeparateStainsXuSnmf --xml
+            docker run --rm dsarchive/histomicstk:latest SuperpixelSegmentation --xml
       - run:
           name: Archive docker images
           command: |

--- a/histomicstk/cli/SuperpixelSegmentation/SuperpixelSegmentation.py
+++ b/histomicstk/cli/SuperpixelSegmentation/SuperpixelSegmentation.py
@@ -178,7 +178,7 @@ def createSuperPixels(opts):  # noqa
 
     if opts.outputAnnotationFile:
         print(opts.outputAnnotationFile)
-        region = utils.get_region_dict(opts.roi, None, ts)['region']
+        region_dict = utils.get_region_dict(opts.roi, None, ts)
         annotation = {
             'name': 'Superpixel Pixelmap %s' % (
                 os.path.splitext(os.path.basename(opts.outputAnnotationFile))[0]),
@@ -187,8 +187,8 @@ def createSuperPixels(opts):  # noqa
                 'type': 'pixelmap',
                 'girderId': 'outputImageFile',
                 'transform': {
-                    'xoffset': region.get('left', 0),
-                    'yoffset': region.get('top', 0),
+                    'xoffset': region_dict.get('region', {}).get('left', 0),
+                    'yoffset': region_dict.get('region', {}).get('top', 0),
                 },
                 'values': [0] * found,
                 'categories': [{

--- a/histomicstk/cli/SuperpixelSegmentation/SuperpixelSegmentation.py
+++ b/histomicstk/cli/SuperpixelSegmentation/SuperpixelSegmentation.py
@@ -177,7 +177,29 @@ def createSuperPixels(opts):  # noqa
         bigtiff=True, compression='lzw', predictor='horizontal')
 
     if opts.outputAnnotationFile:
-        print(opts.outputAnnotationFile)
+        print('>> Generating annotation file')
+        categories = [
+            {
+                'label': 'no_category',
+                'fillColor': 'rgba(0, 0, 0, 0)',
+                'strokeColor': 'rgba(0, 0, 0, 1)',
+            },
+            {
+                'label': opts.label_1,
+                'fillColor': opts.fillColor_1,
+                'strokeColor': opts.strokeColor_1,
+            },
+            {
+                'label': opts.label_2,
+                'fillColor': opts.fillColor_2,
+                'strokeColor': opts.strokeColor_2,
+            },
+            {
+                'label': opts.label_3,
+                'fillColor': opts.fillColor_3,
+                'strokeColor': opts.strokeColor_3,
+            },
+        ]
         region_dict = utils.get_region_dict(opts.roi, None, ts)
         annotation = {
             'name': 'Superpixel Pixelmap %s' % (
@@ -191,11 +213,7 @@ def createSuperPixels(opts):  # noqa
                     'yoffset': region_dict.get('region', {}).get('top', 0),
                 },
                 'values': [0] * found,
-                'categories': [{
-                    'fillColor': 'rgba(0, 0, 0, 0)',
-                    'strokeColor': 'rgba(0, 0, 0, 1)',
-                    'label': 'default_category',
-                }],
+                'categories': categories,
                 'boundaries': opts.boundaries,
             }],
         }

--- a/histomicstk/cli/SuperpixelSegmentation/SuperpixelSegmentation.py
+++ b/histomicstk/cli/SuperpixelSegmentation/SuperpixelSegmentation.py
@@ -28,7 +28,7 @@ def createSuperPixels(opts):  # noqa
     tiparams = utils.get_region_dict(opts.roi, None, ts)
 
     print('>> Generating superpixels')
-    if opts.compactness == 0:
+    if opts.slic_zero:
         print('>> Using SLIC Zero for segmentation')
     for tile in ts.tileIterator(
         format=large_image.constants.TILE_FORMAT_NUMPY,
@@ -66,11 +66,12 @@ def createSuperPixels(opts):  # noqa
                     mask[suby:suby + submask.shape[0], :submask.shape[1]] *= submask
             n_pixels = numpy.count_nonzero(mask)
         n_segments = math.ceil(n_pixels / averageSize)
-        if opts.compactness == 0:
+        if opts.slic_zero:
             segments = skimage.segmentation.slic(
                 img,
                 n_segments=n_segments,
                 slic_zero=True,
+                compactness=opts.compactness,
                 sigma=opts.sigma,
                 start_label=0,
                 enforce_connectivity=True,
@@ -195,7 +196,7 @@ def createSuperPixels(opts):  # noqa
                 'strokeColor': opts.default_strokeColor,
             },
         ]
-        if opts.compactness == 0:
+        if opts.slic_zero:
             annotation_name = '%s - SLIC 0' % (
                 os.path.splitext(os.path.basename(opts.outputAnnotationFile))[0])
         else:

--- a/histomicstk/cli/SuperpixelSegmentation/SuperpixelSegmentation.py
+++ b/histomicstk/cli/SuperpixelSegmentation/SuperpixelSegmentation.py
@@ -1,0 +1,207 @@
+import json
+import logging
+import math
+import os
+
+import large_image
+import numpy
+import pyvips
+import scipy
+import skimage
+from histomicstk.cli import utils
+from histomicstk.cli.utils import CLIArgumentParser
+
+logging.basicConfig()
+
+
+def createSuperPixels(opts):  # noqa
+    averageSize = opts.superpixelSize ** 2
+    overlap = opts.superpixelSize * 4 * 2 if opts.overlap else 0
+    tileSize = opts.tileSize + overlap
+    boundaries = opts.boundaries
+
+    print('>> Reading input image')
+    print(opts.inputImageFile)
+
+    ts = large_image.getTileSource(opts.inputImageFile)
+    meta = ts.getMetadata()
+    found = 0
+    strips = []
+    tiparams = {}
+    tiparams = utils.get_region_dict(opts.roi, None, ts)
+
+    print('>> Generating superpixels')
+    for tile in ts.tileIterator(
+        format=large_image.constants.TILE_FORMAT_NUMPY,
+        tile_size=dict(width=tileSize, height=tileSize),
+        tile_overlap=dict(x=overlap, y=overlap),
+        **tiparams,
+    ):
+        print('%d/%d (%d x %d) - %d' % (
+            tile['tile_position']['position'], tile['iterator_range']['position'],
+            tile['width'], tile['height'],
+            found))
+        x0 = tiparams.get('region', {}).get('left', 0)
+        y0 = tiparams.get('region', {}).get('top', 0)
+        img = tile['tile']
+        compactness = opts.compactness
+        n_pixels = tile['width'] * tile['height']
+        mask = None
+        if overlap:
+            mask = numpy.ones(img.shape[:2])
+            for y, simg in strips:
+                if (y < tile['y'] - y0 + tile['height'] and
+                        y + simg.height > tile['y'] - y0 and
+                        simg.width > tile['x'] - x0):
+                    suby = max(0, y - (tile['y'] - y0))
+                    subimg = simg.crop(
+                        tile['x'] - x0,
+                        max(0, tile['y'] - y0 - y),
+                        min(tile['width'], simg.width),
+                        min(tile['height'], simg.height - max(0, tile['y'] - y0 - y)))
+                    # Our mask is true when a pixel has not been set
+                    submask = numpy.ndarray(
+                        buffer=subimg[3].write_to_memory(),
+                        dtype=numpy.uint8,
+                        shape=[subimg.height, subimg.width]) == 0
+                    mask[suby:suby + submask.shape[0], :submask.shape[1]] *= submask
+            n_pixels = numpy.count_nonzero(mask)
+        n_segments = math.ceil(n_pixels / averageSize)
+        while True:
+            segments = skimage.segmentation.slic(
+                img,
+                n_segments=n_segments,
+                compactness=compactness,
+                sigma=opts.sigma,
+                start_label=0,
+                enforce_connectivity=True,
+                # max_num_iter=100,
+                mask=mask,
+            )
+            # We now have an array that is the same size as the image
+            maxValue = numpy.max(segments) + 1
+            if maxValue >= n_segments / 4:
+                break
+            print('Adjusting compactness from %g - got %d rather than %d' % (
+                compactness, maxValue, n_segments))
+            compactness *= 10
+        if compactness != opts.compactness:
+            print('Adjusted compactness to %g - got %d' % (
+                compactness, maxValue))
+        if overlap:
+            # Keep any segment that is at all in the non-overlap region
+            core = segments[
+                :tile['height'] - tile['tile_overlap']['bottom'],
+                :tile['width'] - tile['tile_overlap']['right']]
+            coremask = mask[
+                :tile['height'] - tile['tile_overlap']['bottom'],
+                :tile['width'] - tile['tile_overlap']['right']]
+            core[numpy.where(coremask != 1)] = -1
+            usedIndices = numpy.unique(core)
+            usedIndices = numpy.delete(usedIndices, numpy.where(usedIndices < 0))
+            usedLut = [-1] * maxValue
+            for idx, used in enumerate(usedIndices):
+                if used >= 0:
+                    usedLut[used] = idx
+            usedLut = numpy.array(usedLut, dtype=int)
+            print('reduced from %d to %d' % (maxValue, len(usedIndices)))
+            maxValue = len(usedIndices)
+            segments = usedLut[segments]
+            mask *= (segments != -1)
+        if boundaries:
+            segments *= 2
+            maxValue *= 2
+            edges = (scipy.ndimage.sobel(segments, axis=0) != 0) | (
+                scipy.ndimage.sobel(segments, axis=1) != 0)
+            edges[0, :] = True
+            edges[-1, :] = True
+            edges[:, 0] = True
+            edges[:, -1] = True
+            segments += edges
+        segments += found
+        found += int(maxValue)
+        if mask is None:
+            data = numpy.dstack((
+                (segments % 256).astype(int),
+                (segments / 256).astype(int) % 256,
+                (segments / 65536).astype(int) % 256)).astype('B')
+        else:
+            data = numpy.dstack((
+                (segments % 256).astype(int),
+                (segments / 256).astype(int) % 256,
+                (segments / 65536).astype(int) % 256,
+                mask * 255)).astype('B')
+        # For overlay, suppose we make any value whose centroid is in the
+        # overlap region transparent.  Then, use vips to overlap the
+        # images rather than inserting them.
+        vimg = pyvips.Image.new_from_memory(
+            numpy.ascontiguousarray(data).data,
+            data.shape[1], data.shape[0], data.shape[2],
+            large_image.constants.dtypeToGValue[data.dtype.char])
+        vimg = vimg.copy(interpretation=pyvips.Interpretation.RGB)
+        vimgTemp = pyvips.Image.new_temp_file('%s.v')
+        vimg.write(vimgTemp)
+        vimg = vimgTemp
+        x = tile['x'] - x0
+        ty = tile['tile_position']['region_y']
+        while len(strips) <= ty:
+            strips.append(None)
+        if strips[ty] is None:
+            strip = pyvips.Image.black(
+                tiparams.get('region', {}).get('width', meta['sizeX']),
+                vimg.height, bands=vimg.bands)
+            strip = strip.copy(interpretation=pyvips.Interpretation.RGB)
+            strips[ty] = [tile['y'] - y0, strip]
+        strips[ty][1] = strips[ty][1].composite([vimg], pyvips.BlendMode.OVER, x=int(x), y=0)
+    print('>> Found %d superpixels' % found)
+    if found > 256 ** 3:
+        print('Too many superpixels')
+    img = pyvips.Image.black(
+        tiparams.get('region', {}).get('width', meta['sizeX']),
+        tiparams.get('region', {}).get('height', meta['sizeY']),
+        bands=strips[0][1].bands)
+    img = img.copy(interpretation=pyvips.Interpretation.RGB)
+    for stripidx in range(len(strips)):
+        img = img.composite(
+            [strips[stripidx][1]], pyvips.BlendMode.OVER, x=0, y=int(strips[stripidx][0]))
+    # Discard alpha band, if any.
+    img = img[:3]
+    # Add program run parameters to the image description and list the
+    # superpixel count
+    img.set_type(
+        pyvips.GValue.gstr_type, 'image-description',
+        json.dumps(dict(vars(opts), indexCount=found)))
+    img.write_to_file(
+        opts.outputImageFile, tile=True, tile_width=256, tile_height=256, pyramid=True,
+        region_shrink='nearest',
+        bigtiff=True, compression='lzw', predictor='horizontal')
+
+    if opts.outputAnnotationFile:
+        print(opts.outputAnnotationFile)
+        region = utils.get_region_dict(opts.roi, None, ts)['region']
+        annotation = {
+            'name': 'Superpixel Pixelmap %s' % (
+                os.path.splitext(os.path.basename(opts.outputAnnotationFile))[0]),
+            'description': 'Used params %r' % vars(opts),
+            'elements': [{
+                'type': 'pixelmap',
+                'girderId': 'outputImageFile',
+                'transform': {
+                    'xoffset': region.get('left', 0),
+                    'yoffset': region.get('top', 0),
+                },
+                'values': [0] * found,
+                'categories': [{
+                    'fillColor': 'rgba(0, 0, 0, 0)',
+                    'strokeColor': 'rgba(0, 0, 0, 1)',
+                    'label': 'default_category',
+                }],
+                'boundaries': opts.boundaries,
+            }],
+        }
+        with open(opts.outputAnnotationFile, 'w') as annotation_file:
+            json.dump(annotation, annotation_file, indent=2, sort_keys=False)
+
+
+if __name__ == "__main__":
+    createSuperPixels(CLIArgumentParser().parse_args())

--- a/histomicstk/cli/SuperpixelSegmentation/SuperpixelSegmentation.xml
+++ b/histomicstk/cli/SuperpixelSegmentation/SuperpixelSegmentation.xml
@@ -76,9 +76,9 @@
       <name>compactness</name>
       <label>Compactness</label>
       <longflag>compactness</longflag>
-      <description>Balances color proximity and space proximity. Higher values give more weight to space proximity, making superpixel shapes more square/cubic.</description>
+      <description>Balances color proximity and space proximity. Higher values give more weight to space proximity, making superpixel shapes more square/cubic. If set to 0, use SLICO to adaptively choose compactness for each superpixel.</description>
       <channel>input</channel>
-      <default>1.0</default>
+      <default>0</default>
     </float>
     <float>
       <name>sigma</name>

--- a/histomicstk/cli/SuperpixelSegmentation/SuperpixelSegmentation.xml
+++ b/histomicstk/cli/SuperpixelSegmentation/SuperpixelSegmentation.xml
@@ -89,4 +89,79 @@
       <default>1.0</default>
     </float>
   </parameters>
+  <parameters>
+    <label>Category Details 1</label>
+    <description>Details for a category to label superpixels with. Used in the annotation file.</description>
+    <string>
+      <name>label_1</name>
+      <label>Label</label>
+      <longflag>label_1</longflag>
+      <description>Label used for superpixels</description>
+      <default>Label_1</default>
+    </string>
+    <string>
+      <name>fillColor_1</name>
+      <label>Fill Color</label>
+      <longflag>fillColor_1</longflag>
+      <description>Color to fill superpixels with this label</description>
+      <default>rgba(255, 0, 0, 0.5)</default>
+    </string>
+    <string>
+      <name>strokeColor_1</name>
+      <label>Stroke Color</label>
+      <longflag>strokeColor_1</longflag>
+      <description>If creating boundary superpixels, this is the color of the boundaries of superpixels with this label</description>
+      <default>rgba(0, 0, 0, 1)</default>
+    </string>
+  </parameters>
+  <parameters>
+    <label>Category Details 2</label>
+    <description>Details for a category to label superpixels with. Used in the annotation file.</description>
+    <string>
+      <name>label_2</name>
+      <label>Label</label>
+      <longflag>label_2</longflag>
+      <description>Label used for superpixels</description>
+      <default>Label_2</default>
+    </string>
+    <string>
+      <name>fillColor_2</name>
+      <label>Fill Color</label>
+      <longflag>fillColor_2</longflag>
+      <description>Color to fill superpixels with this label</description>
+      <default>rgba(0, 255, 0, 0.5)</default>
+    </string>
+    <string>
+      <name>strokeColor_2</name>
+      <label>Stroke Color</label>
+      <longflag>strokeColor_2</longflag>
+      <description>If creating boundary superpixels, this is the color of the boundaries of superpixels with this label</description>
+      <default>rgba(0, 0, 0, 1)</default>
+    </string>
+  </parameters>
+  <parameters>
+    <label>Category Details 3</label>
+    <description>Details for a category to label superpixels with. Used in the annotation file.</description>
+    <string>
+      <name>label_3</name>
+      <label>Label</label>
+      <longflag>label_3</longflag>
+      <description>Label used for superpixels</description>
+      <default>Label_3</default>
+    </string>
+    <string>
+      <name>fillColor_3</name>
+      <label>Fill Color</label>
+      <longflag>fillColor_3</longflag>
+      <description>Color to fill superpixels with this label</description>
+      <default>rgba(0, 0, 255, 0.5)</default>
+    </string>
+    <string>
+      <name>strokeColor_3</name>
+      <label>Stroke Color</label>
+      <longflag>strokeColor_3</longflag>
+      <description>If creating boundary superpixels, this is the color of the boundaries of superpixels with this label</description>
+      <default>rgba(0, 0, 0, 1)</default>
+    </string>
+  </parameters>
 </executable>

--- a/histomicstk/cli/SuperpixelSegmentation/SuperpixelSegmentation.xml
+++ b/histomicstk/cli/SuperpixelSegmentation/SuperpixelSegmentation.xml
@@ -21,7 +21,7 @@
     <image fileExtensions=".tiff" reference="inputImageFile">
       <name>outputImageFile</name>
       <label>Output Image of Superpixel Pixelmap</label>
-      <description>Output Image of Superpixel Pixelmap (.tiff)</description>
+      <description>Output Image of Superpixel Pixelmap (*.tiff)</description>
       <channel>output</channel>
       <index>1</index>
     </image>

--- a/histomicstk/cli/SuperpixelSegmentation/SuperpixelSegmentation.xml
+++ b/histomicstk/cli/SuperpixelSegmentation/SuperpixelSegmentation.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <executable>
   <category>HistomicsTK</category>
-  <title>Create Superpixel Pixelmap</title>
+  <title>Superpixel Pixelmap</title>
   <description>Create a pixelmap image of superpixels using SLIC.</description>
   <version>0.1.0</version>
   <documentation-url>https://digitalslidearchive.github.io/HistomicsTK/</documentation-url>
@@ -44,7 +44,7 @@
        <name>tileSize</name>
        <longflag>tileSize</longflag>
        <label>Working tile size</label>
-       <description>Specify the size of the working tile. If there is no overlap, superpixxel boundaries will appear at these locations.</description>
+       <description>Specify the size of the working tile. If there is no overlap, superpixel boundaries will appear at these locations.</description>
        <channel>input</channel>
        <default>4096</default>
     </integer>
@@ -52,7 +52,7 @@
        <name>superpixelSize</name>
        <longflag>superpixelSize</longflag>
        <label>Superpixel Size</label>
-       <description>Approximate width of the superpixel.</description>
+       <description>Approximate diameter of the average superpixel.</description>
        <channel>input</channel>
        <default>50</default>
     </integer>
@@ -68,7 +68,7 @@
       <name>boundaries</name>
       <label>Boundaries</label>
       <longflag>boundaries</longflag>
-      <description>If specified, draw separate superpixels as boundaries around actual superpixels.</description>
+      <description>Mark the boundary around each superpixel. Boundaries are specified with a separate pixelmap index value that is always 1 higher than the pixelmap index value of the superpixel's interior.</description>
       <channel>input</channel>
       <default>true</default>
     </boolean>
@@ -76,7 +76,7 @@
       <name>compactness</name>
       <label>Compactness</label>
       <longflag>compactness</longflag>
-      <description>SLIC Algorithm Compactness</description>
+      <description>Balances color proximity and space proximity. Higher values give more weight to space proximity, making superpixel shapes more square/cubic.</description>
       <channel>input</channel>
       <default>1.0</default>
     </float>
@@ -84,83 +84,33 @@
       <name>sigma</name>
       <label>Sigma</label>
       <longflag>sigma</longflag>
-      <description>SLIC Algorithm Sigma</description>
+      <description>Width of Gaussian smoothing kernel for pre-processing for each dimension of the image. The same sigma is applied to each dimension in case of a scalar value. Zero means no smoothing.</description>
       <channel>input</channel>
       <default>1.0</default>
     </float>
   </parameters>
   <parameters>
-    <label>Category Details 1</label>
-    <description>Details for a category to label superpixels with. Used in the annotation file.</description>
+    <label>Default Annotation Category</label>
+    <description>Specify a default category for the output pixelmap annotation. Configure the default color of superpixels.</description>
     <string>
-      <name>label_1</name>
-      <label>Label</label>
-      <longflag>label_1</longflag>
-      <description>Label used for superpixels</description>
-      <default>Label_1</default>
+      <name>default_category_label</name>
+      <label>Default Category Label</label>
+      <longflag>default_category_label</longflag>
+      <description>Default category label used for superpixels</description>
+      <default>default</default>
     </string>
     <string>
-      <name>fillColor_1</name>
+      <name>default_fillColor</name>
       <label>Fill Color</label>
-      <longflag>fillColor_1</longflag>
-      <description>Color to fill superpixels with this label</description>
-      <default>rgba(255, 0, 0, 0.5)</default>
+      <longflag>default_fillColor</longflag>
+      <description>Default color for superpixels</description>
+      <default>rgba(0, 0, 0, 0)</default>
     </string>
     <string>
-      <name>strokeColor_1</name>
+      <name>default_strokeColor</name>
       <label>Stroke Color</label>
-      <longflag>strokeColor_1</longflag>
-      <description>If creating boundary superpixels, this is the color of the boundaries of superpixels with this label</description>
-      <default>rgba(0, 0, 0, 1)</default>
-    </string>
-  </parameters>
-  <parameters>
-    <label>Category Details 2</label>
-    <description>Details for a category to label superpixels with. Used in the annotation file.</description>
-    <string>
-      <name>label_2</name>
-      <label>Label</label>
-      <longflag>label_2</longflag>
-      <description>Label used for superpixels</description>
-      <default>Label_2</default>
-    </string>
-    <string>
-      <name>fillColor_2</name>
-      <label>Fill Color</label>
-      <longflag>fillColor_2</longflag>
-      <description>Color to fill superpixels with this label</description>
-      <default>rgba(0, 255, 0, 0.5)</default>
-    </string>
-    <string>
-      <name>strokeColor_2</name>
-      <label>Stroke Color</label>
-      <longflag>strokeColor_2</longflag>
-      <description>If creating boundary superpixels, this is the color of the boundaries of superpixels with this label</description>
-      <default>rgba(0, 0, 0, 1)</default>
-    </string>
-  </parameters>
-  <parameters>
-    <label>Category Details 3</label>
-    <description>Details for a category to label superpixels with. Used in the annotation file.</description>
-    <string>
-      <name>label_3</name>
-      <label>Label</label>
-      <longflag>label_3</longflag>
-      <description>Label used for superpixels</description>
-      <default>Label_3</default>
-    </string>
-    <string>
-      <name>fillColor_3</name>
-      <label>Fill Color</label>
-      <longflag>fillColor_3</longflag>
-      <description>Color to fill superpixels with this label</description>
-      <default>rgba(0, 0, 255, 0.5)</default>
-    </string>
-    <string>
-      <name>strokeColor_3</name>
-      <label>Stroke Color</label>
-      <longflag>strokeColor_3</longflag>
-      <description>If creating boundary superpixels, this is the color of the boundaries of superpixels with this label</description>
+      <longflag>default_strokeColor</longflag>
+      <description>If creating boundary superpixels, this is the default color of the boundaries of the superpixels</description>
       <default>rgba(0, 0, 0, 1)</default>
     </string>
   </parameters>

--- a/histomicstk/cli/SuperpixelSegmentation/SuperpixelSegmentation.xml
+++ b/histomicstk/cli/SuperpixelSegmentation/SuperpixelSegmentation.xml
@@ -72,13 +72,21 @@
       <channel>input</channel>
       <default>true</default>
     </boolean>
+    <boolean>
+      <name>slic_zero</name>
+      <label>SLIC0</label>
+      <longflag>slic_zero</longflag>
+      <description>If true, run the algorithm in SLIC0 mode to adaptively determine compactness for each superpixel.</description>
+      <channel>input</channel>
+      <default>true</default>
+    </boolean>
     <float>
       <name>compactness</name>
       <label>Compactness</label>
       <longflag>compactness</longflag>
-      <description>Balances color proximity and space proximity. Higher values give more weight to space proximity, making superpixel shapes more square/cubic. If set to 0, use SLICO to adaptively choose compactness for each superpixel.</description>
+      <description>Balances color proximity and space proximity. Higher values give more weight to space proximity, making superpixel shapes more square/cubic.</description>
       <channel>input</channel>
-      <default>0</default>
+      <default>1</default>
     </float>
     <float>
       <name>sigma</name>
@@ -86,7 +94,7 @@
       <longflag>sigma</longflag>
       <description>Width of Gaussian smoothing kernel for pre-processing for each dimension of the image. The same sigma is applied to each dimension in case of a scalar value. Zero means no smoothing.</description>
       <channel>input</channel>
-      <default>1.0</default>
+      <default>0</default>
     </float>
   </parameters>
   <parameters>

--- a/histomicstk/cli/SuperpixelSegmentation/SuperpixelSegmentation.xml
+++ b/histomicstk/cli/SuperpixelSegmentation/SuperpixelSegmentation.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<executable>
+  <category>HistomicsTK</category>
+  <title>Create Superpixel Pixelmap</title>
+  <description>Create a pixelmap image of superpixels using SLIC.</description>
+  <version>0.1.0</version>
+  <documentation-url>https://digitalslidearchive.github.io/HistomicsTK/</documentation-url>
+  <license>Apache 2.0</license>
+  <contributor>Kitware</contributor>
+  <acknowledgements>This work is part of the HistomicsTK project.</acknowledgements>
+  <parameters>
+    <label>IO</label>
+    <description>Input/output parameters.</description>
+    <image>
+        <name>inputImageFile</name>
+        <label>Input Image</label>
+        <description>Input image for superpixel segmentation</description>
+        <channel>input</channel>
+        <index>0</index>
+    </image>
+    <image fileExtensions=".tiff" reference="inputImageFile">
+      <name>outputImageFile</name>
+      <label>Output Image of Superpixel Pixelmap</label>
+      <description>Output Image of Superpixel Pixelmap (.tiff)</description>
+      <channel>output</channel>
+      <index>1</index>
+    </image>
+    <file fileExtensions=".anot" reference="inputImageFile">
+      <name>outputAnnotationFile</name>
+      <label>Pixelmap Annotation</label>
+      <description>Annotation to display pixelmap on source (*.anot)</description>
+      <channel>output</channel>
+      <longflag>superpixel_annotation</longflag>
+    </file>
+    <region>
+      <name>roi</name>
+      <label>Analysis ROI</label>
+      <longflag>roi</longflag>
+      <description>Region of interest within which the analysis should be run</description>
+      <channel>input</channel>
+      <default>-1, -1, -1, -1</default>
+    </region>
+    <integer>
+       <name>tileSize</name>
+       <longflag>tileSize</longflag>
+       <label>Working tile size</label>
+       <description>Specify the size of the working tile. If there is no overlap, superpixxel boundaries will appear at these locations.</description>
+       <channel>input</channel>
+       <default>4096</default>
+    </integer>
+    <integer>
+       <name>superpixelSize</name>
+       <longflag>superpixelSize</longflag>
+       <label>Superpixel Size</label>
+       <description>Approximate width of the superpixel.</description>
+       <channel>input</channel>
+       <default>50</default>
+    </integer>
+    <boolean>
+      <name>overlap</name>
+      <label>Overlap</label>
+      <longflag>overlap</longflag>
+      <description>If specified, overlap tile computation to avoid edge effects.</description>
+      <channel>input</channel>
+      <default>false</default>
+    </boolean>
+    <boolean>
+      <name>boundaries</name>
+      <label>Boundaries</label>
+      <longflag>boundaries</longflag>
+      <description>If specified, draw separate superpixels as boundaries around actual superpixels.</description>
+      <channel>input</channel>
+      <default>true</default>
+    </boolean>
+    <float>
+      <name>compactness</name>
+      <label>Compactness</label>
+      <longflag>compactness</longflag>
+      <description>SLIC Algorithm Compactness</description>
+      <channel>input</channel>
+      <default>1.0</default>
+    </float>
+    <float>
+      <name>sigma</name>
+      <label>Sigma</label>
+      <longflag>sigma</longflag>
+      <description>SLIC Algorithm Sigma</description>
+      <channel>input</channel>
+      <default>1.0</default>
+    </float>
+  </parameters>
+</executable>

--- a/histomicstk/cli/slicer_cli_list.json
+++ b/histomicstk/cli/slicer_cli_list.json
@@ -29,5 +29,9 @@
 
   "PositivePixelCount": {
     "type"    : "python"
+  },
+
+  "SuperpixelSegmentation": {
+    "type"    : "python"
   }
 }


### PR DESCRIPTION
This PR adds a new analysis script called `SuperpixelSegmentation`. It outputs a pixelmap image and an annotation file that can be used to overlay the pixelmap on top of the base image.