### PR TITLE
find_stain_index comparison bug

### DIFF
--- a/histomicstk/preprocessing/color_deconvolution/find_stain_index.py
+++ b/histomicstk/preprocessing/color_deconvolution/find_stain_index.py
@@ -33,5 +33,7 @@ def find_stain_index(reference, w):
     histomicstk.preprocessing.color_deconvolution.color_deconvolution
 
     """
-    dot_products = np.dot(linalg.normalize(reference), linalg.normalize(w))
+    dot_products = np.dot(
+        linalg.normalize(np.array(reference)), linalg.normalize(np.array(w))
+    )
     return np.argmax(np.abs(dot_products))

--- a/histomicstk/preprocessing/color_deconvolution/find_stain_index.py
+++ b/histomicstk/preprocessing/color_deconvolution/find_stain_index.py
@@ -3,9 +3,9 @@ import numpy as np
 
 
 def find_stain_index(reference, w):
-    """Identify the stain vector in w that best alignes with the reference vector. 
-    
-    This is used with adaptive deconvolution routines where the order of returned stain 
+    """Identify the stain vector in w that best alignes with the reference vector.
+
+    This is used with adaptive deconvolution routines where the order of returned stain
     vectors is not guaranteed. This function identifies the stain vector of w that most
     closely aligns with the provided reference.
 
@@ -23,7 +23,7 @@ def find_stain_index(reference, w):
 
     Notes
     -----
-    Vectors are normalized to unit-norm prior to comparison using dot product. Alignment 
+    Vectors are normalized to unit-norm prior to comparison using dot product. Alignment
     is determined by vector angles and not distances.
 
     See Also
@@ -32,8 +32,5 @@ def find_stain_index(reference, w):
     histomicstk.preprocessing.color_deconvolution.color_deconvolution
 
     """
-    dot_products = np.dot(
-        linalg.normalize(reference),
-        linalg.normalize(w)
-    )
+    dot_products = np.dot(linalg.normalize(reference), linalg.normalize(w))
     return np.argmax(np.abs(dot_products))

--- a/histomicstk/preprocessing/color_deconvolution/find_stain_index.py
+++ b/histomicstk/preprocessing/color_deconvolution/find_stain_index.py
@@ -1,28 +1,30 @@
+from . import _linalg as linalg
 import numpy as np
 
 
 def find_stain_index(reference, w):
-    """Find the index of the stain column vector in w corresponding to the
-    reference vector.  Useful in connection with adaptive
-    deconvolution routines in order to find the column corresponding
-    with a certain expected stain.
+    """Identify the stain vector in w that best alignes with the reference vector. 
+    
+    This is used with adaptive deconvolution routines where the order of returned stain 
+    vectors is not guaranteed. This function identifies the stain vector of w that most
+    closely aligns with the provided reference.
 
     Parameters
     ----------
     reference : array_like
-        1D array that is the stain vector to find
+        1D array representing the stain vector query.
     w : array_like
-        2D array of columns the same size as reference.
-        The columns should be normalized.
+        3xN array of where columns represent stain vectors to search.
 
     Returns
     -------
     i : int
-        Column of w corresponding to reference
+        Column index of stain vector with best alignment to reference.
 
     Notes
     -----
-    The index of the vector with the smallest distance is returned.
+    Vectors are normalized to unit-norm prior to comparison using dot product. Alignment 
+    is determined by vector angles and not distances.
 
     See Also
     --------
@@ -30,5 +32,8 @@ def find_stain_index(reference, w):
     histomicstk.preprocessing.color_deconvolution.color_deconvolution
 
     """
-    dists = [np.linalg.norm(w[i] - reference) for i in range(w.shape[0])]
-    return np.argmin(dists)
+    dot_products = np.dot(
+        linalg.normalize(reference),
+        linalg.normalize(w)
+    )
+    return np.argmax(np.abs(dot_products))

--- a/histomicstk/preprocessing/color_deconvolution/find_stain_index.py
+++ b/histomicstk/preprocessing/color_deconvolution/find_stain_index.py
@@ -1,5 +1,6 @@
-from . import _linalg as linalg
 import numpy as np
+
+from . import _linalg as linalg
 
 
 def find_stain_index(reference, w):


### PR DESCRIPTION
This fixes a bug in find_stain_index where comparisons are made to the rows of a stain matrix instead of the columns.