### PR TITLE
Optionally add properties to polygon elements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ RUN apt-get update && \
 #     python --version
 
 # copy HistomicsTK files
-ENV htk_path=$PWD/HistomicsTK
+ENV htk_path=/HistomicsTK
 RUN mkdir -p $htk_path
 
 RUN pip install --no-cache-dir --upgrade pip setuptools && \

--- a/histomicstk/cli/ComputeNucleiFeatures/ComputeNucleiFeatures.py
+++ b/histomicstk/cli/ComputeNucleiFeatures/ComputeNucleiFeatures.py
@@ -41,7 +41,7 @@ def check_args(args):
         raise ValueError(msg)
 
 
-def main(args):
+def main(args):  # noqa
     import dask
     import pandas as pd
 
@@ -259,6 +259,12 @@ def main(args):
     annot_fname = os.path.splitext(
         os.path.basename(args.outputNucleiAnnotationFile))[0]
 
+    if args.in_annotations:
+        for key in args.in_annotations.split(','):
+            if key in nuclei_fdata:
+                for row, value in zip(nuclei_annot_list, nuclei_fdata[key]):
+                    if value is not None:
+                        row.setdefault('user', {})[key] = value
     annotation = {
         'name': annot_fname + '-nuclei-' + args.nuclei_annotation_format,
         'elements': nuclei_annot_list,

--- a/histomicstk/cli/ComputeNucleiFeatures/ComputeNucleiFeatures.xml
+++ b/histomicstk/cli/ComputeNucleiFeatures/ComputeNucleiFeatures.xml
@@ -87,6 +87,13 @@
       <description>Compute Intensity and Gradient features from the cytoplasm channel</description>
       <default>true</default>
     </boolean>
+    <string>
+      <name>in_annotations</name>
+      <label>Features In Annotations</label>
+      <description>A comma-separated list of column titles to include in the user attributes of output annotation elements.  Blank for none</description>
+      <longflag>inannotations</longflag>
+      <default>Feature.Size.Area,Feature.Size.MajorAxisLength,Feature.Size.MinorAxisLength,Feature.Shape.Circularity,Feature.Shape.Eccentricity,Feature.Nucleus.Intensity.Mean,Feature.Nucleus.Band0.Intensity.Mean,Feature.Nucleus.Band1.Intensity.Mean,Feature.Nucleus.Band2.Intensity.Mean</default>
+    </string>
   </parameters>
   <parameters advanced="true">
     <label>Color Normalization</label>

--- a/histomicstk/features/compute_nuclei_features.py
+++ b/histomicstk/features/compute_nuclei_features.py
@@ -8,7 +8,7 @@ from .compute_intensity_features import compute_intensity_features
 from .compute_morphometry_features import compute_morphometry_features
 
 
-def compute_nuclei_features(im_label, im_nuclei=None, im_cytoplasm=None,
+def compute_nuclei_features(im_label, im_nuclei=None, im_cytoplasm=None,  # noqa
                             fsd_bnd_pts=128, fsd_freq_bins=6, cyto_width=8,
                             num_glcm_levels=32,
                             morphometry_features_flag=True,
@@ -238,6 +238,15 @@ def compute_nuclei_features(im_label, im_nuclei=None, im_cytoplasm=None,
         compute_intensity_features,
         [im_label, im_nuclei], {'rprops': nuclei_props}, prefix='Nucleus.',
     ))
+    if (tile_info and tile_info.get('tile') is not None and
+            len(tile_info['tile'].shape) == 3 and tile_info['tile'].shape[-1] > 1):
+        for band in range(tile_info['tile'].shape[-1]):
+            feature_list.append(conditional(
+                intensity_features_flag,
+                compute_intensity_features,
+                [im_label, tile_info['tile'][:, :, band].astype(float)],
+                {'rprops': nuclei_props}, prefix=f'Nucleus.Band{band}.',
+            ))
 
     # compute cytoplasm intensity features
     if im_cytoplasm is not None:


### PR DESCRIPTION
When computing nuclei features, include band intensities and optionally add any set of features to the user properties of individual polygon elements.