### PR TITLE
Drop Python 3.8

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,32 +63,6 @@ commands:
           command: for i in $(seq 1 10); do [ $i -gt 1 ] && echo "retrying $i" && sleep 5; ./codecov --disable search pycov gcov --file .tox/coverage/py_coverage.xml .tox/coverage/cobertura-coverage.xml && s=0 && break || s=$?; done; (exit $s)
 
 jobs:
-  py38:
-    working_directory: ~/project
-    machine:
-      image: ubuntu-2004:202111-02
-    steps:
-      - checkout
-      - upgradepython:
-          version: "3.8"
-      - run:
-          name: Use pyenv to set python version
-          command: |
-            pyenv versions
-            pyenv global 3.8
-      - docker-compose
-      - restore_cache:
-          name: Restore external data cache
-          keys:
-            - tox-externaldata-{{ checksum "tests/datastore.py" }}
-      - tox:
-          env: py38
-      - save_cache:
-          name: Save external data cache
-          key: tox-externaldata-{{ checksum "tests/datastore.py" }}
-          paths:
-            - ./.tox/externaldata
-      - coverage
   py39:
     working_directory: ~/project
     machine:
@@ -329,13 +303,6 @@ workflows:
   version: 2
   ci:
     jobs:
-      - py38:
-          filters:
-            tags:
-              only: /^v.*/
-            branches:
-              ignore:
-                - gh-pages
       - py39:
           filters:
             tags:
@@ -387,7 +354,6 @@ workflows:
                 - gh-pages
       - docs-deploy:
           requires:
-            - py38
             - py39
             - py310
             - py311
@@ -404,7 +370,6 @@ workflows:
                 - sphinx
       - publish_docker:
           requires:
-            - py38
             - py39
             - py310
             - py311
@@ -428,7 +393,6 @@ workflows:
               only:
                 - master
     jobs:
-      - py38
       - py39
       - py310
       - py311
@@ -438,7 +402,6 @@ workflows:
       - wheels
       - publish_docker:
           requires:
-            - py38
             - py39
             - py310
             - py311

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     if: github.repository == 'DigitalSlideArchive/HistomicsTK' && ( startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/master' )
     strategy:
       matrix:
-        python: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python: ["3.9", "3.10", "3.11", "3.12"]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -68,7 +68,7 @@ jobs:
           - [ubuntu-latest, x86_64]
           - [macos-latest, "x86_64 arm64"]
           - [windows-latest, auto64]
-        python: ["cp38", "cp39", "cp310", "cp311", "cp312"]
+        python: ["cp39", "cp310", "cp311", "cp312"]
       fail-fast: false
 
     steps:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -61,7 +61,7 @@ repos:
   hooks:
     - id: pyupgrade
       args:
-        - --py37-plus
+        - --py39-plus
         - --keep-percent-format
 - repo: https://github.com/pre-commit/mirrors-autopep8
   rev: v2.0.4

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,8 +30,8 @@ RUN apt-get update && \
 # Make a specific version of python the default and install pip
 # RUN rm -f /usr/bin/python && \
 #     rm -f /usr/bin/python3 && \
-#     ln `which python3.8` /usr/bin/python && \
-#     ln `which python3.8` /usr/bin/python3 && \
+#     ln `which python3.12` /usr/bin/python && \
+#     ln `which python3.12` /usr/bin/python3 && \
 #     curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && \
 #     python get-pip.py && \
 #     rm get-pip.py && \

--- a/Dockerfile-wheels
+++ b/Dockerfile-wheels
@@ -1,8 +1,9 @@
 FROM dockcross/manylinux2014-x64
 
-# Don't build python < 3.8
+# Don't build python < 3.9
 RUN rm -rf /opt/python/cp36*
 RUN rm -rf /opt/python/cp37*
+RUN rm -rf /opt/python/cp38*
 RUN rm -rf /opt/python/pp*
 
 RUN for PYBIN in /opt/python/*/bin; do \

--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,6 @@ setup(
         'Development Status :: 5 - Production/Stable',
         'License :: OSI Approved :: Apache Software License',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
@@ -85,5 +84,5 @@ setup(
     entry_points={
         'console_scripts': ['histomicstk = histomicstk.cli.__main__:main'],
     },
-    python_requires='>=3.8',
+    python_requires='>=3.9',
 )

--- a/test_wheels.py
+++ b/test_wheels.py
@@ -19,7 +19,6 @@ python "$CLIPATH/NucleiDetection/NucleiDetection.py" tcga.svs sample.anot \\
 true"""
 
 containers = [
-    'python:3.8',
     'python:3.9',
     'python:3.10',
     'python:3.11',

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-  py{38,39,310,311,312}
+  py{39,310,311,312}
   docs
   lint
 skip_missing_interpreters = true


### PR DESCRIPTION
It is EOL, and resolving some warnings would require extra code to support 3.8.