### PR TITLE
Fix serializing numpy numeric types in json

### DIFF
--- a/histomicstk/cli/BackgroundIntensity/BackgroundIntensity.py
+++ b/histomicstk/cli/BackgroundIntensity/BackgroundIntensity.py
@@ -37,7 +37,8 @@ def main(args):
     }
 
     with open(args.outputAnnotationFile, 'w') as annotation_file:
-        json.dump(annotation, annotation_file, separators=(',', ':'), sort_keys=False)
+        json.dump(annotation, annotation_file, separators=(',', ':'),
+                  sort_keys=False, default=utils.json_encoder)
 
 
 if __name__ == '__main__':

--- a/histomicstk/cli/ColorDeconvolution/ColorDeconvolution.py
+++ b/histomicstk/cli/ColorDeconvolution/ColorDeconvolution.py
@@ -134,7 +134,8 @@ def main(args):
 
         if args.outputAnnotationFile:
             with open(args.outputAnnotationFile, 'w') as annotation_file:
-                json.dump(annotation, annotation_file, separators=(',', ':'), sort_keys=False)
+                json.dump(annotation, annotation_file, separators=(',', ':'),
+                          sort_keys=False, default=utils.json_encoder)
 
 
 if __name__ == '__main__':

--- a/histomicstk/cli/ComputeNucleiFeatures/ComputeNucleiFeatures.py
+++ b/histomicstk/cli/ComputeNucleiFeatures/ComputeNucleiFeatures.py
@@ -92,7 +92,7 @@ def main(args):  # noqa
 
     ts_metadata = ts.getMetadata()
 
-    print(json.dumps(ts_metadata, indent=2))
+    print(json.dumps(ts_metadata, indent=2, default=cli_utils.json_encoder))
 
     is_wsi = ts_metadata['magnification'] is not None
 
@@ -281,7 +281,8 @@ def main(args):  # noqa
     }
 
     with open(args.outputNucleiAnnotationFile, 'w') as annotation_file:
-        json.dump(annotation, annotation_file, separators=(',', ':'), sort_keys=False)
+        json.dump(annotation, annotation_file, separators=(',', ':'),
+                  sort_keys=False, default=cli_utils.json_encoder)
 
     #
     # Create CSV Feature file

--- a/histomicstk/cli/NucleiClassification/NucleiClassification.py
+++ b/histomicstk/cli/NucleiClassification/NucleiClassification.py
@@ -139,7 +139,7 @@ def process_feature_and_annotation(args):
 
     ts_metadata = ts.getMetadata()
 
-    print(json.dumps(ts_metadata, indent=2))
+    print(json.dumps(ts_metadata, indent=2, default=cli_utils.json_encoder))
 
     src_mu_lab = None
     src_sigma_lab = None
@@ -339,7 +339,8 @@ def main(args):
         },
     })
     with open(args.outputNucleiAnnotationFile, 'w') as annotation_file:
-        json.dump(annotation, annotation_file, separators=(',', ':'), sort_keys=False)
+        json.dump(annotation, annotation_file, separators=(',', ':'),
+                  sort_keys=False, default=cli_utils.json_encoder)
 
 
 if __name__ == '__main__':

--- a/histomicstk/cli/NucleiDetection/NucleiDetection.py
+++ b/histomicstk/cli/NucleiDetection/NucleiDetection.py
@@ -27,7 +27,7 @@ def read_input_image(args, process_whole_image=False):
 
     ts_metadata = ts.getMetadata()
 
-    print(json.dumps(ts_metadata, indent=2))
+    print(json.dumps(ts_metadata, indent=2, default=cli_utils.json_encoder))
 
     is_wsi = ts_metadata['magnification'] is not None
 
@@ -379,7 +379,8 @@ def main(args):  # noqa
     }
 
     with open(args.outputNucleiAnnotationFile, 'w') as annotation_file:
