### PR TITLE
Instead of output a return parameters file, output an annotation.

### DIFF
--- a/histomicstk/cli/SeparateStainsXuSnmf/SeparateStainsXuSnmf.py
+++ b/histomicstk/cli/SeparateStainsXuSnmf/SeparateStainsXuSnmf.py
@@ -1,12 +1,16 @@
+import json
+from pathlib import Path
+
 import numpy
 
+import histomicstk
 import histomicstk.preprocessing.color_deconvolution as htk_cdeconv
 from histomicstk.cli import utils
 from histomicstk.cli.utils import CLIArgumentParser
 
 
-def main(args):
-    args = utils.splitArgs(args)
+def main(origargs):
+    args = utils.splitArgs(origargs)
     args.snmf.I_0 = numpy.array(args.snmf.I_0)
 
     print('>> Starting Dask cluster and sampling pixels')
@@ -26,9 +30,18 @@ def main(args):
     w_est = htk_cdeconv.rgb_separate_stains_xu_snmf(sample.T, **vars(args.snmf))
     w_est = htk_cdeconv.complement_stain_matrix(w_est)
 
-    with open(args.returnParameterFile, 'w') as f:
-        for i, stain in enumerate(w_est.T):
-            f.write('stainColor_{} = {}\n'.format(i + 1, ','.join(map(str, stain))))
+    annotation = {
+        'name': 'SeperateStainsXuSnmf',
+        'attributes': {
+            'params': vars(origargs),
+            'cli': Path(__file__).stem,
+            'version': histomicstk.__version__,
+        },
+    }
+    for i, stain in enumerate(w_est.T):
+        annotation['attributes']['stainColor_{}'.format(i + 1)] = stain.tolist()
+    with open(args.outputAnnotationFile, 'w') as annotation_file:
+        json.dump(annotation, annotation_file, sort_keys=False)
 
 
 if __name__ == '__main__':

--- a/histomicstk/cli/SeparateStainsXuSnmf/SeparateStainsXuSnmf.xml
+++ b/histomicstk/cli/SeparateStainsXuSnmf/SeparateStainsXuSnmf.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <executable>
   <category>HistomicsTK</category>
-  <title>Performs Adaptive Color Deconvolution</title>
-  <description>Uses sparse non-negative matrix factorization to adaptively deconvolve a given RGB image into intensity images representing distinct stains.</description>
+  <title>Adaptive Color Deconvolution</title>
+  <description>Use sparse non-negative matrix factorization to adaptively deconvolve a given RGB image into intensity images representing distinct stains.</description>
   <version>0.1.0</version>
   <documentation-url>https://digitalslidearchive.github.io/HistomicsTK/</documentation-url>
   <license>Apache 2.0</license>
@@ -23,6 +23,7 @@
       <label>Background Intensity</label>
       <index>1</index>
       <description>Background intensity in each channel</description>
+      <default>255,255,255</default>
     </double-vector>
     <float>
       <name>sample_sample_fraction</name>
@@ -30,9 +31,9 @@
       <longflag>sampleFraction</longflag>
       <description>Fraction of pixels to sample.  Specify either this or --sampleApproximateTotal</description>
       <constraints>
-	<maximum>1</maximum>
+        <maximum>1</maximum>
       </constraints>
-      <default>-1</default>
+      <default>0.1</default>
     </float>
     <float>
       <name>sample_magnification</name>
@@ -55,8 +56,8 @@
       <description>Minimum background coverage required for a tile to
       be sampled from.</description>
       <constraints>
-	<minimum>0</minimum>
-	<maximum>1</maximum>
+        <minimum>0</minimum>
+        <maximum>1</maximum>
       </constraints>
       <default>0.1</default>
     </float>
@@ -112,24 +113,13 @@
       <longflag>beta</longflag>
       <default>0.5</default>
     </double>
-    <double-vector>
-      <name>stainColor_1</name>
-      <label>Color of stain 1</label>
+    <file fileExtensions=".anot" reference="sample_slide_path">
+      <name>outputAnnotationFile</name>
+      <label>Output SDA colors of each stain</label>
+      <description>Output stain annotation file (*.anot)</description>
       <channel>output</channel>
-      <description>SDA color of stain 1</description>
-    </double-vector>
-    <double-vector>
-      <name>stainColor_2</name>
-      <label>Color of stain 2</label>
-      <channel>output</channel>
-      <description>SDA color of stain 2</description>
-    </double-vector>
-    <double-vector>
-      <name>stainColor_3</name>
-      <label>Color of stain 3</label>
-      <channel>output</channel>
-      <description>SDA color of stain 3</description>
-    </double-vector>
+      <index>2</index>
+    </file>
   </parameters>
   <parameters advanced="true">
     <label>Dask</label>


### PR DESCRIPTION
This has the same results, but in json instead of key-value pairs.  It also includes the input parameters.

This replaces #1017