### PR TITLE
updated .py and .xml file to output single annotation file.

### DIFF
--- a/histomicstk/cli/PositivePixelCount/PositivePixelCount.py
+++ b/histomicstk/cli/PositivePixelCount/PositivePixelCount.py
@@ -111,18 +111,8 @@ def main(opts):
             utils.disp_time_hms(time.time() - sink_start_time),
             utils.disp_time_hms(time.time() - start_time)))
     pprint.pprint(stats._asdict())
-    with open(opts.returnParameterFile, 'w') as f:
-        for k, v in zip(stats._fields, stats):
-            f.write(f'{k} = {v}\n')
     annotation = {
         'name': 'Positive Pixel Count',
-        'description': 'Used params: %r\nResults: %r' % (vars(opts), stats._asdict()),
-        'attributes': {
-            'params': vars(opts),
-            'stats': stats._asdict(),
-            'cli': Path(__file__).stem,
-            'version': histomicstk.__version__,
-        },
         'elements': [{
             'type': 'image',
             'girderId': 'outputLabelImage',
@@ -132,6 +122,12 @@ def main(opts):
                 'yoffset': tiparams.get('region', {}).get('top', 0),
             },
         }],
+        'attributes': {
+            'params': vars(opts),
+            'stats': stats._asdict(),
+            'cli': Path(__file__).stem,
+            'version': histomicstk.__version__,
+        },
     }
     with open(opts.outputAnnotationFile, 'w') as annotation_file:
         json.dump(annotation, annotation_file, separators=(',', ':'), sort_keys=False)

--- a/histomicstk/cli/PositivePixelCount/PositivePixelCount.xml
+++ b/histomicstk/cli/PositivePixelCount/PositivePixelCount.xml
@@ -99,64 +99,6 @@
       <longflag>image_annotation</longflag>
     </file>
   </parameters>
-  <parameters>
-    <label>Output parameters</label>
-    <description>Parameters for output</description>
-    <float>
-      <name>NumberWeakPositive</name>
-      <label>Number of Weak Positive Pixels</label>
-      <channel>output</channel>
-      <description>Number of pixels classified as weak positive</description>
-    </float>
-    <float>
-      <name>NumberPositive</name>
-      <label>Number of Positive Pixels</label>
-      <channel>output</channel>
-      <description>Number of pixels classified as simply positive</description>
-    </float>
-    <float>
-      <name>NumberStrongPositive</name>
-      <label>Number of Strong Positive Pixels</label>
-      <channel>output</channel>
-      <description>Number of pixels classified as strong positive</description>
-    </float>
-    <float>
-      <name>IntensitySumWeakPositive</name>
-      <label>Sum of Intensities of Weak Positive Pixels</label>
-      <channel>output</channel>
-      <description>Number of pixels classified as weak positive</description>
-    </float>
-    <float>
-      <name>IntensitySumPositive</name>
-      <label>Sum of Intensities of Positive Pixels</label>
-      <channel>output</channel>
-      <description>Number of pixels classified as simply positive</description>
-    </float>
-    <float>
-      <name>IntensitySumStrongPositive</name>
-      <label>Sum of Intensities of Strong Positive Pixels</label>
-      <channel>output</channel>
-      <description>Number of pixels classified as strong positive</description>
-    </float>
-    <float>
-      <name>IntensityAverage</name>
-      <label>Average Intensity</label>
-      <channel>output</channel>
-      <description>Average intensity of across all positive pixels</description>
-    </float>
-    <float>
-      <name>RatioStrongToTotal</name>
-      <label>Ratio of Strong Pixels to Total Pixels</label>
-      <channel>output</channel>
-      <description>The fraction of positive pixels that are strong</description>
-    </float>
-    <float>
-      <name>IntensityAverageWeakAndPositive</name>
-      <label>Average Intensity of Weak and Plain Positive Pixels</label>
-      <channel>output</channel>
-      <description>Average intensity of positive pixels excluding strong positive pixels</description>
-    </float>
-  </parameters>
   <parameters advanced="true">
     <label>Frame and Style</label>
     <description>Frame parameters</description>


### PR DESCRIPTION
-The `description` key is also removed from the annotation structure since it is already present in attribute:{stats}`

- moved the `elements` dict to the top since we were following the structure `name: '', elements: [], attributes:{}` for the annotation metadata.

- when running with an ROI and we don't provide any 'outputLabelImage' 
`sink.crop = ` is throwing an error `Nonetype object is not callable,