### PR TITLE
Resolve issues with sink.crop

### DIFF
--- a/histomicstk/cli/PositivePixelCount/PositivePixelCount.py
+++ b/histomicstk/cli/PositivePixelCount/PositivePixelCount.py
@@ -193,9 +193,10 @@ def main(opts):
     }
 
     # Save the annotation dictionary to the output annotation file
-    with open(opts.outputAnnotationFile, 'w') as annotation_file:
-        json.dump(annotation, annotation_file, separators=(',', ':'), sort_keys=False)
-    print('Finished time %s' % (utils.disp_time_hms(time.time() - start_time)))
+    if opts.outputAnnotationFile:
+        with open(opts.outputAnnotationFile, 'w') as annotation_file:
+            json.dump(annotation, annotation_file, separators=(',', ':'), sort_keys=False)
+        print('Finished time %s' % (utils.disp_time_hms(time.time() - start_time)))
 
 
 if __name__ == '__main__':

--- a/histomicstk/cli/PositivePixelCount/PositivePixelCount.py
+++ b/histomicstk/cli/PositivePixelCount/PositivePixelCount.py
@@ -53,7 +53,7 @@ def main(opts):
         **{k: getattr(opts, k) for k in ppc.Parameters._fields}
     )
     results = []
-    if 'left' in tiparams.get('region', {}):
+    if sink and 'left' in tiparams.get('region', {}):
         sink.crop = (
             tiparams['region']['left'], tiparams['region']['top'],
             tiparams['region']['width'], tiparams['region']['height'])

--- a/histomicstk/cli/PositivePixelCount/PositivePixelCount.xml
+++ b/histomicstk/cli/PositivePixelCount/PositivePixelCount.xml
@@ -80,6 +80,7 @@
       <label>Output Label Image</label>
       <description>Color-coded image of the region, showing the various classes of pixel</description>
       <channel>output</channel>
+      <index>2</index>
     </image>
     <string-enumeration>
       <name>outputImageForm</name>
@@ -97,6 +98,7 @@
       <description>Annotation to relate the image to the source (*.anot)</description>
       <channel>output</channel>
       <longflag>image_annotation</longflag>
+      <index>2</index>
     </file>
   </parameters>
   <parameters>

--- a/histomicstk/cli/PositivePixelCount/PositivePixelCount.xml
+++ b/histomicstk/cli/PositivePixelCount/PositivePixelCount.xml
@@ -80,7 +80,6 @@
       <label>Output Label Image</label>
       <description>Color-coded image of the region, showing the various classes of pixel</description>
       <channel>output</channel>
-      <index>2</index>
     </image>
     <string-enumeration>
       <name>outputImageForm</name>
@@ -98,7 +97,6 @@
       <description>Annotation to relate the image to the source (*.anot)</description>
       <channel>output</channel>
       <longflag>image_annotation</longflag>
-      <index>2</index>
     </file>
   </parameters>
   <parameters>


### PR DESCRIPTION
- while running the `PPC` with default values there are no issues.
- But when we provide ROI and forget to mention the `outputLabelImage`, an error is thrown saying
`sink.crop=... None type object not callable`

- To resolve that I've made both `outputannotationfile` file and `outputlabelimage` as required fields. I believe the way to do that is to add the `<index>2</index>` parameter to the .XML file. That is how I did it. If it is something different please let me know.