### PR TITLE
Expose the version number as histomicstk.__version__

### DIFF
--- a/histomicstk/__init__.py
+++ b/histomicstk/__init__.py
@@ -4,6 +4,19 @@ from . import utils  # must be imported before other packages
 from . import (annotations_and_masks, features, filters, preprocessing,
                saliency, workflows)
 
+try:
+    from importlib.metadata import PackageNotFoundError
+    from importlib.metadata import version as _importlib_version
+except ImportError:
+    from importlib_metadata import PackageNotFoundError
+    from importlib_metadata import version as _importlib_version
+try:
+    __version__ = _importlib_version(__name__)
+except PackageNotFoundError:
+    # package is not installed
+    pass
+
+
 # list out things that are available for public use
 __all__ = (
 

--- a/histomicstk/cli/NucleiDetection/NucleiDetection.py
+++ b/histomicstk/cli/NucleiDetection/NucleiDetection.py
@@ -3,10 +3,12 @@ import logging
 import os
 import pprint
 import time
+from pathlib import Path
 
 import large_image
 import numpy as np
 
+import histomicstk
 import histomicstk.preprocessing.color_deconvolution as htk_cdeconv
 import histomicstk.preprocessing.color_normalization as htk_cnorm
 import histomicstk.segmentation.label as htk_seg_label
@@ -389,6 +391,8 @@ def main(args):
             'src_mu_lab': None if src_mu_lab is None else src_mu_lab.tolist(),
             'src_sigma_lab': None if src_sigma_lab is None else src_sigma_lab.tolist(),
             'params': vars(args),
+            'cli': Path(__file__).stem,
+            'version': histomicstk.__version__,
         },
     }
 

--- a/histomicstk/cli/PositivePixelCount/PositivePixelCount.py
+++ b/histomicstk/cli/PositivePixelCount/PositivePixelCount.py
@@ -1,10 +1,12 @@
 import json
 import pprint
 import time
+from pathlib import Path
 
 import large_image
 import numpy as np
 
+import histomicstk
 import histomicstk.segmentation.positive_pixel_count as ppc
 from histomicstk.cli import utils
 from histomicstk.cli.utils import CLIArgumentParser
@@ -115,7 +117,12 @@ def main(opts):
     annotation = {
         'name': 'Positive Pixel Count',
         'description': 'Used params: %r\nResults: %r' % (vars(opts), stats._asdict()),
-        'attributes': {'params': vars(opts), 'stats': stats._asdict()},
+        'attributes': {
+            'params': vars(opts),
+            'stats': stats._asdict(),
+            'cli': Path(__file__).stem,
+            'version': histomicstk.__version__,
+        },
         'elements': [{
             'type': 'image',
             'girderId': 'outputLabelImage',

--- a/setup.py
+++ b/setup.py
@@ -53,6 +53,8 @@ setup(
     include_package_data=True,
     install_requires=[
         'girder-client',
+        # version
+        'importlib-metadata<5 ; python_version < "3.8"',
         # scientific packages
         'nimfa',
         'numpy',


### PR DESCRIPTION
Also, record the cli and version for those clis storing annotation attributes.

This has the virtue that if you are using a new enough version of large_image, you can get a list like this in the item view:
![image](https://github.com/DigitalSlideArchive/HistomicsTK/assets/8781639/2db3414a-2c41-451e-a93c-11a38fc6609f)
This is done using the following snippet in the [`.large_image_config.yaml`](https://girder.github.io/large_image/girder_annotation_config_options.html#large-image-config-yaml) file:
```
    annotationList:
      # Show these columns
      columns:
        -
          type: record
          value: name
        - 
          type: record
          value: creator
          format: user
        - 
          type: record
          value: created
          format: date
        - 
          type: metadata
          value: cli
          title: Algorithm
        - 
          type: metadata
          value: version
          title: Version
        - 
          type: metadata
          value: params.analysis_roi
          title: ROI
        -
          type: metadata
          value: params.tile_overlap_value
          title: Overlap
```