### PR TITLE
SuperpixelSegmentation-annotation-attributs-added-to-metadata

### DIFF
--- a/histomicstk/cli/SuperpixelSegmentation/SuperpixelSegmentation.py
+++ b/histomicstk/cli/SuperpixelSegmentation/SuperpixelSegmentation.py
@@ -236,6 +236,11 @@ def createSuperPixels(opts):  # noqa
                 'categories': categories,
                 'boundaries': opts.boundaries,
             }],
+            'attributes': {
+                'params': vars(opts),
+                'cli': Path(__file__).stem,
+                'version': histomicstk.__version__,
+            },
         }
         if len(bboxes) and str(opts.bounding).lower() != 'separate':
             annotation['elements'][0]['user'] = {'bbox': bboxesUser}
@@ -255,13 +260,6 @@ def createSuperPixels(opts):  # noqa
                 } for bidx, (bcx, bcy, bw, bh) in enumerate(bboxes)],
             }
             annotation = [annotation, bboxannotation]
-        annotation.append({
-            'attributes': {
-                'params': vars(opts),
-                'cli': Path(__file__).stem,
-                'version': histomicstk.__version__,
-            }}
-        )
         with open(opts.outputAnnotationFile, 'w') as annotation_file:
             json.dump(annotation, annotation_file, separators=(',', ':'), sort_keys=False)
         if hasattr(opts, 'callback'):

--- a/histomicstk/cli/SuperpixelSegmentation/SuperpixelSegmentation.py
+++ b/histomicstk/cli/SuperpixelSegmentation/SuperpixelSegmentation.py
@@ -258,6 +258,11 @@ def createSuperPixels(opts):  # noqa
                     'fillColor': 'rgba(0,0,0,0)',
                     'lineColor': opts.default_strokeColor,
                 } for bidx, (bcx, bcy, bw, bh) in enumerate(bboxes)],
+                'attributes': {
+                    'params': vars(opts),
+                    'cli': Path(__file__).stem,
+                    'version': histomicstk.__version__,
+                },
             }
             annotation = [annotation, bboxannotation]
         with open(opts.outputAnnotationFile, 'w') as annotation_file:

--- a/histomicstk/cli/SuperpixelSegmentation/SuperpixelSegmentation.py
+++ b/histomicstk/cli/SuperpixelSegmentation/SuperpixelSegmentation.py
@@ -1,6 +1,7 @@
 import json
 import math
 import os
+from pathlib import Path
 
 import large_image
 import numpy
@@ -8,6 +9,7 @@ import pyvips
 import scipy
 import skimage
 
+import histomicstk
 from histomicstk.cli import utils
 from histomicstk.cli.utils import CLIArgumentParser
 
@@ -222,7 +224,6 @@ def createSuperPixels(opts):  # noqa
         region_dict = utils.get_region_dict(opts.roi, None, ts)
         annotation = {
             'name': annotation_name,
-            'description': 'Used params %r' % vars(opts),
             'elements': [{
                 'type': 'pixelmap',
                 'girderId': 'outputImageFile',
@@ -242,7 +243,6 @@ def createSuperPixels(opts):  # noqa
             bboxannotation = {
                 'name': '%s bounding boxes' % os.path.splitext(
                     os.path.basename(opts.outputAnnotationFile))[0],
-                'description': 'Used params %r' % vars(opts),
                 'elements': [{
                     'type': 'rectangle',
                     'center': [bcx, bcy, 0],
@@ -255,6 +255,13 @@ def createSuperPixels(opts):  # noqa
                 } for bidx, (bcx, bcy, bw, bh) in enumerate(bboxes)],
             }
             annotation = [annotation, bboxannotation]
+        annotation.append({
+            'attributes': {
+            'params': vars(opts),
+            'cli': Path(__file__).stem,
+            'version': histomicstk.__version__,
+            }}
+        )
         with open(opts.outputAnnotationFile, 'w') as annotation_file:
             json.dump(annotation, annotation_file, separators=(',', ':'), sort_keys=False)
         if hasattr(opts, 'callback'):

--- a/histomicstk/cli/SuperpixelSegmentation/SuperpixelSegmentation.py
+++ b/histomicstk/cli/SuperpixelSegmentation/SuperpixelSegmentation.py
@@ -257,9 +257,9 @@ def createSuperPixels(opts):  # noqa
             annotation = [annotation, bboxannotation]
         annotation.append({
             'attributes': {
-            'params': vars(opts),
-            'cli': Path(__file__).stem,
-            'version': histomicstk.__version__,
+                'params': vars(opts),
+                'cli': Path(__file__).stem,
+                'version': histomicstk.__version__,
             }}
         )
         with open(opts.outputAnnotationFile, 'w') as annotation_file:


### PR DESCRIPTION
Most of the information generated by the code is already added to the metadata. so, I've only added the `attributes`. One change I would like to add is to replace the `opts` name with `args` for consistency. 