### PR TITLE
Adjust for Cython 3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,6 +23,16 @@ commands:
           command: |
             (while true; do date; tail -n 3 /tmp/histomicstk_test_girder_log.txt 2>/dev/null || true; sleep 60; done) &
             tox -e << parameters.env >> | cat; test ${PIPESTATUS[0]} -eq 0
+  docker-compose:
+    description: "Install docker compose extension"
+    steps:
+      - run:
+          name: Install docker compose
+          command: |
+            DOCKER_CONFIG=${DOCKER_CONFIG:-$HOME/.docker}
+            mkdir -p $DOCKER_CONFIG/cli-plugins
+            curl -SL https://github.com/docker/compose/releases/download/v2.20.2/docker-compose-linux-x86_64 -o $DOCKER_CONFIG/cli-plugins/docker-compose
+            chmod +x $DOCKER_CONFIG/cli-plugins/docker-compose
   upgradepython:
     description: "Upgrade python"
     parameters:
@@ -70,6 +80,7 @@ jobs:
           command: |
             pyenv versions
             pyenv global 3.6.15
+      - docker-compose
       - tox:
           env: py36
       - coverage
@@ -86,6 +97,7 @@ jobs:
           command: |
             pyenv versions
             pyenv global 3.7.16
+      - docker-compose
       - tox:
           env: py37
       - coverage
@@ -102,6 +114,7 @@ jobs:
           command: |
             pyenv versions
             pyenv global 3.8.16
+      - docker-compose
       - tox:
           env: py38
       - coverage
@@ -118,6 +131,7 @@ jobs:
           command: |
             pyenv versions
             pyenv global 3.9.16
+      - docker-compose
       - tox:
           env: py39
       - coverage
@@ -134,6 +148,7 @@ jobs:
           command: |
             pyenv versions
             pyenv global 3.10.10
+      - docker-compose
       - tox:
           env: py310
       - coverage
@@ -150,6 +165,7 @@ jobs:
           command: |
             pyenv versions
             pyenv global 3.11.2
+      - docker-compose
       - tox:
           env: py311
       - coverage

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -159,7 +159,7 @@ There are two 'types' of unit tests on HistomicsTK.
     server is fully initialized. To manually start a DSA docker image::
 
       $ cd HistomicsTK/tests/
-      $ docker-compose up --build
+      $ docker compose up --build
 
   You can run your tests using something like::
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,2 @@
 [build-system]
-requires = ["setuptools", "wheel", "scikit-build", "cmake", "ninja", "numpy", "cython<3", "setuptools-scm"]
+requires = ["setuptools", "wheel", "scikit-build", "cmake", "ninja", "numpy", "cython", "setuptools-scm"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,2 @@
 [build-system]
-requires = ["setuptools", "wheel", "scikit-build", "cmake", "ninja", "numpy", "cython", "setuptools-scm"]
+requires = ["setuptools", "wheel", "scikit-build", "cmake", "ninja", "numpy", "cython<3", "setuptools-scm"]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,10 +5,10 @@ scikit-build>=0.8.1
 setuptools
 wheel
 # Also needed for installation
-cython<3
+cython
 numpy>=1.12.1
 setuptools-scm
 # Needed for tests
 docker
-docker-compose
+# docker-compose
 requests

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,7 +5,7 @@ scikit-build>=0.8.1
 setuptools
 wheel
 # Also needed for installation
-cython
+cython<3
 numpy>=1.12.1
 setuptools-scm
 # Needed for tests

--- a/tests/Dockerfile-gc-tests
+++ b/tests/Dockerfile-gc-tests
@@ -1,4 +1,4 @@
-FROM python:3.7-slim
+FROM python:3.11-slim
 
 LABEL HISTOMICSTK_GC_TEST=TRUE
 
@@ -8,8 +8,7 @@ ENV PYTHONDONTWRITEBYTECODE 1
 RUN pip install --no-cache-dir -U pip
 
 # Only sources needed in the test are added.
-RUN pip install --pre --find-links https://girder.github.io/large_image_wheels \
-    'celery<5' \
+RUN pip install --find-links https://girder.github.io/large_image_wheels \
     histomicsui[analysis] \
     large-image-source-openslide \
     pooch \

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     depends_on:
       - mongodb
     volumes:
-      - ../.tox/externaldata:/tests/externaldata
+      - ../.tox/externaldata:/root/.cache/pooch/externaldata
   mongodb:
     image: "circleci/mongo:5.0-ram"
     command: ["mongod", "--storageEngine", "ephemeralForTest", "--dbpath", "/dev/shm/mongo"]

--- a/tox.ini
+++ b/tox.ini
@@ -17,6 +17,7 @@ setenv =
   PIP_FIND_LINKS=https://girder.github.io/large_image_wheels
 deps =
   coverage
+  cython<3
   pooch
   pytest>=3.6
   pytest-cov>=2.6

--- a/tox.ini
+++ b/tox.ini
@@ -17,17 +17,16 @@ setenv =
   PIP_FIND_LINKS=https://girder.github.io/large_image_wheels
 deps =
   coverage
-  cython<3
   pooch
   pytest>=3.6
   pytest-cov>=2.6
   pytest-xdist
   -rrequirements-dev.txt
 allowlist_externals =
-  docker-compose
+  docker
 commands =
   pytest --cov-config tox.ini {posargs}
-  -docker-compose --project-directory tests down --volumes
+  -docker compose --project-directory tests down --volumes
 
 [testenv:flake8]
 skipsdist = true


### PR DESCRIPTION
Cython 3 changes require newer pyyaml.  docker-compose demands an old pyyaml.  Switch to using docker compose instead of docker-compose.

Refactor some of the setup and tear down for the girder server docker.