### PR TITLE
PPC: Don't output an alpha channel if it isn't needed

### DIFF
--- a/histomicstk/cli/PositivePixelCount/PositivePixelCount.py
+++ b/histomicstk/cli/PositivePixelCount/PositivePixelCount.py
@@ -33,7 +33,7 @@ def main(opts):
     region_polygons = utils.get_region_polygons(opts.region)
     print('region: %r %r' % (tiparams, region_polygons))
     tileSize = 2048
-    useAlpha = bool(region_polygons)
+    useAlpha = len(opts.region) > 6
     # Colorize label image.  Colors from the "coolwarm" color map
     color_map = np.empty((4, 4), dtype=np.uint8)
     color_map[ppc.Labels.NEGATIVE] = 255, 255, 255, 255

--- a/histomicstk/cli/utils.py
+++ b/histomicstk/cli/utils.py
@@ -320,7 +320,7 @@ def polygons_to_binary_mask(polygons, x=0, y=0, width=None, height=None):
     for polyidx, poly in enumerate(polygons):
         mask = PIL.Image.new('1', (width, height), 0)
         PIL.ImageDraw.Draw(mask).polygon(
-            [(int(pt[0] - x), int(pt[1] - y)) for pt in poly], outline=None, fill=1, width=0)
+            [(int(pt[0] - x), int(pt[1] - y)) for pt in poly], outline=None, fill=1)
         if not polyidx:
             full = mask
         else:

--- a/setup.py
+++ b/setup.py
@@ -58,9 +58,7 @@ setup(
         'nimfa>=1.3.2',
         'numpy>=1.12.1',
         'scipy>=0.19.0',
-        # Pin Pillow to < 9.1 until a new version of imageio is released that
-        # works with it.
-        'Pillow>=3.2.0,<9.1',
+        'Pillow',
         'pandas>=0.19.2',
         'scikit-image>=0.14.2',
         'scikit-learn>=0.18.1',


### PR DESCRIPTION
This reduces the data volume of positive pixel count output slightly.