### PR TITLE
Refactor the positive pixel count example.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -68,6 +68,16 @@ RUN pip install --no-cache-dir --upgrade pip setuptools && \
     # clean up \
     rm -rf /root/.cache/pip/*
 
+# Install the latest version of large_image.  This can be disabled if the
+# latest version we need has had an official release
+# RUN cd /opt && \
+#     git clone https://github.com/girder/large_image && \
+#     cd large_image && \
+#     # git checkout write-with-mask && \
+#     # We can't install editable when we share system-site-packages \
+#     sed  's/-e //g' -i requirements-dev.txt && \
+#     pip install .[all] -r requirements-dev.txt --find-links https://girder.github.io/large_image_wheels
+
 COPY . $htk_path/
 WORKDIR $htk_path
 

--- a/histomicstk/cli/PositivePixelCount/PositivePixelCount.py
+++ b/histomicstk/cli/PositivePixelCount/PositivePixelCount.py
@@ -1,51 +1,122 @@
-import os
+import json
+import pprint
+import time
 
 import large_image
 import numpy as np
-import skimage.io
 
 import histomicstk.segmentation.positive_pixel_count as ppc
 from histomicstk.cli import utils
 from histomicstk.cli.utils import CLIArgumentParser
 
 
-def main(args):
-    utils.create_dask_client(args)
-    ts = large_image.getTileSource(args.inputImageFile)
-    make_label_image = getattr(args, 'outputLabelImage', None) is not None
-    region = utils.get_region_dict(
-        args.region,
-        *(args.maxRegionSize, ts) if make_label_image else ()
-    ).get('region')
+def tile_positive_pixel_count(imagePath, tilePosition, it_kwargs, ppc_params,
+                              color_map, useAlpha, region_polygons):
+    tile_start_time = time.time()
+    ts = large_image.getTileSource(imagePath)
+    tile = ts.getSingleTile(tile_position=tilePosition, **it_kwargs)
+    mask = utils.polygons_to_binary_mask(
+        region_polygons, tile['x'], tile['y'], tile['width'], tile['height'])
+    result, ppcmask = ppc.count_image(tile['tile'], ppc_params, mask)
+    tile.release()
+    ppcimg = color_map[ppcmask]
+    if not useAlpha:
+        ppcimg = ppcimg[:, :, :3]
+    return result, ppcimg, tile['x'], tile['y'], mask, tile_start_time
+
+
+def main(opts):
+    pprint.pprint(vars(opts))
+    ts = large_image.getTileSource(opts.inputImageFile)
+    sink = large_image.new() if getattr(opts, 'outputLabelImage', None) else None
+    tiparams = utils.get_region_dict(opts.region, None, ts)
+    region_polygons = utils.get_region_polygons(opts.region)
+    print('region: %r %r' % (tiparams, region_polygons))
+    tileSize = 2048
+    useAlpha = bool(region_polygons)
+    # Colorize label image.  Colors from the "coolwarm" color map
+    color_map = np.empty((4, 4), dtype=np.uint8)
+    color_map[ppc.Labels.NEGATIVE] = 255, 255, 255, 255
+    color_map[ppc.Labels.WEAK] = 60, 78, 194, 255
+    color_map[ppc.Labels.PLAIN] = 221, 220, 220, 255
+    color_map[ppc.Labels.STRONG] = 180, 4, 38, 255
     ppc_params = ppc.Parameters(
-        **{k: getattr(args, k) for k in ppc.Parameters._fields}
+        **{k: getattr(opts, k) for k in ppc.Parameters._fields}
     )
-    results = ppc.count_slide(
-        args.inputImageFile, ppc_params, region,
-        args.tile_grouping, make_label_image,
-    )
-    if make_label_image:
-        stats, label_image = results
-        # Colorize label image.  Colors from the "coolwarm" color map
-        color_map = np.empty((4, 3), dtype=np.uint8)
-        color_map[ppc.Labels.NEGATIVE] = 255
-        color_map[ppc.Labels.WEAK] = 60, 78, 194
-        color_map[ppc.Labels.PLAIN] = 221, 220, 220
-        color_map[ppc.Labels.STRONG] = 180, 4, 38
-        # Cleverly index color_map
-        label_image = color_map[label_image]
-        try:
-            skimage.io.imsave(args.outputLabelImage, label_image)
-        except ValueError:
-            # This is likely caused by an unknown extension, so try again
-            altname = args.outputLabelImage + '.png'
-            skimage.io.imsave(altname, label_image)
-            os.rename(altname, args.outputLabelImage)
+    results = []
+    if 'left' in tiparams.get('region', {}):
+        sink.crop = (
+            tiparams['region']['left'], tiparams['region']['top'],
+            tiparams['region']['width'], tiparams['region']['height'])
+    tiparams['format'] = large_image.constants.TILE_FORMAT_NUMPY
+    tiparams['tile_size'] = dict(width=tileSize, height=tileSize)
+    tileCount = next(ts.tileIterator(**tiparams))['iterator_range']['position']
+    start_time = time.time()
+    if tileCount > 4 and getattr(opts, 'scheduler', None) != 'none':
+        print('>> Creating Dask client')
+
+        client = utils.create_dask_client(opts)
+        dask_setup_time = time.time() - start_time
+        print('Dask setup time = {}'.format(utils.disp_time_hms(dask_setup_time)))
+        futureList = []
+        for tile in ts.tileIterator(**tiparams):
+            tile_position = tile['tile_position']['position']
+            futureList.append(client.submit(
+                tile_positive_pixel_count,
+                opts.inputImageFile, tile_position, tiparams, ppc_params,
+                color_map, useAlpha, region_polygons))
+        for idx, future in enumerate(futureList):
+            result, ppcimg, x, y, mask, tile_start_time = future.result()
+            results.append(result)
+            if sink:
+                sink.addTile(ppcimg, x, y, mask=mask)
+            print('Processed tile %d/%d\n  %r\n  time %s (%s from start)' % (
+                idx, tileCount, result,
+                utils.disp_time_hms(time.time() - tile_start_time),
+                utils.disp_time_hms(time.time() - start_time)))
     else:
-        stats, = results
-    with open(args.returnParameterFile, 'w') as f:
+        for tile in ts.tileIterator(**tiparams):
+            tile_position = tile['tile_position']['position']
+            result, ppcimg, x, y, mask, tile_start_time = tile_positive_pixel_count(
+                opts.inputImageFile, tile_position, tiparams, ppc_params,
+                color_map, useAlpha, region_polygons)
+            results.append(result)
+            if sink:
+                sink.addTile(ppcimg, x, y, mask=mask)
+            print('Processed tile %d/%d\n  %r\n  time %s (%s from start)' % (
+                tile_position, tileCount, result,
+                utils.disp_time_hms(time.time() - tile_start_time),
+                utils.disp_time_hms(time.time() - start_time)))
+    print('Combining results, time from start %s' % (utils.disp_time_hms(time.time() - start_time)))
+    stats = ppc._combine(results)
+    if sink:
+        print('Outputting file, time from start %s' % (
+            utils.disp_time_hms(time.time() - start_time)))
+        sink_start_time = time.time()
+        sink.write(opts.outputLabelImage, lossy=False)
+        print('Output file, time %s (%s from start)' % (
+            utils.disp_time_hms(time.time() - sink_start_time),
+            utils.disp_time_hms(time.time() - start_time)))
+    pprint.pprint(stats._asdict())
+    with open(opts.returnParameterFile, 'w') as f:
         for k, v in zip(stats._fields, stats):
             f.write(f'{k} = {v}\n')
+    annotation = {
+        'name': 'Positive Pixel Count',
+        'description': 'Used params: %r\nResults: %r' % (vars(opts), stats._asdict()),
+        'elements': [{
+            'type': 'image',
+            'girderId': 'outputLabelImage',
+            'hasAlpha': useAlpha,
+            'transform': {
+                'xoffset': tiparams.get('region', {}).get('left', 0),
+                'yoffset': tiparams.get('region', {}).get('top', 0),
+            },
+        }],
+    }
+    with open(opts.outputAnnotationFile, 'w') as annotation_file:
+        json.dump(annotation, annotation_file, indent=2, sort_keys=False)
+    print('Finished time %s' % (utils.disp_time_hms(time.time() - start_time)))
 
 
 if __name__ == '__main__':

--- a/histomicstk/cli/PositivePixelCount/PositivePixelCount.py
+++ b/histomicstk/cli/PositivePixelCount/PositivePixelCount.py
@@ -88,7 +88,7 @@ def main(opts):
                 utils.disp_time_hms(time.time() - tile_start_time),
                 utils.disp_time_hms(time.time() - start_time)))
     print('Combining results, time from start %s' % (utils.disp_time_hms(time.time() - start_time)))
-    stats = ppc._combine(results)
+    stats = ppc._totals_to_stats(ppc._combine(results))
     if sink:
         print('Outputting file, time from start %s' % (
             utils.disp_time_hms(time.time() - start_time)))

--- a/histomicstk/cli/PositivePixelCount/PositivePixelCount.xml
+++ b/histomicstk/cli/PositivePixelCount/PositivePixelCount.xml
@@ -6,7 +6,7 @@
   <version>0.1.0</version>
   <documentation-url>https://digitalslidearchive.github.io/HistomicsTK</documentation-url>
   <license>Apache 2.0</license>
-  <contributor>Neal Siekierski (Kitware)</contributor>
+  <contributor>David Manthey (Kitware), Neal Siekierski (Kitware)</contributor>
   <acknowledgements>This work is part of the HistomicsTK project.</acknowledgements>
   <parameters>
     <label>I/O</label>
@@ -18,6 +18,13 @@
       <index>0</index>
       <description>Input image in which to count and classify positive pixels</description>
     </image>
+    <region shapes="rectangle,polygon,multipolygon">
+      <name>region</name>
+      <label>Analysis ROI</label>
+      <longflag>region</longflag>
+      <description>Region of interest where analysis is performed.  This is either -1,-1,-1,-1 for thw hole image, or a four-element vector in the format "left, top, width, height", or a list of four or more x,y vertices to specify a polygon.</description>
+      <default>-1,-1,-1,-1</default>
+    </region>
     <float>
       <name>hue_value</name>
       <label>Hue Value</label>
@@ -67,27 +74,30 @@
       <description>Intensity threshold in HSI space below which a pixel is considered negative</description>
       <default>0.05</default>
     </float>
-    <region>
-      <name>region</name>
-      <label>Region</label>
-      <longflag>region</longflag>
-      <description>left,top,width,height of the region of interest.  All -1 means the whole image is used.</description>
-      <default>-1,-1,-1,-1</default>
-    </region>
-    <image fileExtensions=".png">
+    <image fileExtensions=".tiff" reference="inputImageFile">
       <name>outputLabelImage</name>
       <longflag>outputLabelImage</longflag>
       <label>Output Label Image</label>
       <description>Color-coded image of the region, showing the various classes of pixel</description>
       <channel>output</channel>
     </image>
-    <integer>
-      <name>maxRegionSize</name>
-      <longflag>maxRegionSize</longflag>
-      <label>Maximum region size</label>
-      <description>Maximum width and height allowed when processing an image, in order to prevent accidentally running on too large a region.  Use -1 for no limit</description>
-      <default>5000</default>
-    </integer>
+    <string-enumeration>
+      <name>outputImageForm</name>
+      <label>Image Format</label>
+      <description>The output image can either be colored for easy visibility or coded as categorical values where 0 is negative, 1 weak, 2 plain, and 3 strong</description>
+      <channel>input</channel>
+      <longflag>output_form</longflag>
+      <element>visible</element>
+      <element>pixelmap</element>
+      <default>visible</default>
+    </string-enumeration>
+    <file fileExtensions=".anot" reference="inputImageFile">
+      <name>outputAnnotationFile</name>
+      <label>Image Annotation</label>
+      <description>Annotation to relate the image to the source (*.anot)</description>
+      <channel>output</channel>
+      <longflag>image_annotation</longflag>
+    </file>
   </parameters>
   <parameters>
     <label>Output parameters</label>
@@ -148,7 +158,7 @@
     </float>
   </parameters>
   <parameters advanced="true">
-    <label>Dask parameters</label>
+    <label>Dask</label>
     <description>Dask parameters</description>
     <string>
       <name>scheduler</name>
@@ -164,19 +174,12 @@
       <longflag>num_workers</longflag>
       <default>-1</default>
     </integer>
-      <integer>
+    <integer>
       <name>num_threads_per_worker</name>
       <label>Number of threads per worker</label>
       <description>Number of threads to use per worker while setting up a local cluster internally. Must be a positive integer >= 1.</description>
       <longflag>num_threads_per_worker</longflag>
       <default>1</default>
-    </integer>
-    <integer>
-      <name>tile_grouping</name>
-      <label>Tile grouping</label>
-      <longflag>tileGrouping</longflag>
-      <description>Number of tiles to process as part of a single task</description>
-      <default>256</default>
     </integer>
   </parameters>
 </executable>

--- a/histomicstk/cli/docker-entrypoint.sh
+++ b/histomicstk/cli/docker-entrypoint.sh
@@ -13,7 +13,7 @@ memcached -u root -d -m 1024 || true
 # an extra exec if we find the path directly
 POSSIBLE_PATH="$1/$1.py"
 if [[ -f "$POSSIBLE_PATH" ]]; then
-    python "$POSSIBLE_PATH" "${@:2}"
+    python -u "$POSSIBLE_PATH" "${@:2}"
 else
-    python -m slicer_cli_web.cli_list_entrypoint "$@"
+    python -u -m slicer_cli_web.cli_list_entrypoint "$@"
 fi

--- a/histomicstk/segmentation/positive_pixel_count.py
+++ b/histomicstk/segmentation/positive_pixel_count.py
@@ -60,6 +60,7 @@ OutputTotals = namedtuple('OutputTotals', [
     'NumberWeakPositive',
     'NumberPositive',
     'NumberStrongPositive',
+    'NumberTotalPixels',
     'IntensitySumWeakPositive',
     'IntensitySumPositive',
     'IntensitySumStrongPositive',
@@ -69,6 +70,9 @@ Output = namedtuple('Output', OutputTotals._fields + (
     'IntensityAverage',
     'RatioStrongToTotal',
     'IntensityAverageWeakAndPositive',
+    'RatioStrongToPixels',
+    'RatioWeakToPixels',
+    'RatioTotalToPixels',
 ))
 
 
@@ -203,6 +207,8 @@ def _count_image(image, params, mask=None):
         NumberWeakPositive=nw,
         NumberPositive=np_,
         NumberStrongPositive=ns,
+        NumberTotalPixels=(np.count_nonzero(mask) if mask is not None else
+                           image_hsi.shape[0] * image_hsi.shape[1]),
         IntensitySumWeakPositive=iw,
         IntensitySumPositive=ip,
         IntensitySumStrongPositive=is_,
@@ -224,6 +230,9 @@ def _totals_to_stats(total):
             (t.IntensitySumWeakPositive + t.IntensitySumPositive) /
             (t.NumberWeakPositive + t.NumberPositive)
         ) if t.NumberWeakPositive + t.NumberPositive else 0,
+        RatioStrongToPixels=t.NumberStrongPositive / (t.NumberTotalPixels or 1),
+        RatioWeakToPixels=t.NumberWeakPositive / (t.NumberTotalPixels or 1),
+        RatioTotalToPixels=all_positive / (t.NumberTotalPixels or 1),
         **t._asdict()
     )
 


### PR DESCRIPTION
This now can handle arbitrary polygon regions and output images of any size.  It parallelizes using dask if the region is big enough.  The default is to output an annotation with a tiled tiff.  For a different format, specify a file with a different extension (this will be limited in size based on that format).