### PR TITLE
Update defaults color deconvolution

### DIFF
--- a/histomicstk/cli/ColorDeconvolution/ColorDeconvolution.py
+++ b/histomicstk/cli/ColorDeconvolution/ColorDeconvolution.py
@@ -20,6 +20,8 @@ def colorDeconvolve(args):
     ts = large_image.getTileSource(args.inputImageFile)
     region = {}
     it_kwargs = {}
+    tileSize=8192
+    it_kwargs['tile_size'] = dict(width=tileSize, height=tileSize)
 
     # Provides crop area if ROI present in arguments
     if np.all(np.array(args.region) != -1):
@@ -30,13 +32,10 @@ def colorDeconvolve(args):
             'height': args.region[3],
             'units': 'base_pixels'
         }
-        sink0.crop = (it_kwargs['region']['left'], it_kwargs['region']['top'],
-                      it_kwargs['region']['width'], it_kwargs['region']['height'])
-        sink1.crop = (it_kwargs['region']['left'], it_kwargs['region']['top'],
-                      it_kwargs['region']['width'], it_kwargs['region']['height'])
-        sink2.crop = (it_kwargs['region']['left'], it_kwargs['region']['top'],
-                      it_kwargs['region']['width'], it_kwargs['region']['height'])
-        region = utils.get_region_dict(args.region, args.maxRegionSize, ts)['region']
+        sink0.crop = tuple(args.region)
+        sink1.crop = tuple(args.region)
+        sink2.crop = tuple(args.region)
+        region = utils.get_region_dict(args.region, None, ts)['region']
 
     # Create stain matrix
     print('>> Creating stain matrix')

--- a/histomicstk/cli/ColorDeconvolution/ColorDeconvolution.py
+++ b/histomicstk/cli/ColorDeconvolution/ColorDeconvolution.py
@@ -20,7 +20,7 @@ def colorDeconvolve(args):
     ts = large_image.getTileSource(args.inputImageFile)
     region = {}
     it_kwargs = {}
-    tileSize=8192
+    tileSize = 8192
     it_kwargs['tile_size'] = dict(width=tileSize, height=tileSize)
 
     # Provides crop area if ROI present in arguments

--- a/histomicstk/cli/ColorDeconvolution/ColorDeconvolution.py
+++ b/histomicstk/cli/ColorDeconvolution/ColorDeconvolution.py
@@ -95,8 +95,8 @@ def main(args):
 
     print(args.inputImageFile)
 
-    transform = colorDeconvolve_ROI(args) if np.any(
-        args.region) == -1 else colorDeconvolve_WSI(args)
+    transform = colorDeconvolve_ROI(args) if np.all(np.array(
+        args.region)) == -1 else colorDeconvolve_WSI(args)
 
     if args.outputAnnotationFile:
 

--- a/histomicstk/cli/ColorDeconvolution/ColorDeconvolution.xml
+++ b/histomicstk/cli/ColorDeconvolution/ColorDeconvolution.xml
@@ -25,24 +25,24 @@
       <longflag>region</longflag>
       <default>-1,-1,-1,-1</default>
     </region>
-    <image fileExtensions=".png" reference="inputImageFile">
+    <image fileExtensions=".tiff" reference="inputImageFile">
       <name>outputStainImageFile_1</name>
       <label>Output Image of Stain 1</label>
-      <description>Output Image of Stain 1 (*.png)</description>
+      <description>Output Image of Stain 1 (*.tiff)</description>
       <channel>output</channel>
       <index>1</index>
     </image>
-    <image fileExtensions=".png" reference="inputImageFile">
+    <image fileExtensions=".tiff" reference="inputImageFile">
       <name>outputStainImageFile_2</name>
       <label>Output Image of Stain 2</label>
-      <description>Output Image of Stain 2 (*.png)</description>
+      <description>Output Image of Stain 2 (*.tiff)</description>
       <channel>output</channel>
       <index>2</index>
     </image>
-    <image fileExtensions=".png" reference="inputImageFile">
+    <image fileExtensions=".tiff" reference="inputImageFile">
       <name>outputStainImageFile_3</name>
       <label>Output Image of Stain 3</label>
-      <description>Output Image of Stain 3 (*.png)</description>
+      <description>Output Image of Stain 3 (*.tiff)</description>
       <channel>output</channel>
       <index>3</index>
     </image>


### PR DESCRIPTION
-Here I have changed the .xml file extensions from `.png` to `.tiff`, same will be reflected in the description

-Color deconvolution is divided into two functions
1) color deconvolution WSI - if the user is not specifying the region
2) color deconvolution ROI - if the user provides the region.

-  Both of the above functions return a parameter called `transform`
- Since there is no region present in the WSI I have given a return as `{'No transform available for WSI'}`, This can be changed to anything that is appropriate.
- Going further down the code the return parameter will be saved in the `transform: {....}` tag in the annotation.
- This update fixes #1030 
