### PR TITLE
Use the common exta_requires on non-linux platforms

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,10 +63,6 @@ commands:
           command: for i in $(seq 1 10); do [ $i -gt 1 ] && echo "retrying $i" && sleep 5; ./codecov --disable search pycov gcov --file .tox/coverage/py_coverage.xml .tox/coverage/cobertura-coverage.xml && s=0 && break || s=$?; done; (exit $s)
 
 jobs:
-  # Because some of our tests use docker-compose as part of the test, we can't
-  # use a CircleCI docker environment, since those environments run sub dockers
-  # in a separate environment.  The 201808-01 machine environment has versions
-  # of Python 2.7, 3.5, 3.6, 3.7 with specific subversions.
   py37:
     working_directory: ~/project
     machine:
@@ -74,12 +70,12 @@ jobs:
     steps:
       - checkout
       - upgradepython:
-          version: 3.7.16
+          version: "3.7"
       - run:
           name: Use pyenv to set python version
           command: |
             pyenv versions
-            pyenv global 3.7.16
+            pyenv global 3.7
       - docker-compose
       - restore_cache:
           name: Restore external data cache
@@ -100,12 +96,12 @@ jobs:
     steps:
       - checkout
       - upgradepython:
-          version: 3.8.16
+          version: "3.8"
       - run:
           name: Use pyenv to set python version
           command: |
             pyenv versions
-            pyenv global 3.8.16
+            pyenv global 3.8
       - docker-compose
       - restore_cache:
           name: Restore external data cache
@@ -126,12 +122,12 @@ jobs:
     steps:
       - checkout
       - upgradepython:
-          version: 3.9.16
+          version: "3.9"
       - run:
           name: Use pyenv to set python version
           command: |
             pyenv versions
-            pyenv global 3.9.16
+            pyenv global 3.9
       - docker-compose
       - restore_cache:
           name: Restore external data cache
@@ -152,12 +148,12 @@ jobs:
     steps:
       - checkout
       - upgradepython:
-          version: 3.10.10
+          version: "3.10"
       - run:
           name: Use pyenv to set python version
           command: |
             pyenv versions
-            pyenv global 3.10.10
+            pyenv global 3.10
       - docker-compose
       - restore_cache:
           name: Restore external data cache
@@ -178,12 +174,12 @@ jobs:
     steps:
       - checkout
       - upgradepython:
-          version: 3.11.2
+          version: "3.11"
       - run:
           name: Use pyenv to set python version
           command: |
             pyenv versions
-            pyenv global 3.11.2
+            pyenv global 3.11
       - docker-compose
       - restore_cache:
           name: Restore external data cache

--- a/setup.py
+++ b/setup.py
@@ -56,9 +56,8 @@ setup(
         'distributed',
         # large image; for non-linux systems only install the PIL tile source
         # by default.
-        'large-image[sources];sys.platform=="linux"',
-        'large-image[sources];sys.platform=="linux2"',
-        'large-image[pil];sys.platform!="linux" and sys.platform!="linux2"',
+        'large-image[sources];sys.platform=="linux" or sys.platform=="linux2"',
+        'large-image[common];sys.platform!="linux" and sys.platform!="linux2"',
         'girder-slicer-cli-web',
         # cli
         'ctk-cli',

--- a/tests/datastore.py
+++ b/tests/datastore.py
@@ -33,8 +33,9 @@ registry = {
     # Source: TCGA-06-0129-01Z-00-DX3.bae772ea-dd36-47ec-8185-761989be3cc8.svs
     'TCGA-06-0129-01Z-00-DX3.bae772ea-dd36-47ec-8185-761989be3cc8.svs': 'sha512:b7bf2d6a56e90bca599351d93a716a7433fe376b78c8df08fa4b9e3c41b91b879a85dd5597f343bde5a552c0744515685712bf36c5e8b60287b8d991dc304f94',  # noqa
     #
-    # Source: TCGA-06-0129-01Z-00-DX3_fgnd_mask_lres2.png
-    'TCGA-06-0129-01Z-00-DX3_fgnd_mask_lres.png': 'sha512:d100f935c7ca243a584d21371c763a109b8590dee45ab35991f7678ea6b5a8bd35b39101aea202b185eee5cb4a4e51807c9be66fef6a3397616fcf19f86aa9e5',  # noqa
+    # Source: TCGA-06-0129-01Z-00-DX3_fgnd_mask_lres.png
+    'TCGA-06-0129-01Z-00-DX3_fgnd_mask_lres.png': 'sha512:58f04dd79ee5e14e68856321a9786e65b4e8b3075e84e13ff1dd20da820de933149b269bcb5f68184468d06b8956bf5426e4b11f4fa89a74c103946c1d974ec7',  # noqa
+    'TCGA-06-0129-01Z-00-DX3_fgnd_mask_lres2.png': 'sha512:d3e62945013a239c2489bc0b6291951e741007509fca181bda079cd3c1464a28cd0514e2846db4a2cf7919c2d495e22d609d51b708481176e6574a3be5e6b0f3',  # noqa
     #
     # Source: TCGA-06-0129-01Z-00-DX3_roi_nuclei_bbox.anot
     'TCGA-06-0129-01Z-00-DX3_roi_nuclei_bbox.anot': 'sha512:d880fd29abf6e5c9afb624a93631697b4f8eb70ffad36a21689839783bcac206b6494352412ded0cb2129eb36b007ec67e0609c1862dd9ee3df2815c5f9e7c52',  # noqa

--- a/tests/test_cli_common.py
+++ b/tests/test_cli_common.py
@@ -62,20 +62,26 @@ class TestCliCommon:
 
         np.testing.assert_equal(fgnd_seg_scale['magnification'], 2.5)
 
-        fgnd_mask_gtruth_file = os.path.join(datastore.fetch(
-            'TCGA-06-0129-01Z-00-DX3_fgnd_mask_lres.png'))
-
-        im_fgnd_mask_lres_gtruth = skimage.io.imread(
-            fgnd_mask_gtruth_file) > 0
-
         if GENERATE_GROUNDTRUTH:
             import PIL.Image
 
             PIL.Image.fromarray(im_fgnd_mask_lres).save(
                 '/tmp/TCGA-06-0129-01Z-00-DX3_fgnd_mask_lres.png')
 
-        np.testing.assert_array_equal(im_fgnd_mask_lres > 0,
-                                      im_fgnd_mask_lres_gtruth)
+        for gtruth in {
+            'TCGA-06-0129-01Z-00-DX3_fgnd_mask_lres.png',
+            'TCGA-06-0129-01Z-00-DX3_fgnd_mask_lres2.png',
+        }:
+            fgnd_mask_gtruth_file = os.path.join(datastore.fetch(gtruth))
+
+            im_fgnd_mask_lres_gtruth = skimage.io.imread(fgnd_mask_gtruth_file)
+            if len(im_fgnd_mask_lres_gtruth.shape) > 2:
+                im_fgnd_mask_lres_gtruth = im_fgnd_mask_lres_gtruth[:, :, 0]
+            im_fgnd_mask_lres_gtruth = im_fgnd_mask_lres_gtruth > 0
+
+            if np.array_equal(im_fgnd_mask_lres > 0, im_fgnd_mask_lres_gtruth):
+                break
+        np.testing.assert_array_equal(im_fgnd_mask_lres > 0, im_fgnd_mask_lres_gtruth)
 
     def test_create_tile_nuclei_annotations(self):
 


### PR DESCRIPTION
This will get more sources by default than before.

This also fixes some CI issues.