### PR TITLE
Revert artifact workflow version changes.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Run tox for lint and docs
         run: |
           tox -e lint,docs
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v3
         with:
           name: docs
           path: ./docs/_build
@@ -89,7 +89,7 @@ jobs:
           CIBW_ARCHS: ${{ matrix.buildplat[1] }}
           MACOSX_DEPLOYMENT_TARGET: "10.12"
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v3
         with:
           # name: ${{ matrix.python }}-${{ startsWith(matrix.buildplat[1], 'macosx') && 'macosx' || matrix.buildplat[1] }}
           path: ./wheelhouse/*.whl
@@ -102,7 +102,7 @@ jobs:
         fetch-depth: 0
     - name: Build SDist
       run: pipx run build --sdist
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v3
       with:
         # name: sdist
         path: dist/*.tar.gz
@@ -126,7 +126,7 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v3
         with:
           name: artifact
           path: dist


### PR DESCRIPTION
These broke the release.  We need to refactor how artifacts are downloaded if we name uploaded artifacts.