### PR TITLE
Tell setuptools-scm not to use local versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -152,6 +152,7 @@ cython_debug/
 .idea/
 
 .vscode
+*.sw[po]
 
 # temporary downloaded data when doing unit testing locally
 tests/externaldata/

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,4 @@
 import importlib
-import os
 import sys
 
 from setuptools import find_packages
@@ -19,27 +18,9 @@ with open('README.rst') as readme_file:
     readme = readme_file.read()
 
 
-def prerelease_local_scheme(version):
-    """
-    Return local scheme version unless building on master in CircleCI.
-
-    This function returns the local scheme version number
-    (e.g. 0.0.0.dev<N>+g<HASH>) unless building on CircleCI for a
-    pre-release in which case it ignores the hash and produces a
-    PEP440 compliant pre-release version number (e.g. 0.0.0.dev<N>).
-    """
-    from setuptools_scm.version import get_local_node_and_date
-
-    if (os.getenv('CIRCLE_BRANCH') or os.getenv('CI_BRANCH') or
-            os.getenv('GITHUB_REF_NAME')) in {'master'}:
-        return ''
-    else:
-        return get_local_node_and_date(version)
-
-
 setup(
     name='histomicstk',
-    use_scm_version={'local_scheme': prerelease_local_scheme,
+    use_scm_version={'local_scheme': 'no-local-version',
                      'fallback_version': '0.0.0'},
     description='A Python toolkit for Histopathology Image Analysis',
     long_description=readme,


### PR DESCRIPTION
The local version is desirable outside of CI, but is hard to work with in CI.