### PR TITLE
fix: Update matrix inversion to pseudo-inverse

### DIFF
--- a/histomicstk/preprocessing/color_deconvolution/color_deconvolution.py
+++ b/histomicstk/preprocessing/color_deconvolution/color_deconvolution.py
@@ -77,7 +77,7 @@ def color_deconvolution(im_rgb, w, I_0=None):
     wc = normalize(wc)
 
     # invert stain matrix
-    Q = np.linalg.inv(wc)
+    Q = np.linalg.pinv(wc)
 
     # transform 3D input image to 2D RGB matrix format
     m = utils.convert_image_to_matrix(im_rgb)[:3]


### PR DESCRIPTION
The (Moore-Penrose) [pseudo-inverse](https://numpy.org/doc/stable/reference/generated/numpy.linalg.pinv.html#numpy-linalg-pinv) of a matrix can avoid `numpy.linalg.LinAlgError`: Singular matrix.