### PR TITLE
Refactor the docker to make it smaller.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,19 +4,11 @@
 #
 # All plugins of HistomicsTK should derive from this docker image
 
-FROM nvidia/cuda:9.2-cudnn7-devel-ubuntu18.04
+FROM python:3.8-slim
 LABEL maintainer="Kitware, Inc. <kitware@kitware.com>"
 
 RUN apt-get update && \
-    # We need software-properties-common for add-apt-repository \
-    apt-get install --yes --no-install-recommends software-properties-common && \
-    # Add python repos \
-    add-apt-repository ppa:deadsnakes/ppa && \
-    apt-get update && \
     apt-get install --yes --no-install-recommends \
-    # Specific version of python \
-    python3.8-dev \
-    python3.8-distutils \
     # For installing pip \
     curl \
     ca-certificates \
@@ -24,29 +16,25 @@ RUN apt-get update && \
     git \
     # for convenience \
     wget \
-    # libcurl4-openssl-dev \
-    # libssl-dev \
     # Needed for building \
     build-essential \
-    # pkg-config \
-    # needed for supporting CUDA \
-    libcupti-dev \
     # can speed up large_image caching \
-    memcached && \
+    memcached \
+    && \
     # Clean up to reduce docker size \
     apt-get autoremove && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # Make a specific version of python the default and install pip
-RUN rm -f /usr/bin/python && \
-    rm -f /usr/bin/python3 && \
-    ln `which python3.8` /usr/bin/python && \
-    ln `which python3.8` /usr/bin/python3 && \
-    curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && \
-    python get-pip.py && \
-    rm get-pip.py && \
-    ln `which pip3` /usr/bin/pip && \
-    python --version
+# RUN rm -f /usr/bin/python && \
+#     rm -f /usr/bin/python3 && \
+#     ln `which python3.8` /usr/bin/python && \
+#     ln `which python3.8` /usr/bin/python3 && \
+#     curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && \
+#     python get-pip.py && \
+#     rm get-pip.py && \
+#     ln `which pip3` /usr/bin/pip && \
+#     python --version
 
 # copy HistomicsTK files
 ENV htk_path=$PWD/HistomicsTK
@@ -55,9 +43,6 @@ RUN mkdir -p $htk_path
 RUN pip install --no-cache-dir --upgrade pip setuptools && \
     # Install bokeh to help debug dask \
     pip install --no-cache-dir 'bokeh>=0.12.14' && \
-    # Install a specific version of numpy.  This needs to be compatible with
-    # tensorflow and our wheels \
-    # pip install --no-cache-dir 'numpy==1.17.5' && \
     # Install large_image memcached and sources extras \
     pip install --no-cache-dir 'large-image[all]' --find-links https://girder.github.io/large_image_wheels && \
     # Install girder-client \
@@ -73,9 +58,7 @@ RUN pip install --no-cache-dir --upgrade pip setuptools && \
 # RUN cd /opt && \
 #     git clone https://github.com/girder/large_image && \
 #     cd large_image && \
-#     # git checkout write-with-mask && \
-#     # We can't install editable when we share system-site-packages \
-#     sed  's/-e //g' -i requirements-dev.txt && \
+#     # git checkout some-branch && \
 #     pip install .[all] -r requirements-dev.txt --find-links https://girder.github.io/large_image_wheels
 
 COPY . $htk_path/
@@ -83,16 +66,11 @@ WORKDIR $htk_path
 
 # Install HistomicsTK and its dependencies
 RUN pip install --no-cache-dir . --find-links https://girder.github.io/large_image_wheels && \
-    # Create separate virtual environments with CPU and GPU versions of tensorflow \
     pip install --no-cache-dir virtualenv && \
-    virtualenv --system-site-packages /venv-gpu && \
-    chmod +x /venv-gpu/bin/activate && \
-    /venv-gpu/bin/pip install --no-cache-dir 'tensorflow-gpu>=1.3.0' && \
     rm -rf /root/.cache/pip/*
 
 # Show what was installed
-RUN pip freeze && \
-    /venv-gpu/bin/pip freeze
+RUN pip freeze
 
 # pregenerate font cache
 RUN python -c "from matplotlib import pylab"

--- a/histomicstk/cli/docker-entrypoint.sh
+++ b/histomicstk/cli/docker-entrypoint.sh
@@ -1,11 +1,5 @@
 #!/usr/bin/env bash
 
-if type nvidia-smi >/dev/null 2>/dev/null;
-then
-    source /venv-gpu/bin/activate
-    echo "NOTE: GPU available" >&2
-fi
-
 # Try to start a local version memcached, but fail gracefully if we can't.
 memcached -u root -d -m 1024 || true
 


### PR DESCRIPTION
We had been using a cuda docker image, but not using any of its features.  The superpixel example
(https://github.com/DigitalSlideArchive/superpixel-classification) has an example that actually uses the GPU.