### PR TITLE
Support frame/style parameter in Nuclei Detection

### DIFF
--- a/histomicstk/cli/NucleiDetection/NucleiDetection.xml
+++ b/histomicstk/cli/NucleiDetection/NucleiDetection.xml
@@ -218,4 +218,17 @@
       <default>1</default>
     </integer>
   </parameters>
+    <parameters advanced="true">
+    <label>Color inversion</label>
+    <description>Choose if color inversion is needed</description>
+    <string-enumeration>
+      <name>colorInversionForm</name>
+      <description>Color inversion may be needed for greyscale images with bright nuclei with dark background. Choose if color inversion is needed.</description>
+      <channel>input</channel>
+      <longflag>output_form</longflag>
+      <element>Yes</element>
+      <element>No</element>
+      <default>No</default>
+    </string-enumeration>
+  </parameters>
 </executable>


### PR DESCRIPTION
1. Updated the code to support color inversion for greyscale images
2. Added a drop-down menu in the UI for receive user input for color inversion.
3. Color de-convolution is only triggered if the user loads an image with more than one channel.