### PR TITLE
Remove 'vectorized' from the shapely dependency.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
         'scikit-image',
         'scikit-learn',
         'imageio',
-        'shapely[vectorized]',
+        'shapely',
         'sqlalchemy',
         'matplotlib',
         'pyvips',


### PR DESCRIPTION
This extras went away with shapely 2, and was only including numpy which is a hard dependecy anyway.