### PR TITLE
Improve repeatability of tox docs process.

### DIFF
--- a/docs/make_docs.sh
+++ b/docs/make_docs.sh
@@ -3,13 +3,12 @@
 set -e
 
 cd "$(dirname $0)"
-stat make_docs.sh
 
-pushd ..
-pip install . -r requirements-dev.txt --find-links https://girder.github.io/large_image_wheels
-popd
-# git clean -fxd .
+# Remove old docs if they exist
+rm -fr _build
 
+# Make the docs
 make html
 
+# Tell circleci not to run CI on the docs output
 cp -r ../.circleci _build/html/.

--- a/tox.ini
+++ b/tox.ini
@@ -41,7 +41,7 @@ commands = flake8 {posargs}
 
 [testenv:docs]
 passenv = HOME
-skip_install = true
+# skip_install = true
 usedevelop = false
 deps =
   jupyter


### PR DESCRIPTION
This uses the tox environment (as much as scikit-build permits) and cleans the docs _build directory.

True build isolation requires switching from scikit-build to scikit-build-core, but that is a different issue.