### PR TITLE
supress rank warning

### DIFF
--- a/histomicstk/features/compute_morphometry_features.py
+++ b/histomicstk/features/compute_morphometry_features.py
@@ -1,3 +1,4 @@
+import warnings
 from collections import OrderedDict
 
 import numpy as np
@@ -205,6 +206,8 @@ def _fractal_dimension(Z):
         counts.append(boxcount(Z, size))
 
     # Fit the successive log(sizes) with log (counts)
-    coeffs = np.polyfit(np.log(sizes), np.log(counts), 1)
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore', np.RankWarning)
+        coeffs = np.polyfit(np.log(sizes), np.log(counts), 1)
 
     return -coeffs[0]


### PR DESCRIPTION
When no cytoplasm is found, the cytoplasm features are set to zero. That can raise warnings in `compute_morphometry_features` since it cannot fit zero arrays to a specific order. 

I have suppressed the warning so it doesn't show on the log.  Otherwise for a large WSI - there will be a log of rank warning in the log screen. 