### PR TITLE
Adjust dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,8 @@ dependencies = [
     "large-image-converter;sys.platform=='linux'",
     "girder-slicer-cli-web",
     "ctk-cli",
-    "opencv-python-headless",
+    "opencv-python-headless<4.12; python_version < '3.10'",
+    "opencv-python-headless; python_version >= '3.10'",
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
The latest opencv pins a numpy version that doesn't play well in Python 3.9 with some other libraries.