-        json.dump(annotation, annotation_file, separators=(',', ':'), sort_keys=False)
+        json.dump(annotation, annotation_file, separators=(',', ':'),
+                  sort_keys=False, default=cli_utils.json_encoder)
 
     total_time_taken = time.time() - total_start_time
 

--- a/histomicstk/cli/PositivePixelCount/PositivePixelCount.py
+++ b/histomicstk/cli/PositivePixelCount/PositivePixelCount.py
@@ -195,7 +195,8 @@ def main(opts):
     # Save the annotation dictionary to the output annotation file
     if opts.outputAnnotationFile:
         with open(opts.outputAnnotationFile, 'w') as annotation_file:
-            json.dump(annotation, annotation_file, separators=(',', ':'), sort_keys=False)
+            json.dump(annotation, annotation_file, separators=(',', ':'),
+                      sort_keys=False, default=utils.json_encoder)
         print('Finished time %s' % (utils.disp_time_hms(time.time() - start_time)))
 
 

--- a/histomicstk/cli/SeparateStainsMacenkoPCA/SeparateStainsMacenkoPCA.py
+++ b/histomicstk/cli/SeparateStainsMacenkoPCA/SeparateStainsMacenkoPCA.py
@@ -31,7 +31,7 @@ def main(origargs):
         annotation['attributes'][f'stainColor_{i + 1}'] = stain.tolist()
 
     with open(args.outputAnnotationFile, 'w') as annotation_file:
-        json.dump(annotation, annotation_file, sort_keys=False)
+        json.dump(annotation, annotation_file, sort_keys=False, default=utils.json_encoder)
 
 
 if __name__ == '__main__':

--- a/histomicstk/cli/SeparateStainsXuSnmf/SeparateStainsXuSnmf.py
+++ b/histomicstk/cli/SeparateStainsXuSnmf/SeparateStainsXuSnmf.py
@@ -41,7 +41,7 @@ def main(origargs):
     for i, stain in enumerate(w_est.T):
         annotation['attributes'][f'stainColor_{i + 1}'] = stain.tolist()
     with open(args.outputAnnotationFile, 'w') as annotation_file:
-        json.dump(annotation, annotation_file, sort_keys=False)
+        json.dump(annotation, annotation_file, sort_keys=False, default=utils.json_encoder)
 
 
 if __name__ == '__main__':

