### PR TITLE
Adjust the length of the value array.

### DIFF
--- a/histomicstk/cli/SuperpixelSegmentation/SuperpixelSegmentation.py
+++ b/histomicstk/cli/SuperpixelSegmentation/SuperpixelSegmentation.py
@@ -215,7 +215,7 @@ def createSuperPixels(opts):  # noqa
                     'yoffset': region_dict.get('region', {}).get('top', 0) / scale,
                     'matrix': [[scale, 0], [0, scale]],
                 },
-                'values': [0] * found,
+                'values': [0] * (found // (2 if opts.boundaries else 1)),
                 'categories': categories,
                 'boundaries': opts.boundaries,
             }],


### PR DESCRIPTION
When boundaries are turned on, this should be half the number of superpixel indices.