### PR TITLE
Harden compute nuclei features

### DIFF
--- a/histomicstk/features/compute_gradient_features.py
+++ b/histomicstk/features/compute_gradient_features.py
@@ -93,6 +93,8 @@ def compute_gradient_features(im_label, im_intensity,
     cannyG = canny(im_intensity)
 
     for i in range(numLabels):
+        if rprops[i] is None:
+            continue
 
         # get gradients of object pixels
         pixelGradients = np.sort(

--- a/histomicstk/features/compute_haralick_features.py
+++ b/histomicstk/features/compute_haralick_features.py
@@ -282,6 +282,8 @@ def compute_haralick_features(im_label, im_intensity, offsets=None,
     eps = np.finfo(float).eps  # small constant to avoid div / 0
 
     for i in range(numLabels):
+        if rprops[i] is None:
+            continue
 
         # get bounds of an intensity image
         minr, minc, maxr, maxc = rprops[i].bbox

--- a/histomicstk/features/compute_intensity_features.py
+++ b/histomicstk/features/compute_intensity_features.py
@@ -129,6 +129,8 @@ def compute_intensity_features(
         return x
 
     for i in range(numLabels):
+        if rprops[i] is None:
+            continue
 
         # get intensities of object pixels
         pixelIntensities = np.sort(

--- a/histomicstk/features/compute_nuclei_features.py
+++ b/histomicstk/features/compute_nuclei_features.py
@@ -187,7 +187,8 @@ def compute_nuclei_features(im_label, im_nuclei=None, im_cytoplasm=None,
 
         # ensure that cytoplasm props order corresponds to the nuclei
         lablocs = {v['label']: i for i, v in enumerate(cyto_props)}
-        cyto_props = [cyto_props[lablocs[v['label']]] for v in nuclei_props]
+        cyto_props = [cyto_props[lablocs[v['label']]] if v['label'] in lablocs else None
+                      for v in nuclei_props]
 
     # compute morphometry features
     if morphometry_features_flag:


### PR DESCRIPTION
Don't fail if we can't identify cytoplasm because the tile is small or nuclei are close to overlapping.