### PR TITLE
946 compute haralick features works incorrectly when im intensity is a float with 0 1 values

### DIFF
--- a/histomicstk/features/compute_haralick_features.py
+++ b/histomicstk/features/compute_haralick_features.py
@@ -25,7 +25,7 @@ def compute_haralick_features(im_label, im_intensity, offsets=None,
         objects.
 
     im_intensity : array_like
-        An ND single channel intensity image
+        An ND single channel intensity image.
 
     offsets : array_like, optional
         A (num_offsets, num_image_dims) array of offset vectors
@@ -291,7 +291,7 @@ def compute_haralick_features(im_label, im_intensity, offsets=None,
         minr, minc, maxr, maxc = rprops[i].bbox
 
         # grab nucleus mask
-        subImage = im_intensity[minr:maxr + 1, minc:maxc + 1].astype(np.uint8)
+        subImage = im_intensity[minr:maxr + 1, minc:maxc + 1]
 
         # gets GLCM or gray-tone spatial dependence matrix
         arrayGLCM = graycomatrixext(subImage, offsets=offsets,

--- a/tests/test_feature_extraction.py
+++ b/tests/test_feature_extraction.py
@@ -112,8 +112,8 @@ class TestFeatureExtraction:
 
         # compute nuclei features
         fdata_nuclei = htk_features.compute_nuclei_features(
-            im_nuclei_seg_mask, im_nuclei_stain,
-            im_cytoplasm=im_cytoplasm_stain)
+            im_nuclei_seg_mask, im_nuclei_stain.astype(np.uint8),
+            im_cytoplasm=im_cytoplasm_stain.astype(np.uint8))
 
         cfg.im_input = im_input
         cfg.im_input_nmzd = im_input_nmzd
@@ -188,7 +188,7 @@ class TestFeatureExtraction:
             expected_feature_list.append(col + '.Range')
 
         fdata = htk_features.compute_haralick_features(
-            cfg.im_nuclei_seg_mask, cfg.im_nuclei_stain)
+            cfg.im_nuclei_seg_mask, cfg.im_nuclei_stain.astype(np.uint8))
 
         check_fdata_sanity(fdata, expected_feature_list)
 


### PR DESCRIPTION
Address Issue #946 where intensity image inputs to `compute_haralick_features` are cast to uint8. For float images with pixel values in the recommended [0,1] range, this will not allow more than two levels of comparison.