--- a/histomicstk/cli/SuperpixelSegmentation/SuperpixelSegmentation.py
+++ b/histomicstk/cli/SuperpixelSegmentation/SuperpixelSegmentation.py
@@ -201,7 +201,8 @@ def createSuperPixels(opts):  # noqa
     img.set_type(
         pyvips.GValue.gstr_type, 'image-description',
         json.dumps(dict(
-            {k: v for k, v in vars(opts).items() if k != 'callback'}, indexCount=found)))
+            {k: v for k, v in vars(opts).items() if k != 'callback'}, indexCount=found),
+            default=utils.json_encoder))
     img.write_to_file(
         opts.outputImageFile, tile=True, tile_width=256, tile_height=256, pyramid=True,
         region_shrink=pyvips.RegionShrink.NEAREST,
@@ -268,7 +269,8 @@ def createSuperPixels(opts):  # noqa
             annotation = [annotation, bboxannotation]
         with open(opts.outputAnnotationFile, 'w') as annotation_file:
             try:
-                json.dump(annotation, annotation_file, separators=(',', ':'), sort_keys=False)
+                json.dump(annotation, annotation_file, separators=(',', ':'),
+                          sort_keys=False, default=utils.json_encoder)
             except Exception:
                 print('Failed to serialize annotation')
                 print(repr(annotation))

--- a/histomicstk/cli/utils.py
+++ b/histomicstk/cli/utils.py
@@ -476,13 +476,24 @@ def splitArgs(args, split='_'):
 def sample_pixels(args):
     """Version of histomicstk.utils.sample_pixels that takes a Namespace
     and handles the special default values.
-
     """
     args = (args._asdict() if hasattr(args, '_asdict') else vars(args)).copy()
     for k in 'magnification', 'sample_fraction', 'sample_approximate_total':
         if args[k] == -1:
             del args[k]
     return htk_utils.sample_pixels(**args)
+
+
+def json_encoder(obj):
+    """
+    Default encoder for `json.dump`/`json.dumps` to handle NumPy scalars that
+    fail native serialization (e.g., int64, float64).
+    """
+    if isinstance(obj, np.integer):
+        return int(obj)
+    elif isinstance(obj, np.floating):
+        return float(obj)
+    raise TypeError
 
 
 __all__ = (
@@ -495,6 +506,7 @@ __all__ = (
     'get_region_dict',
     'get_stain_matrix',
     'get_stain_vector',
+    'json_encoder',
     'sample_pixels',
     'segment_wsi_foreground_at_low_res',
     'splitArgs',

--- a/tests/test_cli_results.py
+++ b/tests/test_cli_results.py
@@ -112,3 +112,73 @@ class TestColorDeconvolution:
             '479066d2016122b2b60575f4e9abe201b4f79d8a894ce76191419e21c7539186',
             'd06317130f4a4aabd155c97f32cec4708ec3eec24d09d16daa2181f18b2051bb',
         }
+
+
+class TestPositivePixelCount:
+    POSITIVE_PIXEL_COUNT_DEFAULTS = [
+        '0.83',      # hue_value
+        '0.15',      # hue_width
+        '0.05',      # saturation_minimum
+        '0.95',      # intensity_upper_limit
+        '0.65',      # intensity_weak_threshold
+        '0.35',      # intensity_strong_threshold
+        '0.05',       # intensity_lower_limit
+    ]
+
+    def _runTest(self, image_file, extra_args=None):
+        """
+        Run PositivePixelCount CLI and return the annotation file contents.
+
+        Plus optional named flags like --image_annotation for output files.
+        """
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            outpath = os.path.join(tmpdirname, 'result.anot')
+            args = [image_file] + self.POSITIVE_PIXEL_COUNT_DEFAULTS
+            args.append('--image_annotation')
+            args.append(outpath)
+            if extra_args:
+                args += extra_args
+            _runCLITest('PositivePixelCount', args)
+            with open(outpath) as f:
+                return json.load(f)
+
+    def test_positive_pixel_count_with_annotation(self):
+        """
+        Test that PositivePixelCount completes and writes valid JSON
+        annotation.
+        """
+        src = datastore.fetch('Easy1.png')
+        annot = self._runTest(src, ['--scheduler=multithreading'])
+
+        assert 'name' in annot
+        assert 'elements' in annot
+        assert 'attributes' in annot
+        assert 'stats' in annot['attributes']
+
+    def test_positive_pixel_count_json_serialization(self):
+        """
+        Directly test that annotation JSON can be parsed.
+        """
+        from histomicstk.cli.PositivePixelCount import PositivePixelCount
+        from histomicstk.cli.utils import CLIArgumentParser
+
+        src = datastore.fetch('Easy1.png')
+
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            outpath = os.path.join(tmpdirname, 'result.anot')
+            args = [src] + self.POSITIVE_PIXEL_COUNT_DEFAULTS  #
+            args.append('--image_annotation')
+            args.append(outpath)
+            parser = CLIArgumentParser(
+                os.path.join(os.path.dirname(PositivePixelCount.__file__),
+                             'PositivePixelCount.xml'),
+            )
+            parsed_args = parser.parse_args(args)
+            PositivePixelCount.main(parsed_args)
+            with open(outpath) as f:
+                annot = json.load(f)
+            stats = annot['attributes']['stats']
+            assert 'NumberWeakPositive' in stats
+            assert 'NumberPositive' in stats
+            assert 'NumberStrongPositive' in stats
+            assert 'NumberTotalPixels' in stats


### PR DESCRIPTION
The PositivePixelCount cli task would fail on newer version of numpy because it failed to serial a numpy float or int value.